### PR TITLE
chore: add CI/CD, code review, git hooks, and dev tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug Report
+description: Report a bug in Forge Harness
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for reporting a bug! Please fill out the sections below.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Run `forge_plan` with intent "..."
+        2. See error...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+      placeholder: e.g., 20.11.0
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: e.g., macOS 14.2, Ubuntu 22.04, Windows 11

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature Request
+description: Suggest a new feature for Forge Harness
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for suggesting a feature! Please describe your idea below.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative approaches you've considered?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+      - run: npm run build
+      - run: npm test
+
+      - name: Validate commit message
+        if: github.event_name == 'push'
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          if echo "$COMMIT_MSG" | grep -qE "^Merge "; then exit 0; fi
+          if ! echo "$COMMIT_MSG" | grep -qE "^(feat|fix|docs|chore|refactor|test|style|perf|ci|build|revert)(\(.+\))?(!)?: .+"; then
+            echo "ERROR: HEAD commit message does not follow Conventional Commits format."
+            echo "  Got: $COMMIT_MSG"
+            exit 1
+          fi

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,50 @@
+name: AI Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  code-review:
+    if: |
+      github.event.pull_request.draft == false &&
+      !startsWith(github.head_ref, 'release-please--') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(gh pr:*)",
+                  "Bash(gh api:*)",
+                  "Bash(git:*)",
+                  "Read",
+                  "Write",
+                  "Glob",
+                  "Grep"
+                ]
+              }
+            }
+          prompt: |
+            Review this PR for bugs, logic errors, security issues, and CLAUDE.md convention violations.
+            Be specific and actionable. Only flag issues with high confidence.
+            After completing your review, write it to /tmp/review.md using the Write tool,
+            then post it with: gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review.md
+          claude_args: "--max-turns 25"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0](https://github.com/ziyilam3999/forge-harness/commits/v0.1.0) (2026-04-02)
+
+### Features
+
+* feat: project initialization with ESM TypeScript scaffold

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to Forge Harness
+
+Thanks for your interest in contributing!
+
+## Getting Started
+
+1. Fork and clone the repo
+2. Install dependencies: `npm install`
+3. Build: `npm run build`
+4. Run tests: `npm test`
+
+## Development
+
+```bash
+npm run build     # Compile TypeScript
+npm run test      # Run Vitest suite
+npm run lint      # Run ESLint
+```
+
+## Submitting Changes
+
+1. Create a branch: `git checkout -b feature/your-feature`
+2. Make changes and add tests
+3. Ensure all tests pass: `npm test`
+4. Submit a pull request
+
+## Guidelines
+
+- Keep PRs focused on a single change
+- Add tests for new features
+- Follow existing TypeScript conventions (ESM, strict types)
+- Use Zod for runtime validation where applicable
+
+## Bug Reports
+
+Open an issue with:
+- Steps to reproduce
+- Expected vs actual behavior
+- Node.js version and OS

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,23 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+
+export default [
+  {
+    files: ["server/**/*.ts"],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tseslint,
+    },
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest run",
-    "lint": "eslint server/"
+    "lint": "eslint server/",
+    "postinstall": "node scripts/install-hooks.cjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/scripts/install-hooks.cjs
+++ b/scripts/install-hooks.cjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Cross-platform git hook installer — runs on npm install (postinstall)
+// Installs commit-msg (Conventional Commits) and pre-commit (tsc) hooks
+
+const fs = require("fs");
+const path = require("path");
+
+// Find .git directory (walk up from this script's location)
+function findGitDir(startDir) {
+  let dir = startDir;
+  while (dir !== path.dirname(dir)) {
+    const gitDir = path.join(dir, ".git");
+    if (fs.existsSync(gitDir)) return gitDir;
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+const gitDir = findGitDir(__dirname);
+if (!gitDir) {
+  console.log("install-hooks: .git directory not found — skipping hook install.");
+  process.exit(0);
+}
+
+const hooksDir = path.join(gitDir, "hooks");
+if (!fs.existsSync(hooksDir)) {
+  fs.mkdirSync(hooksDir, { recursive: true });
+}
+
+const commitMsgHook = `#!/bin/sh
+# Conventional Commits validation hook
+commit_msg_file="$1"
+commit_msg=$(head -1 "$commit_msg_file")
+
+if echo "$commit_msg" | grep -qE "^Merge "; then exit 0; fi
+
+if ! echo "$commit_msg" | grep -qE "^(feat|fix|docs|chore|refactor|test|style|perf|ci|build|revert)(\\\\(.+\\\\))?(!)?: .+"; then
+  echo ""
+  echo "ERROR: Commit message does not follow Conventional Commits format."
+  echo "  Expected: <type>[scope]: <description>"
+  echo "  Got:      $commit_msg"
+  echo "  Valid types: feat, fix, docs, chore, refactor, test, style, perf, ci, build, revert"
+  echo "  Use --no-verify to bypass."
+  exit 1
+fi
+`;
+
+const preCommitHook = `#!/bin/sh
+# Pre-commit: type-check staged .ts/.tsx files
+staged_ts=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\\\\.(ts|tsx)$')
+if [ -z "$staged_ts" ]; then exit 0; fi
+
+echo "Running TypeScript type-check..."
+npx tsc --noEmit
+if [ $? -ne 0 ]; then
+  echo "ERROR: TypeScript type-check failed. Use --no-verify to bypass."
+  exit 1
+fi
+`;
+
+const hooks = [
+  { name: "commit-msg", content: commitMsgHook },
+  { name: "pre-commit", content: preCommitHook },
+];
+
+for (const hook of hooks) {
+  const hookPath = path.join(hooksDir, hook.name);
+  fs.writeFileSync(hookPath, hook.content, { mode: 0o755 });
+  console.log(`install-hooks: installed ${hook.name}`);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["server/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
## Summary
- GitHub Actions CI workflow (Node 20, build + test + conventional commit validation)
- AI code review via `anthropics/claude-code-action@v1` on PR open/sync
- Issue templates (bug report + feature request)
- Git hooks installer (`postinstall`) with commit-msg and pre-commit hooks
- ESLint flat config targeting `server/**/*.ts`
- Vitest config with `passWithNoTests: true`
- CONTRIBUTING.md and CHANGELOG.md (v0.1.0)

Adapted from hive-mind's proven automation stack.

## Test plan
- [ ] `npm run build` exits 0
- [ ] `npm test` exits 0 (passWithNoTests)
- [ ] `.github/workflows/ci.yml` exists
- [ ] `.github/workflows/code-review.yml` exists
- [ ] Git hooks installed in `.git/hooks/`