### PR TITLE
feat: MCP server scaffold with 4 placeholder tools

### DIFF
--- a/schema/eval-report.schema.json
+++ b/schema/eval-report.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ziyilam3999/forge-harness/schema/eval-report.schema.json",
+  "title": "Forge Evaluation Report",
+  "description": "Output of forge_evaluate — per-criterion PASS/FAIL with evidence",
+  "type": "object",
+  "required": ["storyId", "verdict", "criteria"],
+  "properties": {
+    "storyId": { "type": "string" },
+    "verdict": {
+      "type": "string",
+      "enum": ["PASS", "FAIL", "INCONCLUSIVE"]
+    },
+    "criteria": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "status"],
+        "properties": {
+          "id": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": ["PASS", "FAIL", "SKIPPED"]
+          },
+          "evidence": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schema/execution-plan.schema.json
+++ b/schema/execution-plan.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ziyilam3999/forge-harness/schema/execution-plan.schema.json",
+  "title": "Forge Execution Plan",
+  "description": "Contract between forge_plan (producer) and forge_generate/forge_evaluate (consumers)",
+  "type": "object",
+  "required": ["schemaVersion", "stories"],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "3.0.0"
+    },
+    "prdPath": {
+      "type": "string",
+      "description": "Path to the source PRD or intent document"
+    },
+    "stories": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Story"
+      }
+    }
+  },
+  "$defs": {
+    "Story": {
+      "type": "object",
+      "required": ["id", "title", "acceptanceCriteria"],
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "dependencies": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "acceptanceCriteria": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/AcceptanceCriterion" }
+        },
+        "affectedPaths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Directory prefixes this story modifies"
+        }
+      }
+    },
+    "AcceptanceCriterion": {
+      "type": "object",
+      "required": ["id", "description", "command"],
+      "properties": {
+        "id": { "type": "string" },
+        "description": { "type": "string" },
+        "command": {
+          "type": "string",
+          "description": "Shell command producing exit 0 (PASS) or non-zero (FAIL)"
+        },
+        "flaky": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, retry on failure before marking FAIL"
+        }
+      }
+    }
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,70 @@
-// Forge Harness MCP Server — placeholder entry point
-// Real implementation in Feature 3 (PR #3)
-console.error("forge-harness: server not yet implemented");
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { planInputSchema, handlePlan } from "./tools/plan.js";
+import { evaluateInputSchema, handleEvaluate } from "./tools/evaluate.js";
+import { generateInputSchema, handleGenerate } from "./tools/generate.js";
+import { coordinateInputSchema, handleCoordinate } from "./tools/coordinate.js";
+
+const server = new McpServer({
+  name: "forge",
+  version: "0.1.0",
+});
+
+server.registerTool(
+  "forge_plan",
+  {
+    title: "Forge Plan",
+    description:
+      "Transform intent (PRD, description, or goal) into a structured execution plan with stories and binary acceptance criteria. Uses double-critique pattern.",
+    inputSchema: planInputSchema,
+    annotations: { readOnlyHint: true },
+  },
+  handlePlan
+);
+
+server.registerTool(
+  "forge_evaluate",
+  {
+    title: "Forge Evaluate",
+    description:
+      "Grade work against the execution plan contract. Returns PASS/FAIL per criterion with evidence. Stateless — never modifies code.",
+    inputSchema: evaluateInputSchema,
+    annotations: { readOnlyHint: true },
+  },
+  handleEvaluate
+);
+
+server.registerTool(
+  "forge_generate",
+  {
+    title: "Forge Generate",
+    description:
+      "Implement one story via GAN loop: implement, evaluate, fix, evaluate (max 3 rounds). Manages git branches per story.",
+    inputSchema: generateInputSchema,
+    annotations: { destructiveHint: true },
+  },
+  handleGenerate
+);
+
+server.registerTool(
+  "forge_coordinate",
+  {
+    title: "Forge Coordinate",
+    description:
+      "Compose plan/generate/evaluate into dependency-ordered workflows. Reads execution-plan.json, dispatches stories, tracks progress, enforces budgets.",
+    inputSchema: coordinateInputSchema,
+    annotations: { destructiveHint: true },
+  },
+  handleCoordinate
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("forge: MCP server running on stdio");
+}
+
+main().catch((error) => {
+  console.error("forge: fatal error", error);
+  process.exit(1);
+});

--- a/server/tools/coordinate.ts
+++ b/server/tools/coordinate.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const coordinateInputSchema = {
+  planPath: z.string().describe("Path to execution-plan.json"),
+};
+
+export async function handleCoordinate({ planPath }: { planPath: string }) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `forge_coordinate for "${planPath}": not yet implemented. Phase 4 required.`,
+      },
+    ],
+  };
+}

--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const evaluateInputSchema = {
+  storyId: z.string().describe("Story ID to evaluate (e.g., US-01)"),
+};
+
+export async function handleEvaluate({ storyId }: { storyId: string }) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `forge_evaluate for "${storyId}": not yet implemented. Phase 2 required.`,
+      },
+    ],
+  };
+}

--- a/server/tools/generate.ts
+++ b/server/tools/generate.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const generateInputSchema = {
+  storyId: z.string().describe("Story ID to implement (e.g., US-01)"),
+};
+
+export async function handleGenerate({ storyId }: { storyId: string }) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `forge_generate for "${storyId}": not yet implemented. Phase 3 required.`,
+      },
+    ],
+  };
+}

--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { handlePlan } from "./plan.js";
+
+describe("forge_plan placeholder", () => {
+  it("returns not-implemented message with intent", async () => {
+    const result = await handlePlan({ intent: "build a calculator" });
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toContain("not yet implemented");
+    expect(result.content[0].text).toContain("build a calculator");
+  });
+});

--- a/server/tools/plan.ts
+++ b/server/tools/plan.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const planInputSchema = {
+  intent: z.string().describe("What to build — a PRD, description, or goal statement"),
+};
+
+export async function handlePlan({ intent }: { intent: string }) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `forge_plan for "${intent}": not yet implemented. Phase 1 required.`,
+      },
+    ],
+  };
+}

--- a/server/validation/execution-plan.ts
+++ b/server/validation/execution-plan.ts
@@ -1,0 +1,9 @@
+export interface ValidationResult {
+  valid: boolean;
+  errors?: string[];
+}
+
+export function validateExecutionPlan(_data: unknown): ValidationResult {
+  // Stub — real validation against schema/execution-plan.schema.json in Phase 1
+  return { valid: true };
+}


### PR DESCRIPTION
## Summary
- MCP server entry point (`server/index.ts`) with `StdioServerTransport`
- 4 placeholder tools registered via `server.registerTool()`:
  - `forge_plan` (readOnlyHint: true)
  - `forge_evaluate` (readOnlyHint: true)
  - `forge_generate` (destructiveHint: true)
  - `forge_coordinate` (destructiveHint: true)
- Schema validation stub (`server/validation/execution-plan.ts`)
- JSON Schema skeletons (`schema/execution-plan.schema.json` v3.0.0, `schema/eval-report.schema.json`)
- Smoke test for `forge_plan` placeholder

## Test plan
- [ ] `npx tsc` exits 0
- [ ] `npx vitest run` exits 0 (1 test passes)
- [ ] Server responds to MCP `initialize` request with valid JSON-RPC response
- [ ] Server reports `serverInfo.name: "forge"` and lists tools capability