### PR TITLE
feat: add setup script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Forge Harness
+
+Composable AI primitives — plan, evaluate, generate, coordinate — as a local MCP server.
+
+Successor to [Hive Mind v3](https://github.com/ziyilam3999/hive-mind). Each primitive works standalone and composes together.
+
+## Quick Start
+
+```bash
+git clone https://github.com/ziyilam3999/forge-harness.git
+cd forge-harness
+./setup.sh
+```
+
+Then restart Claude Code. The forge tools will appear in your tool list.
+
+## Tools
+
+| Tool | What It Does | Phase |
+|------|-------------|-------|
+| `forge_plan` | Transform intent into a structured execution plan with binary acceptance criteria | 1 |
+| `forge_evaluate` | Grade work against the contract — PASS/FAIL per criterion with evidence | 2 |
+| `forge_generate` | Implement one story via GAN loop (implement, evaluate, fix) | 3 |
+| `forge_coordinate` | Compose plan/generate/evaluate into dependency-ordered workflows | 4 |
+
+## Status
+
+**Phase 0** — MCP server scaffold with placeholder tools. All tools return "not yet implemented."
+
+## Development
+
+```bash
+npm install       # Install dependencies + git hooks
+npm run build     # Compile TypeScript
+npm test          # Run Vitest suite
+npm run lint      # Run ESLint
+```
+
+## Architecture
+
+Forge is a **local MCP server** — runs on your machine as a subprocess. Claude Code (or any MCP client) connects via stdio. See `docs/forge-harness-plan.md` for the full design spec.
+
+## License
+
+MIT

--- a/scripts/setup-config.cjs
+++ b/scripts/setup-config.cjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Merge forge MCP server config into ~/.claude/settings.json
+// Usage: node scripts/setup-config.cjs <repo-root-path>
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const repoRoot = process.argv[2];
+if (!repoRoot) {
+  console.error("ERROR: repo root path argument required.");
+  console.error("Usage: node scripts/setup-config.cjs <repo-root>");
+  process.exit(1);
+}
+
+const claudeDir = path.join(os.homedir(), ".claude");
+const settingsPath = path.join(claudeDir, "settings.json");
+
+// Ensure ~/.claude/ exists
+if (!fs.existsSync(claudeDir)) {
+  fs.mkdirSync(claudeDir, { recursive: true });
+  console.error("setup-config: created ~/.claude/");
+}
+
+// Read existing settings or start fresh
+let settings;
+if (fs.existsSync(settingsPath)) {
+  const raw = fs.readFileSync(settingsPath, "utf-8");
+  try {
+    settings = JSON.parse(raw);
+  } catch {
+    console.error(
+      "ERROR: ~/.claude/settings.json contains invalid JSON. Please fix it manually or delete it and re-run setup.sh."
+    );
+    process.exit(1);
+  }
+} else {
+  settings = {};
+  console.error("setup-config: creating new ~/.claude/settings.json");
+}
+
+// Merge forge MCP server entry
+if (!settings.mcpServers) {
+  settings.mcpServers = {};
+}
+
+// Resolve to absolute path and normalize to forward slashes
+const normalizedRoot = path.resolve(repoRoot).replace(/\\/g, "/");
+
+settings.mcpServers.forge = {
+  command: "node",
+  args: ["dist/index.js"],
+  cwd: normalizedRoot,
+};
+
+fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+console.error(
+  `setup-config: registered forge MCP server (cwd: ${normalizedRoot})`
+);

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Forge Harness setup — registers the MCP server in Claude Code
+# Requires: Git Bash or MSYS2 on Windows, Node.js 20+
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "forge setup: repo root = $SCRIPT_DIR"
+
+# Install dependencies if needed
+if [ ! -d "$SCRIPT_DIR/node_modules" ]; then
+  echo "forge setup: installing dependencies..."
+  (cd "$SCRIPT_DIR" && npm install)
+fi
+
+# Build TypeScript
+echo "forge setup: compiling TypeScript..."
+(cd "$SCRIPT_DIR" && npx tsc)
+
+# Register MCP server in Claude Code settings
+echo "forge setup: registering MCP server..."
+node "$SCRIPT_DIR/scripts/setup-config.cjs" "$SCRIPT_DIR"
+
+echo "forge setup: done. Restart Claude Code to pick up the forge tools."


### PR DESCRIPTION
## Summary
- `setup.sh`: one-command setup that installs deps, builds TypeScript, and registers forge MCP server in `~/.claude/settings.json`
- `scripts/setup-config.cjs`: config merge helper with edge case handling (missing dir/file, corrupted JSON)
- `README.md`: project overview, quick start, tool list, architecture note

## Test plan
- [ ] `bash setup.sh` exits 0
- [ ] `~/.claude/settings.json` contains `mcpServers.forge` with `command: "node"`
- [ ] Existing `mcpServers.context7` preserved after setup
- [ ] Running setup.sh twice produces same result (idempotent)