### PR TITLE
feat: implement forge_plan with double-critique pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,9 @@
     "": {
       "name": "forge-harness",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.82.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "zod": "^3.25.0"
       },
@@ -21,6 +23,35 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
+      "integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2355,6 +2386,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -3445,6 +3489,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "postinstall": "node scripts/install-hooks.cjs"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.82.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "zod": "^3.25.0"
   },

--- a/server/lib/anthropic.ts
+++ b/server/lib/anthropic.ts
@@ -1,0 +1,119 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+const DEFAULT_MODEL = "claude-sonnet-4-6-20250514";
+const DEFAULT_MAX_TOKENS = 8192;
+
+let client: Anthropic | null = null;
+
+export function getClient(): Anthropic {
+  if (client) return client;
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "ANTHROPIC_API_KEY environment variable is not set. " +
+        "Set it in your shell before starting the MCP server: export ANTHROPIC_API_KEY=sk-...",
+    );
+  }
+
+  client = new Anthropic({ apiKey });
+  return client;
+}
+
+export interface CallClaudeOptions {
+  system: string;
+  messages: Array<{ role: "user" | "assistant"; content: string }>;
+  model?: string;
+  jsonMode?: boolean;
+  maxTokens?: number;
+}
+
+export interface CallClaudeResult {
+  text: string;
+  usage: { inputTokens: number; outputTokens: number };
+}
+
+/**
+ * Extract JSON from an LLM response that may contain markdown fences or preamble.
+ * Strategy: (1) try full parse, (2) extract between first {/[ and last }/], (3) throw.
+ */
+export function extractJson(text: string): unknown {
+  // Try direct parse first
+  try {
+    return JSON.parse(text);
+  } catch {
+    // Fall through to extraction
+  }
+
+  // Try extracting between braces or brackets
+  const firstBrace = text.indexOf("{");
+  const firstBracket = text.indexOf("[");
+  let start: number;
+  let end: number;
+
+  if (firstBrace === -1 && firstBracket === -1) {
+    throw new Error(
+      `Failed to extract JSON from response: no { or [ found. Response starts with: "${text.slice(0, 100)}"`,
+    );
+  }
+
+  if (firstBracket === -1 || (firstBrace !== -1 && firstBrace < firstBracket)) {
+    start = firstBrace;
+    end = text.lastIndexOf("}");
+  } else {
+    start = firstBracket;
+    end = text.lastIndexOf("]");
+  }
+
+  if (end <= start) {
+    throw new Error(
+      `Failed to extract JSON from response: unmatched brackets. Response starts with: "${text.slice(0, 100)}"`,
+    );
+  }
+
+  const extracted = text.slice(start, end + 1);
+  try {
+    return JSON.parse(extracted);
+  } catch (e) {
+    throw new Error(
+      `Failed to parse extracted JSON from response. ` +
+        `Parse error: ${e instanceof Error ? e.message : String(e)}. ` +
+        `Extracted text starts with: "${extracted.slice(0, 100)}"`,
+    );
+  }
+}
+
+/**
+ * Call Claude API with the given prompt. Handles JSON extraction when jsonMode is true.
+ */
+export async function callClaude(options: CallClaudeOptions): Promise<CallClaudeResult> {
+  const anthropic = getClient();
+
+  const response = await anthropic.messages.create({
+    model: options.model ?? DEFAULT_MODEL,
+    max_tokens: options.maxTokens ?? DEFAULT_MAX_TOKENS,
+    system: options.jsonMode
+      ? options.system +
+        "\n\nIMPORTANT: Respond with ONLY valid JSON. No markdown fences, no preamble text, no trailing text. Just the JSON object."
+      : options.system,
+    messages: options.messages,
+  });
+
+  // Extract text from response content blocks
+  const text = response.content
+    .filter((block): block is Anthropic.TextBlock => block.type === "text")
+    .map((block) => block.text)
+    .join("");
+
+  const usage = {
+    inputTokens: response.usage.input_tokens,
+    outputTokens: response.usage.output_tokens,
+  };
+
+  if (options.jsonMode) {
+    // Validate that the response is parseable JSON
+    extractJson(text); // throws if not valid
+  }
+
+  return { text, usage };
+}

--- a/server/lib/codebase-scan.test.ts
+++ b/server/lib/codebase-scan.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scanCodebase, SCANNER_CHAR_CAP } from "./codebase-scan.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "forge-scan-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("scanCodebase", () => {
+  it("returns directory structure for a simple project", async () => {
+    await mkdir(join(tempDir, "src"));
+    await writeFile(join(tempDir, "src", "index.ts"), "console.log('hello');");
+    await writeFile(
+      join(tempDir, "package.json"),
+      JSON.stringify({ name: "test" }),
+    );
+
+    const result = await scanCodebase(tempDir);
+    expect(result).toContain("Directory Structure");
+    expect(result).toContain("src/");
+    expect(result).toContain("package.json");
+  });
+
+  it("reads key file contents", async () => {
+    await writeFile(
+      join(tempDir, "package.json"),
+      JSON.stringify({ name: "my-project", version: "1.0.0" }),
+    );
+
+    const result = await scanCodebase(tempDir);
+    expect(result).toContain("my-project");
+  });
+
+  it("skips node_modules", async () => {
+    await mkdir(join(tempDir, "node_modules", "some-pkg"), { recursive: true });
+    await writeFile(
+      join(tempDir, "node_modules", "some-pkg", "index.js"),
+      "nope",
+    );
+
+    const result = await scanCodebase(tempDir);
+    expect(result).not.toContain("node_modules");
+    expect(result).not.toContain("some-pkg");
+  });
+
+  it("skips .git directory", async () => {
+    await mkdir(join(tempDir, ".git", "objects"), { recursive: true });
+
+    const result = await scanCodebase(tempDir);
+    expect(result).not.toContain(".git");
+  });
+
+  it("skips dist directory", async () => {
+    await mkdir(join(tempDir, "dist"));
+    await writeFile(join(tempDir, "dist", "bundle.js"), "compiled");
+
+    const result = await scanCodebase(tempDir);
+    expect(result).not.toContain("dist");
+  });
+
+  it("respects max depth", async () => {
+    // Create deeply nested structure: d1/d2/d3/d4/d5/d6/deep.txt
+    // depth 0=d1, 1=d2, 2=d3, 3=d4, 4=d5 (MAX_DEPTH=4), d6 should be excluded
+    let dir = tempDir;
+    for (let i = 1; i <= 6; i++) {
+      dir = join(dir, `d${i}`);
+      await mkdir(dir);
+    }
+    await writeFile(join(dir, "deep.txt"), "deep");
+
+    const result = await scanCodebase(tempDir);
+    expect(result).toContain("d5/");
+    expect(result).not.toContain("d6");
+  });
+
+  it("throws for non-existent path", async () => {
+    await expect(scanCodebase("/nonexistent/path/xyz")).rejects.toThrow(
+      "does not exist",
+    );
+  });
+
+  it("throws for a file path (not directory)", async () => {
+    const filePath = join(tempDir, "notadir.txt");
+    await writeFile(filePath, "text");
+
+    await expect(scanCodebase(filePath)).rejects.toThrow("not a directory");
+  });
+
+  it("uses forward slashes in output", async () => {
+    await mkdir(join(tempDir, "src", "lib"), { recursive: true });
+    await writeFile(join(tempDir, "src", "lib", "util.ts"), "export {}");
+
+    const result = await scanCodebase(tempDir);
+    // Should not contain backslashes (Windows compat)
+    expect(result).not.toMatch(/\\/);
+    expect(result).toContain("src/lib/");
+  });
+
+  it("truncates output at SCANNER_CHAR_CAP", async () => {
+    // Create many files to exceed the cap
+    await mkdir(join(tempDir, "src"));
+    for (let i = 0; i < 200; i++) {
+      await writeFile(
+        join(tempDir, "src", `file-${String(i).padStart(3, "0")}.ts`),
+        `export const x${i} = ${i};`,
+      );
+    }
+    // Also add a large README
+    await writeFile(
+      join(tempDir, "README.md"),
+      "# Big README\n" + "x".repeat(20000),
+    );
+
+    const result = await scanCodebase(tempDir);
+    expect(result.length).toBeLessThanOrEqual(SCANNER_CHAR_CAP + "\n[truncated]".length);
+    expect(result).toContain("[truncated]");
+  });
+});

--- a/server/lib/codebase-scan.ts
+++ b/server/lib/codebase-scan.ts
@@ -1,0 +1,126 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+/** Maximum character count for scanner output (~4000 tokens at 4:1 ratio). Tunable. */
+export const SCANNER_CHAR_CAP = 16_000;
+
+/** Maximum directory recursion depth. Tunable. */
+const MAX_DEPTH = 4;
+
+/** Directories to skip during scan. */
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "dist",
+  ".git",
+  ".ai-workspace",
+  ".forge",
+  "__pycache__",
+  ".next",
+  "coverage",
+]);
+
+/** Key files to read contents of (first 100 lines each). */
+const KEY_FILES = ["package.json", "tsconfig.json", "README.md"];
+
+/**
+ * Normalize path separators to forward slashes (Windows compat).
+ */
+function toSlash(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+/**
+ * Recursively list directory contents up to MAX_DEPTH.
+ */
+async function listDir(
+  dir: string,
+  rootDir: string,
+  depth: number,
+  lines: string[],
+): Promise<void> {
+  if (depth > MAX_DEPTH) return;
+
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    // Permission denied or other error — skip silently
+    return;
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    const relPath = toSlash(relative(rootDir, fullPath));
+    const indent = "  ".repeat(depth);
+
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      lines.push(`${indent}${relPath}/`);
+      await listDir(fullPath, rootDir, depth + 1, lines);
+    } else {
+      lines.push(`${indent}${relPath}`);
+    }
+  }
+}
+
+/**
+ * Read first N lines of a file, returning empty string if not found.
+ */
+async function readHead(filePath: string, maxLines: number): Promise<string> {
+  try {
+    const content = await readFile(filePath, "utf-8");
+    return content.split("\n").slice(0, maxLines).join("\n");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Scan a project directory and return a text summary for LLM context.
+ *
+ * @param projectPath - Absolute path to the project root
+ * @returns Text summary capped at SCANNER_CHAR_CAP characters
+ * @throws If projectPath doesn't exist or isn't a directory
+ */
+export async function scanCodebase(projectPath: string): Promise<string> {
+  // Validate projectPath
+  let stats;
+  try {
+    stats = await stat(projectPath);
+  } catch {
+    throw new Error(
+      `projectPath "${projectPath}" does not exist or is not accessible.`,
+    );
+  }
+  if (!stats.isDirectory()) {
+    throw new Error(`projectPath "${projectPath}" is not a directory.`);
+  }
+
+  const sections: string[] = [];
+
+  // 1. Directory listing
+  const dirLines: string[] = [];
+  await listDir(projectPath, projectPath, 0, dirLines);
+  sections.push("## Directory Structure\n```\n" + dirLines.join("\n") + "\n```");
+
+  // 2. Key file contents
+  for (const fileName of KEY_FILES) {
+    const content = await readHead(join(projectPath, fileName), 100);
+    if (content) {
+      sections.push(
+        `## ${fileName}\n\`\`\`\n${content}\n\`\`\``,
+      );
+    }
+  }
+
+  let output = sections.join("\n\n");
+
+  // 3. Truncate to cap
+  if (output.length > SCANNER_CHAR_CAP) {
+    output = output.slice(0, SCANNER_CHAR_CAP) + "\n[truncated]";
+  }
+
+  return output;
+}

--- a/server/lib/prompts/corrector.ts
+++ b/server/lib/prompts/corrector.ts
@@ -1,0 +1,49 @@
+/**
+ * Build the system prompt for a corrector agent.
+ * Correctors receive the plan + critic findings and produce a corrected plan.
+ */
+export function buildCorrectorPrompt(): string {
+  return `You are a plan corrector. You receive an execution plan and a list of findings from an independent reviewer.
+
+## Your Job
+
+For each finding:
+- If VALID: apply the fix precisely. Modify the plan JSON.
+- If INVALID: skip it — do not apply changes you disagree with.
+
+## Output Format
+
+Respond with ONLY a JSON object containing:
+
+{
+  "plan": {
+    "schemaVersion": "3.0.0",
+    "stories": [ ... the corrected stories ... ]
+  },
+  "dispositions": [
+    {
+      "findingIndex": 0,
+      "applied": true | false,
+      "reason": "Brief explanation"
+    }
+  ]
+}
+
+## Rules
+
+- Only fix what was flagged. Do NOT introduce new content or refactor the plan.
+- Maintain cross-story consistency (if you change a story ID, update all references).
+- The corrected plan must still be valid against the execution-plan v3.0.0 schema.
+- Keep all existing stories and ACs that were NOT flagged — do not remove unflagged content.
+- If a MINOR finding doesn't actually improve the plan, skip it with a reason.`;
+}
+
+/**
+ * Build the user message for the corrector — plan + findings.
+ */
+export function buildCorrectorUserMessage(
+  planJson: string,
+  findingsJson: string,
+): string {
+  return `## Execution Plan\n\n${planJson}\n\n## Critic Findings\n\n${findingsJson}`;
+}

--- a/server/lib/prompts/critic.ts
+++ b/server/lib/prompts/critic.ts
@@ -1,0 +1,60 @@
+/**
+ * Build the system prompt for a critic agent.
+ * Critics see ONLY the execution plan — no planner context (isolation principle).
+ */
+export function buildCriticPrompt(round: 1 | 2): string {
+  const regressionCheck =
+    round === 2
+      ? `\n\n### Regression Check (Round 2 Only)
+- This plan was already reviewed and corrected once.
+- Check whether the corrections introduced NEW problems.
+- Tag any regression finding with [REGRESSION] at the start of the finding.`
+      : "";
+
+  return `You are an independent plan reviewer. You have never seen how this plan was created.
+You see ONLY the execution plan JSON. Review it for quality and correctness.
+
+## What to Check
+
+1. **Binary ACs:** Is every acceptance criterion a shell command that exits 0 (PASS) or non-zero (FAIL)?
+   - Flag any AC that is subjective, vague, or not a real shell command.
+2. **AC Verifiability:** Would each AC actually verify what the story claims to do?
+   - Flag any AC that could pass even if the story's goal is NOT met.
+3. **Dependencies:** Are they correct? No circular deps, no missing refs?
+4. **Story Scope:** Is each story too broad (should be split) or too narrow (should be merged)?
+5. **Coverage:** Does the plan cover all aspects of the intent described in the stories?
+6. **affectedPaths:** Do they make sense for each story?
+
+## Output Format
+
+Respond with ONLY a JSON object:
+
+{
+  "findings": [
+    {
+      "severity": "CRITICAL" | "MAJOR" | "MINOR",
+      "storyId": "US-01",
+      "acId": "AC-01 or null if story-level",
+      "description": "What's wrong",
+      "suggestedFix": "How to fix it"
+    }
+  ]
+}
+
+If the plan is sound and you find no issues, respond with:
+{ "findings": [] }
+
+## Rules
+
+- Every finding MUST cite a specific story ID (and AC ID if applicable).
+- Classify severity: CRITICAL = plan won't work, MAJOR = significant gap, MINOR = improvement.
+- If you can't explain why something is a problem in plain language, don't flag it.
+- Be thorough but not pedantic. Only flag real problems.${regressionCheck}`;
+}
+
+/**
+ * Build the user message for the critic — just the plan JSON.
+ */
+export function buildCriticUserMessage(planJson: string): string {
+  return `Review this execution plan:\n\n${planJson}`;
+}

--- a/server/lib/prompts/planner.ts
+++ b/server/lib/prompts/planner.ts
@@ -1,0 +1,86 @@
+/**
+ * Build the system prompt for the planner agent.
+ */
+export function buildPlannerPrompt(
+  mode: "feature" | "full-project" | "bugfix",
+): string {
+  const modeRules = {
+    feature: `- Prefer a single story unless complexity warrants splitting.
+- Each story should be independently implementable and testable.`,
+    "full-project": `- Decompose into multiple stories ordered by dependency graph.
+- Earlier stories should have no or fewer dependencies.
+- Each story should be independently implementable and testable.`,
+    bugfix: `- The FIRST acceptance criterion (AC-01) of the FIRST story MUST be a reproduction test:
+  a shell command that FAILS before the fix (non-zero exit) and PASSES after the fix (exit 0).
+- Keep scope minimal — fix the bug, don't refactor surrounding code.`,
+  };
+
+  return `You are a software planning agent. Your job is to transform a user's intent into a structured execution plan.
+
+## Output Format
+
+Respond with ONLY a JSON object matching this exact schema (execution-plan v3.0.0):
+
+{
+  "schemaVersion": "3.0.0",
+  "stories": [
+    {
+      "id": "US-01",
+      "title": "Short descriptive title",
+      "dependencies": [],
+      "acceptanceCriteria": [
+        {
+          "id": "AC-01",
+          "description": "Human-readable description of what this verifies",
+          "command": "shell command that exits 0 on PASS, non-zero on FAIL"
+        }
+      ],
+      "affectedPaths": ["directory/prefix/"]
+    }
+  ]
+}
+
+## Rules
+
+### Story Rules
+- Story IDs follow the pattern US-01, US-02, US-03, etc.
+- Each story must have a clear, descriptive title.
+- Dependencies must reference existing story IDs. No circular dependencies.
+- affectedPaths are directory prefixes (e.g., "server/tools/", "src/components/").
+
+### Acceptance Criteria Rules
+- EVERY AC must be a shell command that produces exit 0 (PASS) or non-zero (FAIL).
+- AC IDs follow the pattern AC-01, AC-02, etc., scoped per story.
+- ACs must be CONCRETE and VERIFIABLE. No subjective criteria.
+  - GOOD: "npx tsc && echo PASS" / "node -e \\"process.exit(require('./dist/foo').bar?0:1)\\""
+  - BAD: "code is well-structured" / "API responses are reasonable"
+- Commands should work on both Unix and Windows (Git Bash). Prefer node -e for portability.
+
+### Mode-Specific Rules (mode: ${mode})
+${modeRules[mode]}
+
+### Fields NOT to Populate
+- Do NOT include "prdPath" in the output (reserved for future use).
+- Do NOT include "flaky" in any AC (reserved for future use).
+
+### Quality Checks
+- Ensure every story's ACs actually verify the story's title/goal.
+- Ensure no duplicate story IDs or AC IDs within a story.
+- Ensure dependencies form a valid DAG (no cycles).`;
+}
+
+/**
+ * Build the user message for the planner, including intent and optional codebase context.
+ */
+export function buildPlannerUserMessage(
+  intent: string,
+  codebaseSummary?: string,
+): string {
+  let message = `## Intent\n\n${intent}`;
+
+  if (codebaseSummary) {
+    message += `\n\n## Codebase Context\n\n${codebaseSummary}`;
+  }
+
+  return message;
+}

--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -1,12 +1,303 @@
-import { describe, it, expect } from "vitest";
-import { handlePlan } from "./plan.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { CallClaudeResult } from "../lib/anthropic.js";
 
-describe("forge_plan placeholder", () => {
-  it("returns not-implemented message with intent", async () => {
-    const result = await handlePlan({ intent: "build a calculator" });
-    expect(result.content).toHaveLength(1);
-    expect(result.content[0].type).toBe("text");
-    expect(result.content[0].text).toContain("not yet implemented");
-    expect(result.content[0].text).toContain("build a calculator");
+// Mock the anthropic module before importing plan
+vi.mock("../lib/anthropic.js", () => ({
+  callClaude: vi.fn(),
+  extractJson: vi.fn((text: string) => JSON.parse(text)),
+}));
+
+// Mock codebase-scan
+vi.mock("../lib/codebase-scan.js", () => ({
+  scanCodebase: vi.fn(async () => "## Directory Structure\n```\nsrc/\n```"),
+}));
+
+// Import after mocks
+const { callClaude, extractJson } = await import("../lib/anthropic.js");
+const { scanCodebase } = await import("../lib/codebase-scan.js");
+const { handlePlan } = await import("./plan.js");
+
+const mockedCallClaude = vi.mocked(callClaude);
+const mockedExtractJson = vi.mocked(extractJson);
+const mockedScanCodebase = vi.mocked(scanCodebase);
+
+function makeValidPlan() {
+  return {
+    schemaVersion: "3.0.0",
+    stories: [
+      {
+        id: "US-01",
+        title: "Test story",
+        dependencies: [],
+        acceptanceCriteria: [
+          { id: "AC-01", description: "passes", command: "echo PASS" },
+        ],
+        affectedPaths: ["src/"],
+      },
+    ],
+  };
+}
+
+function makeCallResult(data: unknown): CallClaudeResult {
+  return {
+    text: JSON.stringify(data),
+    usage: { inputTokens: 100, outputTokens: 50 },
+  };
+}
+
+function makeCriticResult(findings: Array<Record<string, unknown>> = []) {
+  return makeCallResult({ findings });
+}
+
+function makeCorrectorResult(plan: unknown, dispositions: Array<Record<string, unknown>> = []) {
+  return makeCallResult({ plan, dispositions });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: extractJson just parses
+  mockedExtractJson.mockImplementation((text: string) => JSON.parse(text));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("handlePlan", () => {
+  describe("basic pipeline", () => {
+    it("returns valid execution plan JSON", async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan)) // planner
+        .mockResolvedValueOnce(makeCriticResult()) // critic-1 (zero findings)
+        .mockResolvedValueOnce(makeCriticResult()); // critic-2 (zero findings)
+
+      const result = await handlePlan({ intent: "add dark mode" });
+      expect(result.content[0].text).toContain("EXECUTION PLAN");
+      expect(result.content[0].text).toContain('"schemaVersion": "3.0.0"');
+      expect(result.content[0].text).toContain("USAGE");
+    });
+
+    it("includes critique summary when findings exist", async () => {
+      const plan = makeValidPlan();
+      const findings = [
+        { severity: "MINOR", storyId: "US-01", acId: "AC-01", description: "d", suggestedFix: "f" },
+      ];
+
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan)) // planner
+        .mockResolvedValueOnce(makeCriticResult(findings)) // critic-1
+        .mockResolvedValueOnce(makeCorrectorResult(plan, [{ findingIndex: 0, applied: true, reason: "ok" }])) // corrector-1
+        .mockResolvedValueOnce(makeCriticResult()); // critic-2 (zero findings)
+
+      const result = await handlePlan({ intent: "add dark mode" });
+      expect(result.content[0].text).toContain("CRITIQUE SUMMARY");
+      expect(result.content[0].text).toContain("1 findings");
+    });
+  });
+
+  describe("tier behavior", () => {
+    it('tier "quick" skips critique loop', async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude.mockResolvedValueOnce(makeCallResult(plan));
+
+      await handlePlan({ intent: "add button", tier: "quick" });
+      expect(mockedCallClaude).toHaveBeenCalledTimes(1); // planner only
+    });
+
+    it('tier "standard" runs 1 critique round', async () => {
+      const plan = makeValidPlan();
+      const findings = [
+        { severity: "MINOR", storyId: "US-01", acId: null, description: "d", suggestedFix: "f" },
+      ];
+
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan)) // planner
+        .mockResolvedValueOnce(makeCriticResult(findings)) // critic-1
+        .mockResolvedValueOnce(makeCorrectorResult(plan, [{ findingIndex: 0, applied: true, reason: "ok" }])); // corrector-1
+
+      await handlePlan({ intent: "add button", tier: "standard" });
+      expect(mockedCallClaude).toHaveBeenCalledTimes(3); // planner + critic + corrector
+    });
+
+    it('tier "thorough" runs 2 critique rounds', async () => {
+      const plan = makeValidPlan();
+      const findings = [
+        { severity: "MINOR", storyId: "US-01", acId: null, description: "d", suggestedFix: "f" },
+      ];
+
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan)) // planner
+        .mockResolvedValueOnce(makeCriticResult(findings)) // critic-1
+        .mockResolvedValueOnce(makeCorrectorResult(plan, [{ findingIndex: 0, applied: true, reason: "ok" }])) // corrector-1
+        .mockResolvedValueOnce(makeCriticResult(findings)) // critic-2
+        .mockResolvedValueOnce(makeCorrectorResult(plan, [{ findingIndex: 0, applied: true, reason: "ok" }])); // corrector-2
+
+      await handlePlan({ intent: "add button", tier: "thorough" });
+      expect(mockedCallClaude).toHaveBeenCalledTimes(5);
+    });
+
+    it("defaults to thorough tier", async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan)) // planner
+        .mockResolvedValueOnce(makeCriticResult()) // critic-1
+        .mockResolvedValueOnce(makeCriticResult()); // critic-2
+
+      await handlePlan({ intent: "add button" });
+      expect(mockedCallClaude).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("mode auto-detection", () => {
+    it('detects "fix" keyword as bugfix', async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan))
+        .mockResolvedValueOnce(makeCriticResult())
+        .mockResolvedValueOnce(makeCriticResult());
+
+      await handlePlan({ intent: "fix the login bug" });
+
+      const firstCall = mockedCallClaude.mock.calls[0][0];
+      expect(firstCall.system).toContain("FIRST acceptance criterion");
+    });
+
+    it('detects "add feature" as feature mode', async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan))
+        .mockResolvedValueOnce(makeCriticResult())
+        .mockResolvedValueOnce(makeCriticResult());
+
+      await handlePlan({ intent: "add dark mode toggle" });
+
+      const firstCall = mockedCallClaude.mock.calls[0][0];
+      expect(firstCall.system).toContain("Prefer a single story");
+    });
+
+    it("uses explicit mode when provided", async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan))
+        .mockResolvedValueOnce(makeCriticResult())
+        .mockResolvedValueOnce(makeCriticResult());
+
+      await handlePlan({ intent: "add error handling", mode: "feature" });
+
+      const firstCall = mockedCallClaude.mock.calls[0][0];
+      expect(firstCall.system).toContain("Prefer a single story");
+    });
+  });
+
+  describe("error handling", () => {
+    it("retries planner on validation failure", async () => {
+      const invalidPlan = { schemaVersion: "3.0.0", stories: [] };
+      const validPlan = makeValidPlan();
+
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(invalidPlan)) // first attempt fails validation
+        .mockResolvedValueOnce(makeCallResult(validPlan)) // retry succeeds
+        .mockResolvedValueOnce(makeCriticResult())
+        .mockResolvedValueOnce(makeCriticResult());
+
+      const result = await handlePlan({ intent: "add button" });
+      expect(result.content[0].text).toContain("EXECUTION PLAN");
+      expect(mockedCallClaude).toHaveBeenCalledTimes(4); // 2 planner + 2 critics
+    });
+
+    it("throws if planner fails validation after retry", async () => {
+      const invalidPlan = { schemaVersion: "3.0.0", stories: [] };
+
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(invalidPlan))
+        .mockResolvedValueOnce(makeCallResult(invalidPlan));
+
+      await expect(handlePlan({ intent: "add button" })).rejects.toThrow(
+        "failed validation after retry",
+      );
+    });
+
+    it("treats malformed critic response as zero findings", async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan)) // planner
+        .mockResolvedValueOnce(makeCallResult({ not: "findings" })) // malformed critic
+        .mockResolvedValueOnce(makeCriticResult()); // critic-2 ok
+
+      const result = await handlePlan({ intent: "add button" });
+      expect(result.content[0].text).toContain("EXECUTION PLAN");
+    });
+
+    it("uses pre-correction plan when corrector fails", async () => {
+      const plan = makeValidPlan();
+      const findings = [
+        { severity: "MAJOR", storyId: "US-01", acId: null, description: "d", suggestedFix: "f" },
+      ];
+
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan)) // planner
+        .mockResolvedValueOnce(makeCriticResult(findings)) // critic-1
+        .mockRejectedValueOnce(new Error("corrector crashed")) // corrector-1 fails
+        .mockResolvedValueOnce(makeCriticResult()); // critic-2
+
+      const result = await handlePlan({ intent: "add button" });
+      expect(result.content[0].text).toContain("EXECUTION PLAN");
+    });
+
+    it("uses pre-correction plan when corrector output fails validation", async () => {
+      const plan = makeValidPlan();
+      const findings = [
+        { severity: "MAJOR", storyId: "US-01", acId: null, description: "d", suggestedFix: "f" },
+      ];
+      const brokenPlan = { schemaVersion: "3.0.0", stories: [] };
+
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan)) // planner
+        .mockResolvedValueOnce(makeCriticResult(findings)) // critic-1
+        .mockResolvedValueOnce(makeCorrectorResult(brokenPlan)) // corrector returns invalid plan
+        .mockResolvedValueOnce(makeCriticResult()); // critic-2
+
+      const result = await handlePlan({ intent: "add button" });
+      expect(result.content[0].text).toContain("EXECUTION PLAN");
+      expect(result.content[0].text).toContain("US-01"); // original plan preserved
+    });
+  });
+
+  describe("codebase scanning", () => {
+    it("calls scanCodebase when projectPath provided", async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan))
+        .mockResolvedValueOnce(makeCriticResult())
+        .mockResolvedValueOnce(makeCriticResult());
+
+      await handlePlan({ intent: "add button", projectPath: "/some/path" });
+      expect(mockedScanCodebase).toHaveBeenCalledWith("/some/path");
+    });
+
+    it("does not call scanCodebase when projectPath omitted", async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan))
+        .mockResolvedValueOnce(makeCriticResult())
+        .mockResolvedValueOnce(makeCriticResult());
+
+      await handlePlan({ intent: "add button" });
+      expect(mockedScanCodebase).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("critic zero findings", () => {
+    it("skips corrector when critic finds no issues", async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan)) // planner
+        .mockResolvedValueOnce(makeCriticResult()) // critic-1 zero findings
+        .mockResolvedValueOnce(makeCriticResult()); // critic-2 zero findings
+
+      await handlePlan({ intent: "add button" });
+      expect(mockedCallClaude).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/server/tools/plan.ts
+++ b/server/tools/plan.ts
@@ -1,15 +1,322 @@
 import { z } from "zod";
+import { callClaude, extractJson } from "../lib/anthropic.js";
+import { scanCodebase } from "../lib/codebase-scan.js";
+import { buildPlannerPrompt, buildPlannerUserMessage } from "../lib/prompts/planner.js";
+import { buildCriticPrompt, buildCriticUserMessage } from "../lib/prompts/critic.js";
+import { buildCorrectorPrompt, buildCorrectorUserMessage } from "../lib/prompts/corrector.js";
+import { validateExecutionPlan } from "../validation/execution-plan.js";
+import type { ExecutionPlan } from "../types/execution-plan.js";
 
 export const planInputSchema = {
   intent: z.string().describe("What to build — a PRD, description, or goal statement"),
+  projectPath: z
+    .string()
+    .optional()
+    .describe(
+      "Absolute path to project root for codebase context. If omitted, plans without codebase awareness.",
+    ),
+  mode: z
+    .enum(["feature", "full-project", "bugfix"])
+    .optional()
+    .describe(
+      "Planning mode. Auto-detected from intent if omitted — see known limitations below.",
+    ),
+  tier: z
+    .enum(["quick", "standard", "thorough"])
+    .optional()
+    .describe(
+      "Critique depth. quick=no critique, standard=1 round, thorough=2 rounds. Default: thorough.",
+    ),
 };
 
-export async function handlePlan({ intent }: { intent: string }) {
+/** Keywords that trigger bugfix mode auto-detection. */
+const BUGFIX_KEYWORDS = ["fix", "bug", "broken", "crash", "error"];
+
+/**
+ * Auto-detect planning mode from intent.
+ *
+ * KNOWN LIMITATION: keyword-based detection can produce false positives.
+ * "add error handling" would be classified as bugfix because it contains "error".
+ * Users should pass `mode` explicitly when intent is ambiguous.
+ */
+function detectMode(intent: string): "feature" | "bugfix" {
+  const lower = intent.toLowerCase();
+  for (const keyword of BUGFIX_KEYWORDS) {
+    if (lower.includes(keyword)) return "bugfix";
+  }
+  return "feature";
+}
+
+interface CritiqueFindings {
+  findings: Array<{
+    severity: string;
+    storyId: string;
+    acId: string | null;
+    description: string;
+    suggestedFix: string;
+  }>;
+}
+
+interface CorrectorOutput {
+  plan: ExecutionPlan;
+  dispositions: Array<{
+    findingIndex: number;
+    applied: boolean;
+    reason: string;
+  }>;
+}
+
+interface UsageAccumulator {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/**
+ * Run the planner agent to produce a draft execution plan.
+ */
+async function runPlanner(
+  intent: string,
+  mode: "feature" | "full-project" | "bugfix",
+  codebaseSummary: string | undefined,
+  model: string | undefined,
+  usage: UsageAccumulator,
+): Promise<ExecutionPlan> {
+  const system = buildPlannerPrompt(mode);
+  const userMessage = buildPlannerUserMessage(intent, codebaseSummary);
+
+  const result = await callClaude({
+    system,
+    messages: [{ role: "user", content: userMessage }],
+    model,
+    jsonMode: true,
+  });
+  usage.inputTokens += result.usage.inputTokens;
+  usage.outputTokens += result.usage.outputTokens;
+
+  const parsed = extractJson(result.text);
+  const validation = validateExecutionPlan(parsed);
+
+  if (!validation.valid) {
+    // Retry once with error feedback
+    console.error(
+      "forge_plan: planner output failed validation, retrying with feedback:",
+      validation.errors,
+    );
+    const retryResult = await callClaude({
+      system,
+      messages: [
+        { role: "user", content: userMessage },
+        { role: "assistant", content: result.text },
+        {
+          role: "user",
+          content: `Your JSON output failed schema validation with these errors:\n${validation.errors?.join("\n")}\n\nPlease fix the issues and respond with the corrected JSON only.`,
+        },
+      ],
+      model,
+      jsonMode: true,
+    });
+    usage.inputTokens += retryResult.usage.inputTokens;
+    usage.outputTokens += retryResult.usage.outputTokens;
+
+    const retryParsed = extractJson(retryResult.text);
+    const retryValidation = validateExecutionPlan(retryParsed);
+    if (!retryValidation.valid) {
+      throw new Error(
+        `Planner output failed validation after retry: ${retryValidation.errors?.join("; ")}`,
+      );
+    }
+    return retryParsed as ExecutionPlan;
+  }
+
+  return parsed as ExecutionPlan;
+}
+
+/**
+ * Run a critic agent on the plan. Returns findings or empty array on failure.
+ */
+async function runCritic(
+  plan: ExecutionPlan,
+  round: 1 | 2,
+  model: string | undefined,
+  usage: UsageAccumulator,
+): Promise<CritiqueFindings> {
+  const system = buildCriticPrompt(round);
+  const planJson = JSON.stringify(plan, null, 2);
+
+  try {
+    const result = await callClaude({
+      system,
+      messages: [{ role: "user", content: buildCriticUserMessage(planJson) }],
+      model,
+      jsonMode: true,
+    });
+    usage.inputTokens += result.usage.inputTokens;
+    usage.outputTokens += result.usage.outputTokens;
+
+    const parsed = extractJson(result.text) as CritiqueFindings;
+    if (!parsed.findings || !Array.isArray(parsed.findings)) {
+      console.error("forge_plan: critic returned malformed findings, treating as zero findings");
+      return { findings: [] };
+    }
+    return parsed;
+  } catch (e) {
+    console.error(
+      `forge_plan: critic round ${round} failed, treating as zero findings:`,
+      e instanceof Error ? e.message : String(e),
+    );
+    return { findings: [] };
+  }
+}
+
+/**
+ * Run a corrector agent. Returns corrected plan or the original on failure.
+ */
+async function runCorrector(
+  plan: ExecutionPlan,
+  findings: CritiqueFindings,
+  model: string | undefined,
+  usage: UsageAccumulator,
+): Promise<{ plan: ExecutionPlan; dispositions: CorrectorOutput["dispositions"] }> {
+  const system = buildCorrectorPrompt();
+  const planJson = JSON.stringify(plan, null, 2);
+  const findingsJson = JSON.stringify(findings, null, 2);
+
+  try {
+    const result = await callClaude({
+      system,
+      messages: [
+        { role: "user", content: buildCorrectorUserMessage(planJson, findingsJson) },
+      ],
+      model,
+      jsonMode: true,
+    });
+    usage.inputTokens += result.usage.inputTokens;
+    usage.outputTokens += result.usage.outputTokens;
+
+    const parsed = extractJson(result.text) as CorrectorOutput;
+
+    // Validate the corrected plan
+    const validation = validateExecutionPlan(parsed.plan);
+    if (!validation.valid) {
+      console.error(
+        "forge_plan: corrector output failed validation, using pre-correction plan:",
+        validation.errors,
+      );
+      return { plan, dispositions: [] };
+    }
+
+    return { plan: parsed.plan, dispositions: parsed.dispositions ?? [] };
+  } catch (e) {
+    console.error(
+      "forge_plan: corrector failed, using pre-correction plan:",
+      e instanceof Error ? e.message : String(e),
+    );
+    return { plan, dispositions: [] };
+  }
+}
+
+/**
+ * Format critique summary for output.
+ */
+function formatCritiqueSummary(
+  rounds: Array<{ findings: CritiqueFindings; dispositions: CorrectorOutput["dispositions"] }>,
+): string {
+  if (rounds.length === 0) return "";
+
+  const lines: string[] = ["=== CRITIQUE SUMMARY ==="];
+
+  for (let i = 0; i < rounds.length; i++) {
+    const { findings, dispositions } = rounds[i];
+    const critical = findings.findings.filter((f) => f.severity === "CRITICAL").length;
+    const major = findings.findings.filter((f) => f.severity === "MAJOR").length;
+    const minor = findings.findings.filter((f) => f.severity === "MINOR").length;
+    const applied = dispositions.filter((d) => d.applied).length;
+
+    lines.push(
+      `Round ${i + 1}: ${findings.findings.length} findings ` +
+        `(${critical} CRITICAL, ${major} MAJOR, ${minor} MINOR) — ${applied} applied`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Main handler for forge_plan.
+ */
+export async function handlePlan({
+  intent,
+  projectPath,
+  mode,
+  tier,
+}: {
+  intent: string;
+  projectPath?: string;
+  mode?: "feature" | "full-project" | "bugfix";
+  tier?: "quick" | "standard" | "thorough";
+}) {
+  const effectiveMode = mode ?? detectMode(intent);
+  const effectiveTier = tier ?? "thorough";
+
+  const usage: UsageAccumulator = { inputTokens: 0, outputTokens: 0 };
+
+  // Step 1: Optional codebase scan
+  let codebaseSummary: string | undefined;
+  if (projectPath) {
+    codebaseSummary = await scanCodebase(projectPath);
+  }
+
+  // Step 2: Run planner
+  let plan = await runPlanner(intent, effectiveMode, codebaseSummary, undefined, usage);
+
+  // Step 3: Critique loop
+  const critiqueRounds: Array<{
+    findings: CritiqueFindings;
+    dispositions: CorrectorOutput["dispositions"];
+  }> = [];
+
+  if (effectiveTier !== "quick") {
+    const maxRounds = effectiveTier === "thorough" ? 2 : 1;
+
+    for (let round = 1; round <= maxRounds; round++) {
+      const findings = await runCritic(plan, round as 1 | 2, undefined, usage);
+
+      if (findings.findings.length === 0) {
+        critiqueRounds.push({ findings, dispositions: [] });
+        continue;
+      }
+
+      const { plan: correctedPlan, dispositions } = await runCorrector(
+        plan,
+        findings,
+        undefined,
+        usage,
+      );
+      plan = correctedPlan;
+      critiqueRounds.push({ findings, dispositions });
+    }
+  }
+
+  // Step 4: Build output
+  const sections: string[] = [
+    "=== EXECUTION PLAN ===",
+    JSON.stringify(plan, null, 2),
+  ];
+
+  const critiqueSummary = formatCritiqueSummary(critiqueRounds);
+  if (critiqueSummary) {
+    sections.push(critiqueSummary);
+  }
+
+  sections.push(
+    `=== USAGE ===\nTotal tokens: ${usage.inputTokens} input / ${usage.outputTokens} output`,
+  );
+
   return {
     content: [
       {
         type: "text" as const,
-        text: `forge_plan for "${intent}": not yet implemented. Phase 1 required.`,
+        text: sections.join("\n\n"),
       },
     ],
   };

--- a/server/types/execution-plan.ts
+++ b/server/types/execution-plan.ts
@@ -1,0 +1,20 @@
+export interface ExecutionPlan {
+  schemaVersion: "3.0.0";
+  prdPath?: string; // Reserved for future use; not populated by the planner in Phase 1.
+  stories: Story[];
+}
+
+export interface Story {
+  id: string;
+  title: string;
+  dependencies?: string[];
+  acceptanceCriteria: AcceptanceCriterion[];
+  affectedPaths?: string[];
+}
+
+export interface AcceptanceCriterion {
+  id: string;
+  description: string;
+  command: string;
+  flaky?: boolean; // Not populated by the planner in Phase 1. Exists for future manual annotation.
+}

--- a/server/validation/execution-plan.test.ts
+++ b/server/validation/execution-plan.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from "vitest";
+import { validateExecutionPlan } from "./execution-plan.js";
+
+function validPlan(overrides?: Record<string, unknown>) {
+  return {
+    schemaVersion: "3.0.0",
+    stories: [
+      {
+        id: "US-01",
+        title: "Test story",
+        dependencies: [],
+        acceptanceCriteria: [
+          {
+            id: "AC-01",
+            description: "Runs successfully",
+            command: "echo PASS",
+          },
+        ],
+        affectedPaths: ["server/"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("validateExecutionPlan", () => {
+  it("accepts a valid plan", () => {
+    const result = validateExecutionPlan(validPlan());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it("rejects null input", () => {
+    const result = validateExecutionPlan(null);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Plan must be a non-null object");
+  });
+
+  it("rejects wrong schemaVersion", () => {
+    const result = validateExecutionPlan(validPlan({ schemaVersion: "2.0.0" }));
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("schemaVersion"))).toBe(true);
+  });
+
+  it("rejects missing schemaVersion", () => {
+    const plan = validPlan();
+    delete (plan as Record<string, unknown>).schemaVersion;
+    const result = validateExecutionPlan(plan);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects non-array stories", () => {
+    const result = validateExecutionPlan(validPlan({ stories: "not-an-array" }));
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("stories must be an array"))).toBe(true);
+  });
+
+  it("rejects empty stories array", () => {
+    const result = validateExecutionPlan(validPlan({ stories: [] }));
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("at least one story"))).toBe(true);
+  });
+
+  it("rejects story with missing id", () => {
+    const result = validateExecutionPlan(
+      validPlan({
+        stories: [
+          { title: "No ID", acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }] },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("id must be a non-empty string"))).toBe(true);
+  });
+
+  it("rejects story with empty title", () => {
+    const result = validateExecutionPlan(
+      validPlan({
+        stories: [
+          { id: "US-01", title: "", acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }] },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("title must be a non-empty string"))).toBe(true);
+  });
+
+  it("rejects duplicate story IDs", () => {
+    const result = validateExecutionPlan(
+      validPlan({
+        stories: [
+          { id: "US-01", title: "A", acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }] },
+          { id: "US-01", title: "B", acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }] },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes('Duplicate story ID: "US-01"'))).toBe(true);
+  });
+
+  it("rejects empty acceptanceCriteria", () => {
+    const result = validateExecutionPlan(
+      validPlan({
+        stories: [{ id: "US-01", title: "A", acceptanceCriteria: [] }],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("at least one criterion"))).toBe(true);
+  });
+
+  it("rejects AC with missing command", () => {
+    const result = validateExecutionPlan(
+      validPlan({
+        stories: [
+          { id: "US-01", title: "A", acceptanceCriteria: [{ id: "AC-01", description: "d" }] },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("command must be a non-empty string"))).toBe(true);
+  });
+
+  it("rejects duplicate AC IDs within a story", () => {
+    const result = validateExecutionPlan(
+      validPlan({
+        stories: [
+          {
+            id: "US-01",
+            title: "A",
+            acceptanceCriteria: [
+              { id: "AC-01", description: "d", command: "c" },
+              { id: "AC-01", description: "d2", command: "c2" },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes('duplicate AC ID "AC-01"'))).toBe(true);
+  });
+
+  it("rejects dependency referencing non-existent story", () => {
+    const result = validateExecutionPlan(
+      validPlan({
+        stories: [
+          {
+            id: "US-01",
+            title: "A",
+            dependencies: ["US-99"],
+            acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }],
+          },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes('"US-99" references non-existent story'))).toBe(true);
+  });
+
+  it("rejects self-dependency with specific error message", () => {
+    const result = validateExecutionPlan(
+      validPlan({
+        stories: [
+          {
+            id: "US-01",
+            title: "A",
+            dependencies: ["US-01"],
+            acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }],
+          },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes('"US-01" depends on itself'))).toBe(true);
+  });
+
+  it("rejects circular dependencies", () => {
+    const result = validateExecutionPlan({
+      schemaVersion: "3.0.0",
+      stories: [
+        {
+          id: "US-01",
+          title: "A",
+          dependencies: ["US-02"],
+          acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }],
+        },
+        {
+          id: "US-02",
+          title: "B",
+          dependencies: ["US-01"],
+          acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }],
+        },
+      ],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("Circular dependency"))).toBe(true);
+  });
+
+  it("rejects non-boolean flaky field", () => {
+    const result = validateExecutionPlan(
+      validPlan({
+        stories: [
+          {
+            id: "US-01",
+            title: "A",
+            acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c", flaky: "yes" }],
+          },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("flaky must be a boolean"))).toBe(true);
+  });
+
+  it("accepts valid boolean flaky field", () => {
+    const result = validateExecutionPlan(
+      validPlan({
+        stories: [
+          {
+            id: "US-01",
+            title: "A",
+            acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c", flaky: true }],
+          },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts plan with valid dependencies", () => {
+    const result = validateExecutionPlan({
+      schemaVersion: "3.0.0",
+      stories: [
+        {
+          id: "US-01",
+          title: "A",
+          dependencies: [],
+          acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }],
+        },
+        {
+          id: "US-02",
+          title: "B",
+          dependencies: ["US-01"],
+          acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }],
+        },
+      ],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("skips cycle detection when missing refs exist", () => {
+    // US-01 depends on US-03 (missing) and US-02 depends on US-01
+    // This should report missing ref but NOT attempt cycle detection
+    const result = validateExecutionPlan({
+      schemaVersion: "3.0.0",
+      stories: [
+        {
+          id: "US-01",
+          title: "A",
+          dependencies: ["US-03"],
+          acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }],
+        },
+        {
+          id: "US-02",
+          title: "B",
+          dependencies: ["US-01"],
+          acceptanceCriteria: [{ id: "AC-01", description: "d", command: "c" }],
+        },
+      ],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("non-existent"))).toBe(true);
+    // Should not mention circular dependency
+    expect(result.errors?.some((e) => e.includes("Circular"))).toBe(false);
+  });
+});

--- a/server/validation/execution-plan.ts
+++ b/server/validation/execution-plan.ts
@@ -1,9 +1,230 @@
+import type { ExecutionPlan } from "../types/execution-plan.js";
+
 export interface ValidationResult {
   valid: boolean;
   errors?: string[];
 }
 
-export function validateExecutionPlan(_data: unknown): ValidationResult {
-  // Stub — real validation against schema/execution-plan.schema.json in Phase 1
-  return { valid: true };
+/**
+ * Validate an execution plan against the v3.0.0 schema rules.
+ * Hand-written validation for clear error messages — no ajv dependency.
+ */
+export function validateExecutionPlan(data: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (!data || typeof data !== "object") {
+    return { valid: false, errors: ["Plan must be a non-null object"] };
+  }
+
+  const plan = data as Record<string, unknown>;
+
+  // 1. schemaVersion
+  if (plan.schemaVersion !== "3.0.0") {
+    errors.push(
+      `schemaVersion must be "3.0.0", got "${String(plan.schemaVersion)}"`,
+    );
+  }
+
+  // 2. stories must be non-empty array
+  if (!Array.isArray(plan.stories)) {
+    errors.push("stories must be an array");
+    return { valid: false, errors };
+  }
+
+  if (plan.stories.length === 0) {
+    errors.push("stories must contain at least one story");
+    return { valid: false, errors };
+  }
+
+  const storyIds = new Set<string>();
+  const allStoryIds = new Set<string>();
+
+  // First pass: collect all story IDs for dependency checking
+  for (const story of plan.stories) {
+    if (story && typeof story === "object" && typeof (story as Record<string, unknown>).id === "string") {
+      allStoryIds.add((story as Record<string, unknown>).id as string);
+    }
+  }
+
+  let hasMissingRefs = false;
+
+  for (let i = 0; i < plan.stories.length; i++) {
+    const story = plan.stories[i] as Record<string, unknown>;
+    const prefix = `stories[${i}]`;
+
+    if (!story || typeof story !== "object") {
+      errors.push(`${prefix}: must be an object`);
+      continue;
+    }
+
+    // 3. Required fields
+    if (typeof story.id !== "string" || story.id.length === 0) {
+      errors.push(`${prefix}: id must be a non-empty string`);
+      continue;
+    }
+
+    if (typeof story.title !== "string" || story.title.length === 0) {
+      errors.push(`${prefix} (${story.id}): title must be a non-empty string`);
+    }
+
+    // 5. No duplicate story IDs
+    if (storyIds.has(story.id)) {
+      errors.push(`Duplicate story ID: "${story.id}"`);
+    }
+    storyIds.add(story.id);
+
+    // 7. Dependency references (run BEFORE cycle detection)
+    if (Array.isArray(story.dependencies)) {
+      // Check for self-dependency
+      if (story.dependencies.includes(story.id)) {
+        errors.push(`Story "${story.id}" depends on itself`);
+      }
+      for (const dep of story.dependencies) {
+        if (typeof dep !== "string") {
+          errors.push(`${prefix} (${story.id}): dependency must be a string`);
+        } else if (dep !== story.id && !allStoryIds.has(dep)) {
+          errors.push(
+            `${prefix} (${story.id}): dependency "${dep}" references non-existent story`,
+          );
+          hasMissingRefs = true;
+        }
+      }
+    }
+
+    // 3. acceptanceCriteria must be non-empty array
+    if (!Array.isArray(story.acceptanceCriteria)) {
+      errors.push(
+        `${prefix} (${story.id}): acceptanceCriteria must be an array`,
+      );
+      continue;
+    }
+
+    if (story.acceptanceCriteria.length === 0) {
+      errors.push(
+        `${prefix} (${story.id}): acceptanceCriteria must contain at least one criterion`,
+      );
+      continue;
+    }
+
+    const acIds = new Set<string>();
+
+    for (let j = 0; j < story.acceptanceCriteria.length; j++) {
+      const ac = story.acceptanceCriteria[j] as Record<string, unknown>;
+      const acPrefix = `${prefix} (${story.id}).acceptanceCriteria[${j}]`;
+
+      if (!ac || typeof ac !== "object") {
+        errors.push(`${acPrefix}: must be an object`);
+        continue;
+      }
+
+      // 4. AC required fields
+      if (typeof ac.id !== "string" || ac.id.length === 0) {
+        errors.push(`${acPrefix}: id must be a non-empty string`);
+      }
+
+      if (typeof ac.description !== "string" || ac.description.length === 0) {
+        errors.push(`${acPrefix}: description must be a non-empty string`);
+      }
+
+      if (typeof ac.command !== "string" || ac.command.length === 0) {
+        errors.push(`${acPrefix}: command must be a non-empty string`);
+      }
+
+      // 6. No duplicate AC IDs within a story
+      if (typeof ac.id === "string" && ac.id.length > 0) {
+        if (acIds.has(ac.id)) {
+          errors.push(
+            `${prefix} (${story.id}): duplicate AC ID "${ac.id}"`,
+          );
+        }
+        acIds.add(ac.id);
+      }
+
+      // 9. flaky must be boolean if present
+      if (ac.flaky !== undefined && typeof ac.flaky !== "boolean") {
+        errors.push(`${acPrefix}: flaky must be a boolean if present`);
+      }
+    }
+  }
+
+  // 8. Circular dependency detection (DFS) — skip if missing refs found
+  if (!hasMissingRefs) {
+    const cycleError = detectCycles(plan.stories as Array<Record<string, unknown>>);
+    if (cycleError) {
+      errors.push(cycleError);
+    }
+  }
+
+  return errors.length === 0
+    ? { valid: true }
+    : { valid: false, errors };
+}
+
+// DFS color constants
+const WHITE = 0; // unvisited
+const GRAY = 1; // visiting (in current path)
+const BLACK = 2; // done
+
+/**
+ * DFS-based cycle detection on the story dependency graph.
+ * Returns an error message if a cycle is found, null otherwise.
+ */
+function detectCycles(
+  stories: Array<Record<string, unknown>>,
+): string | null {
+  const deps = new Map<string, string[]>();
+  for (const story of stories) {
+    const id = story.id as string;
+    const storyDeps = (story.dependencies as string[] | undefined) ?? [];
+    // Filter out self-dependencies (already caught earlier)
+    deps.set(id, storyDeps.filter((d) => d !== id));
+  }
+
+  const color = new Map<string, number>();
+  for (const id of deps.keys()) {
+    color.set(id, WHITE);
+  }
+
+  for (const id of deps.keys()) {
+    if (color.get(id) === WHITE) {
+      const cycle = dfs(id, deps, color);
+      if (cycle) return cycle;
+    }
+  }
+
+  return null;
+}
+
+function dfs(
+  node: string,
+  deps: Map<string, string[]>,
+  color: Map<string, number>,
+): string | null {
+  color.set(node, GRAY);
+
+  for (const neighbor of deps.get(node) ?? []) {
+    if (color.get(neighbor) === GRAY) {
+      return `Circular dependency detected: "${node}" -> "${neighbor}" forms a cycle`;
+    }
+    if (color.get(neighbor) === WHITE) {
+      const result = dfs(neighbor, deps, color);
+      if (result) return result;
+    }
+  }
+
+  color.set(node, BLACK);
+  return null;
+}
+
+/**
+ * Type guard: check if validated data is an ExecutionPlan.
+ */
+export function asExecutionPlan(data: unknown): ExecutionPlan {
+  const result = validateExecutionPlan(data);
+  if (!result.valid) {
+    throw new Error(
+      `Invalid execution plan: ${result.errors?.join("; ") ?? "unknown error"}`,
+    );
+  }
+  return data as ExecutionPlan;
 }


### PR DESCRIPTION
## Summary

- **Phase 1 of Forge Harness**: replaces the `forge_plan` placeholder with a real planning engine
- Calls Claude API directly via `@anthropic-ai/sdk` to transform intent into structured execution plans (v3.0.0 schema)
- Implements the double-critique pattern: planner → critic-1 → corrector-1 → critic-2 → corrector-2
- Three critique tiers: `quick` (no critique), `standard` (1 round), `thorough` (2 rounds, default)
- Full schema validation with DFS cycle detection, self-dependency checks, and clear error messages
- Lightweight codebase scanner (depth-4, 16K char cap) for project context
- 46 unit tests covering pipeline behavior, validation rules, and scanner edge cases

## New Files
- `server/lib/anthropic.ts` — Claude API client wrapper with JSON extraction
- `server/lib/codebase-scan.ts` — Project structure scanner
- `server/lib/prompts/{planner,critic,corrector}.ts` — Prompt templates
- `server/types/execution-plan.ts` — TypeScript interfaces for v3.0.0 schema
- `server/validation/execution-plan.test.ts` — 18 validation tests
- `server/lib/codebase-scan.test.ts` — 10 scanner tests

## Modified Files
- `server/tools/plan.ts` — Full pipeline implementation replacing placeholder
- `server/tools/plan.test.ts` — 18 pipeline tests (mocked API)
- `server/validation/execution-plan.ts` — Real validation replacing stub
- `package.json` — Added `@anthropic-ai/sdk` dependency

## Test plan
- [x] `npx tsc` compiles with zero errors
- [x] `npx vitest run` passes all 46 tests
- [x] `npx eslint server/` passes with zero warnings
- [x] `@anthropic-ai/sdk` present in package.json dependencies
- [ ] Manual: call `forge_plan` from Claude Code with real intent (requires ANTHROPIC_API_KEY)