### PR TITLE
fix: exchange OAuth token for API key before inference calls

### DIFF
--- a/server/lib/anthropic.ts
+++ b/server/lib/anthropic.ts
@@ -107,7 +107,11 @@ export function getClient(): Promise<Anthropic> {
     clientExpiresAt = null;
   }
   if (!clientPromise) {
-    clientPromise = buildClient();
+    clientPromise = buildClient().catch((err: unknown) => {
+      // Clear so the next call retries rather than returning a permanently-cached rejection
+      clientPromise = null;
+      throw err;
+    });
   }
   return clientPromise;
 }


### PR DESCRIPTION
## Summary

- OAuth access tokens from `~/.claude/.credentials.json` cannot be used directly as Bearer tokens with `api.anthropic.com` — the API returns 401 "OAuth authentication is currently not supported"
- Fix mirrors how Claude Code itself works: call `/api/oauth/claude_cli/create_api_key` with the OAuth token to get a short-lived API key, then use that key for inference
- `getClient()` is now async; `callClaude()` already was async so the call site change is minimal

## Test plan

- [ ] `npm run build` exits 0 (TypeScript compiles cleanly)
- [ ] `npm test` passes all 46 existing tests (tests mock `callClaude` so the async change has no impact)
- [ ] On a machine with a valid `~/.claude/.credentials.json`, `getClient()` successfully exchanges the OAuth token and returns a working Anthropic client
- [ ] With `ANTHROPIC_API_KEY` set and no credentials file, falls back correctly
- [ ] With neither credential present, throws the expected error message