### PR TITLE
fix: use OAuth token directly as Bearer instead of key exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.2](https://github.com/ziyilam3999/forge-harness/compare/v0.3.1...v0.3.2) (2026-04-02)
+
+### Bug Fixes
+
+* use OAuth token directly as Bearer instead of key exchange
+  - The create_api_key endpoint requires org:create_api_key scope which is not a valid OAuth scope (anthropics/claude-code#20325)
+  - Pass authToken to Anthropic SDK constructor — sends Authorization: Bearer header
+  - Makes getClient() synchronous; no network call needed for auth setup
+  - Explicit clientExpiresAt reset in API-key path prevents stale expiry from evicting a valid cached client
+
 ## [0.3.1](https://github.com/ziyilam3999/forge-harness/compare/v0.3.0...v0.3.1) (2026-04-02)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-harness",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "Composable AI primitives — plan, evaluate, generate, coordinate — as a local MCP server",
   "scripts": {

--- a/server/lib/anthropic.ts
+++ b/server/lib/anthropic.ts
@@ -6,27 +6,13 @@ import { homedir } from "node:os";
 const DEFAULT_MODEL = "claude-sonnet-4-6-20250514";
 const DEFAULT_MAX_TOKENS = 8192;
 
-// OAuth tokens from credentials.json are issued by the Claude.ai OAuth flow and cannot
-// be used directly as Bearer tokens with api.anthropic.com (returns 401 "OAuth
-// authentication is currently not supported"). Instead, we exchange them for a
-// short-lived API key via the claude_cli endpoint — the same flow Claude Code uses.
-const OAUTH_KEY_EXCHANGE_URL =
-  "https://api.anthropic.com/api/oauth/claude_cli/create_api_key";
-
-// Promise-based singleton so concurrent callers coalesce on one exchange request
-// rather than each firing a redundant key-exchange HTTP call.
-let clientPromise: Promise<Anthropic> | null = null;
-// When the client was built from an OAuth-derived key, track the OAuth token's expiry
-// so we can evict the cache before the key goes stale. Evict 10 min early — wider than
-// the 5-min readOAuthToken rejection window — to guarantee there is always time for a
-// fresh exchange before the token is unreadable.
+let client: Anthropic | null = null;
+// Track the OAuth token's expiry so we can evict the cache before it goes stale.
 let clientExpiresAt: number | null = null;
-const EVICT_BEFORE_MS = 10 * 60 * 1000;
 
 /**
  * Read the Claude OAuth access token from ~/.claude/.credentials.json.
  * Returns null if the file doesn't exist, is invalid, or the token is expired.
- * Also returns the expiresAt timestamp so callers can track key lifetime.
  */
 function readOAuthToken(): { accessToken: string; expiresAt: number } | null {
   try {
@@ -48,47 +34,31 @@ function readOAuthToken(): { accessToken: string; expiresAt: number } | null {
   }
 }
 
-/**
- * Exchange a Claude OAuth access token for a short-lived Anthropic API key.
- * The OAuth token itself is rejected by the inference API; only the derived key works.
- */
-async function exchangeOAuthForApiKey(oauthToken: string): Promise<string | null> {
-  try {
-    const response = await fetch(OAUTH_KEY_EXCHANGE_URL, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${oauthToken}` },
-    });
-    if (!response.ok) {
-      console.error(`forge: OAuth key exchange failed (HTTP ${response.status})`);
-      return null;
-    }
-    const data = (await response.json()) as { raw_key?: string };
-    return data.raw_key ?? null;
-  } catch (err) {
-    console.error(`forge: OAuth key exchange error: ${err instanceof Error ? err.message : String(err)}`);
-    return null;
+export function getClient(): Anthropic {
+  // Evict cache if the OAuth token is expiring within 5 minutes
+  if (client && clientExpiresAt !== null && Date.now() >= clientExpiresAt - 5 * 60 * 1000) {
+    client = null;
+    clientExpiresAt = null;
   }
-}
+  if (client) return client;
 
-async function buildClient(): Promise<Anthropic> {
   // 1. Try Claude OAuth token (primary — works with Claude Code Max subscription).
-  //    Exchange it for a real API key; the OAuth token itself is rejected by the API.
+  //    The SDK sends it as `Authorization: Bearer <token>` which the inference API accepts.
   const oauthCreds = readOAuthToken();
   if (oauthCreds) {
-    const apiKey = await exchangeOAuthForApiKey(oauthCreds.accessToken);
-    if (apiKey) {
-      console.error("forge: using OAuth-derived API key for auth");
-      clientExpiresAt = oauthCreds.expiresAt;
-      return new Anthropic({ apiKey });
-    }
-    console.error("forge: OAuth key exchange failed, falling back to ANTHROPIC_API_KEY");
+    console.error("forge: using Claude OAuth token for auth");
+    client = new Anthropic({ authToken: oauthCreds.accessToken });
+    clientExpiresAt = oauthCreds.expiresAt;
+    return client;
   }
 
   // 2. Fall back to ANTHROPIC_API_KEY (for standalone/CI use)
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (apiKey) {
-    console.error("forge: using ANTHROPIC_API_KEY for API auth");
-    return new Anthropic({ apiKey });
+    console.error("forge: using ANTHROPIC_API_KEY for auth");
+    client = new Anthropic({ apiKey });
+    clientExpiresAt = null;
+    return client;
   }
 
   throw new Error(
@@ -96,24 +66,6 @@ async function buildClient(): Promise<Anthropic> {
       "  1. Log in to Claude Code (OAuth token in ~/.claude/.credentials.json), or\n" +
       "  2. Set ANTHROPIC_API_KEY environment variable: export ANTHROPIC_API_KEY=sk-...",
   );
-}
-
-export function getClient(): Promise<Anthropic> {
-  // Evict cache if the OAuth-derived key is expiring soon. The eviction window is
-  // wider than readOAuthToken's 5-min rejection window, so there is always a gap
-  // in which a fresh exchange can succeed.
-  if (clientPromise && clientExpiresAt !== null && Date.now() >= clientExpiresAt - EVICT_BEFORE_MS) {
-    clientPromise = null;
-    clientExpiresAt = null;
-  }
-  if (!clientPromise) {
-    clientPromise = buildClient().catch((err: unknown) => {
-      // Clear so the next call retries rather than returning a permanently-cached rejection
-      clientPromise = null;
-      throw err;
-    });
-  }
-  return clientPromise;
 }
 
 export interface CallClaudeOptions {
@@ -183,7 +135,7 @@ export function extractJson(text: string): unknown {
  * Call Claude API with the given prompt. Handles JSON extraction when jsonMode is true.
  */
 export async function callClaude(options: CallClaudeOptions): Promise<CallClaudeResult> {
-  const anthropic = await getClient(); // getClient() returns a Promise; concurrent calls share one exchange
+  const anthropic = getClient();
 
   const response = await anthropic.messages.create({
     model: options.model ?? DEFAULT_MODEL,


### PR DESCRIPTION
## Summary
- Removes the `create_api_key` key exchange from PR #14 — that endpoint requires `org:create_api_key` scope which is not a valid Claude OAuth scope (anthropics/claude-code#20325)
- Uses Anthropic SDK `authToken` constructor param instead, sending `Authorization: Bearer <token>` — accepted by the inference API with `user:inference` scope
- Makes `getClient()` synchronous (no async needed without the exchange network call)
- Explicitly resets `clientExpiresAt` in the API-key fallback path to prevent a stale OAuth expiry from evicting a valid cached client

## Test plan
- [x] `npm run build` exits 0
- [x] `npm run test` — all 46 tests pass
- [x] `npx tsc --noEmit` exits 0
- [x] No references to `create_api_key` or `exchangeOAuthForApiKey` remain
- [x] `authToken` passed to `Anthropic` constructor for OAuth path