### PR TITLE
feat: implement forge_evaluate — stateless binary grading (Phase 2)

### DIFF
--- a/schema/eval-report.schema.json
+++ b/schema/eval-report.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/ziyilam3999/forge-harness/schema/eval-report.schema.json",
   "title": "Forge Evaluation Report",
-  "description": "Output of forge_evaluate — per-criterion PASS/FAIL with evidence",
+  "description": "Output of forge_evaluate — per-criterion PASS/FAIL/INCONCLUSIVE with evidence",
   "type": "object",
   "required": ["storyId", "verdict", "criteria"],
   "properties": {
@@ -15,16 +15,20 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "status"],
+        "required": ["id", "status", "evidence"],
         "properties": {
           "id": { "type": "string" },
           "status": {
             "type": "string",
-            "enum": ["PASS", "FAIL", "SKIPPED"]
+            "enum": ["PASS", "FAIL", "SKIPPED", "INCONCLUSIVE"]
           },
           "evidence": { "type": "string" }
         }
       }
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "string" }
     }
   }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import { coordinateInputSchema, handleCoordinate } from "./tools/coordinate.js";
 
 const server = new McpServer({
   name: "forge",
-  version: "0.1.0",
+  version: "0.3.0",
 });
 
 server.registerTool(
@@ -27,9 +27,9 @@ server.registerTool(
   {
     title: "Forge Evaluate",
     description:
-      "Grade work against the execution plan contract. Returns PASS/FAIL per criterion with evidence. Stateless — never modifies code.",
+      "Run acceptance criteria shell commands for a story and produce a structured eval report with PASS/FAIL/INCONCLUSIVE per criterion.",
     inputSchema: evaluateInputSchema,
-    annotations: { readOnlyHint: true },
+    annotations: { readOnlyHint: false },
   },
   handleEvaluate
 );

--- a/server/lib/evaluator.test.ts
+++ b/server/lib/evaluator.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./executor.js", () => ({
+  executeCommand: vi.fn(),
+}));
+
+import { executeCommand } from "./executor.js";
+import { evaluateStory } from "./evaluator.js";
+import type { ExecutionPlan } from "../types/execution-plan.js";
+import type { CriterionResult } from "../types/eval-report.js";
+
+const mockedExecute = vi.mocked(executeCommand);
+
+function makePlan(overrides?: Partial<ExecutionPlan>): ExecutionPlan {
+  return {
+    schemaVersion: "3.0.0",
+    stories: [
+      {
+        id: "US-01",
+        title: "Test story",
+        acceptanceCriteria: [
+          { id: "AC-01", description: "Check A", command: "echo ok" },
+          { id: "AC-02", description: "Check B", command: "echo ok" },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function mockResult(partial: Partial<CriterionResult>): CriterionResult {
+  return {
+    id: "",
+    status: "PASS",
+    evidence: "",
+    ...partial,
+  };
+}
+
+describe("evaluateStory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns PASS when all ACs pass", async () => {
+    mockedExecute
+      .mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "ok" }))
+      .mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "ok" }));
+
+    const report = await evaluateStory(makePlan(), "US-01");
+    expect(report.verdict).toBe("PASS");
+    expect(report.criteria).toHaveLength(2);
+    expect(report.criteria.every((c) => c.status === "PASS")).toBe(true);
+  });
+
+  it("returns FAIL when any AC fails", async () => {
+    mockedExecute
+      .mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "ok" }))
+      .mockResolvedValueOnce(mockResult({ status: "FAIL", evidence: "bad" }));
+
+    const report = await evaluateStory(makePlan(), "US-01");
+    expect(report.verdict).toBe("FAIL");
+    expect(report.criteria[1].status).toBe("FAIL");
+  });
+
+  it("throws when story not found", async () => {
+    await expect(
+      evaluateStory(makePlan(), "US-99"),
+    ).rejects.toThrow("Story 'US-99' not found in plan");
+  });
+
+  it("captures evidence from executor results", async () => {
+    mockedExecute
+      .mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "hello world" }))
+      .mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "42" }));
+
+    const report = await evaluateStory(makePlan(), "US-01");
+    expect(report.criteria[0].evidence).toBe("hello world");
+    expect(report.criteria[1].evidence).toBe("42");
+  });
+
+  it("returns INCONCLUSIVE when command exec fails", async () => {
+    mockedExecute
+      .mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "ok" }))
+      .mockResolvedValueOnce(
+        mockResult({ status: "INCONCLUSIVE", evidence: "Command execution failed: not found" }),
+      );
+
+    const report = await evaluateStory(makePlan(), "US-01");
+    expect(report.verdict).toBe("INCONCLUSIVE");
+    expect(report.criteria[1].status).toBe("INCONCLUSIVE");
+  });
+
+  it("FAIL takes priority over INCONCLUSIVE", async () => {
+    mockedExecute
+      .mockResolvedValueOnce(mockResult({ status: "INCONCLUSIVE", evidence: "err" }))
+      .mockResolvedValueOnce(mockResult({ status: "FAIL", evidence: "bad" }));
+
+    const report = await evaluateStory(makePlan(), "US-01");
+    expect(report.verdict).toBe("FAIL");
+  });
+
+  it("returns PASS with warning for zero ACs", async () => {
+    const plan = makePlan({
+      stories: [
+        { id: "US-01", title: "Empty", acceptanceCriteria: [] },
+      ],
+    });
+    const report = await evaluateStory(plan, "US-01");
+    expect(report.verdict).toBe("PASS");
+    expect(report.criteria).toHaveLength(0);
+    expect(report.warnings).toContain(
+      "Story US-01 has 0 acceptance criteria — PASS verdict is vacuous",
+    );
+  });
+
+  it("assigns correct AC IDs from story", async () => {
+    mockedExecute
+      .mockResolvedValueOnce(mockResult({ status: "PASS" }))
+      .mockResolvedValueOnce(mockResult({ status: "PASS" }));
+
+    const report = await evaluateStory(makePlan(), "US-01");
+    expect(report.criteria[0].id).toBe("AC-01");
+    expect(report.criteria[1].id).toBe("AC-02");
+  });
+
+  it("passes timeout and cwd options to executor", async () => {
+    mockedExecute
+      .mockResolvedValueOnce(mockResult({ status: "PASS" }))
+      .mockResolvedValueOnce(mockResult({ status: "PASS" }));
+
+    await evaluateStory(makePlan(), "US-01", {
+      timeoutMs: 5000,
+      cwd: "/tmp",
+    });
+
+    expect(mockedExecute).toHaveBeenCalledWith(
+      "echo ok",
+      expect.objectContaining({ timeoutMs: 5000, cwd: "/tmp" }),
+    );
+  });
+
+  it("does not include warnings field when no warnings", async () => {
+    mockedExecute
+      .mockResolvedValueOnce(mockResult({ status: "PASS" }))
+      .mockResolvedValueOnce(mockResult({ status: "PASS" }));
+
+    const report = await evaluateStory(makePlan(), "US-01");
+    expect(report.warnings).toBeUndefined();
+  });
+
+  it("runs ACs sequentially", async () => {
+    const callOrder: number[] = [];
+    mockedExecute
+      .mockImplementationOnce(async () => {
+        callOrder.push(1);
+        return mockResult({ status: "PASS" });
+      })
+      .mockImplementationOnce(async () => {
+        callOrder.push(2);
+        return mockResult({ status: "PASS" });
+      });
+
+    await evaluateStory(makePlan(), "US-01");
+    expect(callOrder).toEqual([1, 2]);
+  });
+});

--- a/server/lib/evaluator.ts
+++ b/server/lib/evaluator.ts
@@ -1,0 +1,80 @@
+import type { ExecutionPlan } from "../types/execution-plan.js";
+import type { EvalReport, CriterionResult } from "../types/eval-report.js";
+import { executeCommand, type ExecuteOptions } from "./executor.js";
+
+export interface EvaluateOptions {
+  timeoutMs?: number;
+  cwd?: string;
+}
+
+/**
+ * Evaluate a single story from an execution plan by running all its ACs.
+ *
+ * Stateless: receives plan + storyId, runs shell commands, returns results.
+ */
+export async function evaluateStory(
+  plan: ExecutionPlan,
+  storyId: string,
+  options?: EvaluateOptions,
+): Promise<EvalReport> {
+  const story = plan.stories.find((s) => s.id === storyId);
+  if (!story) {
+    throw new Error(`Story '${storyId}' not found in plan`);
+  }
+
+  const warnings: string[] = [];
+
+  if (story.acceptanceCriteria.length === 0) {
+    warnings.push(
+      `Story ${storyId} has 0 acceptance criteria — PASS verdict is vacuous`,
+    );
+    return {
+      storyId,
+      verdict: "PASS",
+      criteria: [],
+      warnings,
+    };
+  }
+
+  const execOptions: ExecuteOptions = {
+    timeoutMs: options?.timeoutMs,
+    cwd: options?.cwd,
+  };
+
+  const criteria: CriterionResult[] = [];
+
+  for (const ac of story.acceptanceCriteria) {
+    const result = await executeCommand(ac.command, execOptions);
+    criteria.push({
+      id: ac.id,
+      status: result.status,
+      evidence: result.evidence,
+    });
+  }
+
+  const verdict = computeVerdict(criteria);
+
+  const report: EvalReport = {
+    storyId,
+    verdict,
+    criteria,
+  };
+
+  if (warnings.length > 0) {
+    report.warnings = warnings;
+  }
+
+  return report;
+}
+
+function computeVerdict(
+  criteria: CriterionResult[],
+): "PASS" | "FAIL" | "INCONCLUSIVE" {
+  const hasFail = criteria.some((c) => c.status === "FAIL");
+  if (hasFail) return "FAIL";
+
+  const hasInconclusive = criteria.some((c) => c.status === "INCONCLUSIVE");
+  if (hasInconclusive) return "INCONCLUSIVE";
+
+  return "PASS";
+}

--- a/server/lib/executor.test.ts
+++ b/server/lib/executor.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  exec: vi.fn(),
+}));
+
+vi.mock("node:os", () => ({
+  platform: vi.fn(() => "linux"),
+}));
+
+import { exec } from "node:child_process";
+import { platform } from "node:os";
+import { executeCommand } from "./executor.js";
+
+const mockedExec = vi.mocked(exec);
+const mockedPlatform = vi.mocked(platform);
+
+function simulateExec(
+  error: Error | null,
+  stdout: string,
+  stderr: string,
+) {
+  mockedExec.mockImplementationOnce((_cmd, _opts, callback) => {
+    (callback as Function)(error, stdout, stderr);
+    return {} as ReturnType<typeof exec>;
+  });
+}
+
+describe("executeCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedPlatform.mockReturnValue("linux" as ReturnType<typeof platform>);
+  });
+
+  it("returns PASS for exit code 0", async () => {
+    simulateExec(null, "hello", "");
+    const result = await executeCommand("echo hello", {});
+    expect(result.status).toBe("PASS");
+    expect(result.evidence).toBe("hello");
+  });
+
+  it("returns PASS with empty evidence for silent commands", async () => {
+    simulateExec(null, "", "");
+    const result = await executeCommand("true", {});
+    expect(result.status).toBe("PASS");
+    expect(result.evidence).toBe("");
+  });
+
+  it("includes stderr in evidence for PASS results", async () => {
+    simulateExec(null, "output", "warning");
+    const result = await executeCommand("cmd", {});
+    expect(result.status).toBe("PASS");
+    expect(result.evidence).toBe("output\nwarning");
+  });
+
+  it("returns FAIL for non-zero exit code", async () => {
+    const error = Object.assign(new Error("exit 1"), { code: 1 });
+    simulateExec(error, "", "error output");
+    const result = await executeCommand("exit 1", {});
+    expect(result.status).toBe("FAIL");
+    expect(result.evidence).toBe("error output");
+  });
+
+  it("returns FAIL for timeout (error.killed = true)", async () => {
+    const error = Object.assign(new Error("killed"), { killed: true, code: null });
+    simulateExec(error, "", "");
+    const result = await executeCommand("sleep 30", { timeoutMs: 1000 });
+    expect(result.status).toBe("FAIL");
+    expect(result.evidence).toContain("timeout");
+    expect(result.evidence).toContain("1000");
+  });
+
+  it("returns INCONCLUSIVE for ENOENT (binary not found)", async () => {
+    const error = Object.assign(new Error("not found"), { code: "ENOENT" });
+    simulateExec(error, "", "");
+    const result = await executeCommand("nonexistent_binary", {});
+    expect(result.status).toBe("INCONCLUSIVE");
+    expect(result.evidence).toContain("execution failed");
+  });
+
+  it("returns INCONCLUSIVE for signal-killed process (fallback)", async () => {
+    const error = Object.assign(new Error("signal"), {
+      code: null,
+      killed: false,
+      signal: "SIGTERM",
+    });
+    simulateExec(error, "", "");
+    const result = await executeCommand("cmd", {});
+    expect(result.status).toBe("INCONCLUSIVE");
+    expect(result.evidence).toContain("execution failed");
+  });
+
+  it("truncates evidence exceeding 4000 characters", async () => {
+    const longOutput = "x".repeat(5000);
+    simulateExec(null, longOutput, "");
+    const result = await executeCommand("cmd", {});
+    expect(result.status).toBe("PASS");
+    expect(result.evidence.length).toBeLessThanOrEqual(4000 + "[truncated] ".length);
+    expect(result.evidence).toContain("[truncated]");
+  });
+
+  it("uses bash shell on Windows", async () => {
+    mockedPlatform.mockReturnValue("win32" as ReturnType<typeof platform>);
+    simulateExec(null, "", "");
+    await executeCommand("echo test", {});
+    expect(mockedExec).toHaveBeenCalledWith(
+      "echo test",
+      expect.objectContaining({ shell: "bash" }),
+      expect.any(Function),
+    );
+  });
+
+  it("does not force bash shell on Linux", async () => {
+    mockedPlatform.mockReturnValue("linux" as ReturnType<typeof platform>);
+    simulateExec(null, "", "");
+    await executeCommand("echo test", {});
+    expect(mockedExec).toHaveBeenCalledWith(
+      "echo test",
+      expect.not.objectContaining({ shell: "bash" }),
+      expect.any(Function),
+    );
+  });
+
+  it("passes cwd and timeout options to exec", async () => {
+    simulateExec(null, "", "");
+    await executeCommand("cmd", { timeoutMs: 5000, cwd: "/tmp" });
+    expect(mockedExec).toHaveBeenCalledWith(
+      "cmd",
+      expect.objectContaining({ timeout: 5000, cwd: "/tmp" }),
+      expect.any(Function),
+    );
+  });
+
+  it("concatenates stdout and stderr with newline", async () => {
+    simulateExec(null, "out", "err");
+    const result = await executeCommand("cmd", {});
+    expect(result.evidence).toBe("out\nerr");
+  });
+
+  it("omits empty streams from evidence", async () => {
+    simulateExec(null, "output", "");
+    const result = await executeCommand("cmd", {});
+    expect(result.evidence).toBe("output");
+  });
+});

--- a/server/lib/executor.ts
+++ b/server/lib/executor.ts
@@ -1,0 +1,104 @@
+import { exec } from "node:child_process";
+import { platform } from "node:os";
+import type { CriterionResult } from "../types/eval-report.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024; // 10 MB
+const EVIDENCE_CHAR_CAP = 4_000;
+
+export interface ExecuteOptions {
+  timeoutMs?: number;
+  cwd?: string;
+  maxBuffer?: number;
+}
+
+function truncateEvidence(evidence: string): string {
+  if (evidence.length <= EVIDENCE_CHAR_CAP) {
+    return evidence;
+  }
+  return "[truncated] " + evidence.slice(-EVIDENCE_CHAR_CAP);
+}
+
+function buildEvidence(stdout: string, stderr: string): string {
+  const combined = [stdout, stderr].filter(Boolean).join("\n");
+  return truncateEvidence(combined);
+}
+
+/**
+ * Execute a shell command and return a CriterionResult.
+ *
+ * Uses child_process.exec with shell string execution.
+ * On Windows, forces { shell: 'bash' } for Unix-style AC commands.
+ */
+export function executeCommand(
+  command: string,
+  options: ExecuteOptions,
+): Promise<CriterionResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBuffer = options.maxBuffer ?? DEFAULT_MAX_BUFFER;
+  const cwd = options.cwd ?? process.cwd();
+
+  const shellOption = platform() === "win32" ? { shell: "bash" as const } : {};
+
+  return new Promise<CriterionResult>((resolve) => {
+    exec(
+      command,
+      {
+        timeout: timeoutMs,
+        maxBuffer,
+        cwd,
+        ...shellOption,
+      },
+      (error, stdout, stderr) => {
+        const stdoutStr = String(stdout ?? "");
+        const stderrStr = String(stderr ?? "");
+
+        if (!error) {
+          resolve({
+            id: "",
+            status: "PASS",
+            evidence: buildEvidence(stdoutStr, stderrStr),
+          });
+          return;
+        }
+
+        // Timeout: error.killed is true when exec kills the process
+        if (error.killed) {
+          resolve({
+            id: "",
+            status: "FAIL",
+            evidence: `Command timeout after ${timeoutMs}ms`,
+          });
+          return;
+        }
+
+        // Exec-level error: error.code is a string (e.g., 'ENOENT')
+        if (typeof error.code === "string") {
+          resolve({
+            id: "",
+            status: "INCONCLUSIVE",
+            evidence: `Command execution failed: ${error.message}`,
+          });
+          return;
+        }
+
+        // Non-zero exit code: error.code is a number
+        if (typeof error.code === "number") {
+          resolve({
+            id: "",
+            status: "FAIL",
+            evidence: buildEvidence(stdoutStr, stderrStr),
+          });
+          return;
+        }
+
+        // Fallback: signal-killed or unexpected error shape
+        resolve({
+          id: "",
+          status: "INCONCLUSIVE",
+          evidence: `Command execution failed: ${error.message}`,
+        });
+      },
+    );
+  });
+}

--- a/server/tools/evaluate.test.ts
+++ b/server/tools/evaluate.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../lib/evaluator.js", () => ({
+  evaluateStory: vi.fn(),
+}));
+
+import { evaluateStory } from "../lib/evaluator.js";
+import { handleEvaluate } from "./evaluate.js";
+import type { EvalReport } from "../types/eval-report.js";
+
+const mockedEvaluateStory = vi.mocked(evaluateStory);
+
+function makeValidPlanJson(): string {
+  return JSON.stringify({
+    schemaVersion: "3.0.0",
+    stories: [
+      {
+        id: "US-01",
+        title: "Test story",
+        acceptanceCriteria: [
+          { id: "AC-01", description: "Check", command: "echo ok" },
+        ],
+      },
+    ],
+  });
+}
+
+function makeEvalReport(overrides?: Partial<EvalReport>): EvalReport {
+  return {
+    storyId: "US-01",
+    verdict: "PASS",
+    criteria: [{ id: "AC-01", status: "PASS", evidence: "ok" }],
+    ...overrides,
+  };
+}
+
+describe("handleEvaluate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns eval report as JSON in MCP response", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport());
+
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+    });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+
+    const report = JSON.parse(result.content[0].text);
+    expect(report.storyId).toBe("US-01");
+    expect(report.verdict).toBe("PASS");
+    expect(report.criteria).toHaveLength(1);
+  });
+
+  it("returns error when neither planPath nor planJson provided", async () => {
+    const result = await handleEvaluate({ storyId: "US-01" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Either planPath or planJson is required");
+  });
+
+  it("returns error for invalid plan JSON", async () => {
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planJson: "not json",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Invalid plan JSON");
+  });
+
+  it("returns error when plan fails validation", async () => {
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planJson: JSON.stringify({ schemaVersion: "1.0.0", stories: [] }),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Invalid execution plan");
+  });
+
+  it("returns error when story not found", async () => {
+    mockedEvaluateStory.mockRejectedValueOnce(
+      new Error("Story 'US-99' not found in plan"),
+    );
+
+    const result = await handleEvaluate({
+      storyId: "US-99",
+      planJson: makeValidPlanJson(),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Story 'US-99' not found");
+  });
+
+  it("passes timeoutMs to evaluateStory", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport());
+
+    await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      timeoutMs: 5000,
+    });
+
+    expect(mockedEvaluateStory).toHaveBeenCalledWith(
+      expect.anything(),
+      "US-01",
+      expect.objectContaining({ timeoutMs: 5000 }),
+    );
+  });
+
+  it("planJson takes precedence over planPath", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport());
+
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planPath: "/nonexistent/path.json",
+      planJson: makeValidPlanJson(),
+    });
+
+    // Should succeed because planJson is used, not planPath
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("returns error for planPath to nonexistent file", async () => {
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planPath: "/nonexistent/path.json",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Plan file not found");
+  });
+
+  it("returns FAIL verdict in report", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(
+      makeEvalReport({
+        verdict: "FAIL",
+        criteria: [{ id: "AC-01", status: "FAIL", evidence: "error output" }],
+      }),
+    );
+
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+    });
+
+    const report = JSON.parse(result.content[0].text);
+    expect(report.verdict).toBe("FAIL");
+  });
+});

--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -1,16 +1,97 @@
 import { z } from "zod";
+import { readFileSync } from "node:fs";
+import { extractJson } from "../lib/anthropic.js";
+import { validateExecutionPlan } from "../validation/execution-plan.js";
+import { evaluateStory } from "../lib/evaluator.js";
+import type { ExecutionPlan } from "../types/execution-plan.js";
 
 export const evaluateInputSchema = {
   storyId: z.string().describe("Story ID to evaluate (e.g., US-01)"),
+  planPath: z
+    .string()
+    .optional()
+    .describe("Absolute path to execution plan JSON file"),
+  planJson: z
+    .string()
+    .optional()
+    .describe(
+      "Inline execution plan JSON string. Takes precedence over planPath.",
+    ),
+  timeoutMs: z
+    .number()
+    .positive()
+    .optional()
+    .describe("Timeout per AC command in milliseconds. Default: 30000"),
 };
 
-export async function handleEvaluate({ storyId }: { storyId: string }) {
-  return {
-    content: [
-      {
-        type: "text" as const,
-        text: `forge_evaluate for "${storyId}": not yet implemented. Phase 2 required.`,
-      },
-    ],
-  };
+function loadPlan(planPath?: string, planJson?: string): ExecutionPlan {
+  let rawJson: string;
+
+  if (planJson !== undefined) {
+    rawJson = planJson;
+  } else if (planPath !== undefined) {
+    try {
+      rawJson = readFileSync(planPath, "utf-8");
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : String(err);
+      throw new Error(`Plan file not found: ${planPath} (${message})`);
+    }
+  } else {
+    throw new Error("Either planPath or planJson is required");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = typeof rawJson === "string" ? JSON.parse(rawJson) : extractJson(rawJson);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid plan JSON: ${message}`);
+  }
+
+  const validation = validateExecutionPlan(parsed);
+  if (!validation.valid) {
+    throw new Error(
+      `Invalid execution plan: ${validation.errors?.join("; ") ?? "unknown error"}`,
+    );
+  }
+
+  return parsed as ExecutionPlan;
+}
+
+export async function handleEvaluate({
+  storyId,
+  planPath,
+  planJson,
+  timeoutMs,
+}: {
+  storyId: string;
+  planPath?: string;
+  planJson?: string;
+  timeoutMs?: number;
+}) {
+  try {
+    const plan = loadPlan(planPath, planJson);
+    const report = await evaluateStory(plan, storyId, { timeoutMs });
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(report, null, 2),
+        },
+      ],
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `forge_evaluate error: ${message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
 }

--- a/server/types/eval-report.ts
+++ b/server/types/eval-report.ts
@@ -1,0 +1,12 @@
+export interface EvalReport {
+  storyId: string;
+  verdict: "PASS" | "FAIL" | "INCONCLUSIVE";
+  criteria: CriterionResult[];
+  warnings?: string[];
+}
+
+export interface CriterionResult {
+  id: string;
+  status: "PASS" | "FAIL" | "SKIPPED" | "INCONCLUSIVE";
+  evidence: string;
+}

--- a/server/validation/eval-report.test.ts
+++ b/server/validation/eval-report.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { validateEvalReport } from "./eval-report.js";
+
+function makeValidReport() {
+  return {
+    storyId: "US-01",
+    verdict: "PASS",
+    criteria: [
+      { id: "AC-01", status: "PASS", evidence: "ok" },
+    ],
+  };
+}
+
+describe("validateEvalReport", () => {
+  it("returns valid for a correct report", () => {
+    const result = validateEvalReport(makeValidReport());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it("rejects null input", () => {
+    const result = validateEvalReport(null);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Report must be a non-null object");
+  });
+
+  it("rejects missing storyId", () => {
+    const report = makeValidReport();
+    delete (report as Record<string, unknown>).storyId;
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("storyId"))).toBe(true);
+  });
+
+  it("rejects empty storyId", () => {
+    const report = { ...makeValidReport(), storyId: "" };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("storyId"))).toBe(true);
+  });
+
+  it("rejects invalid verdict", () => {
+    const report = { ...makeValidReport(), verdict: "MAYBE" };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("verdict"))).toBe(true);
+  });
+
+  it("accepts all valid verdicts", () => {
+    for (const verdict of ["PASS", "FAIL", "INCONCLUSIVE"]) {
+      const report = { ...makeValidReport(), verdict };
+      const result = validateEvalReport(report);
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  it("rejects non-array criteria", () => {
+    const report = { ...makeValidReport(), criteria: "not-array" };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("criteria must be an array"))).toBe(true);
+  });
+
+  it("accepts empty criteria array", () => {
+    const report = { ...makeValidReport(), criteria: [] };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects criterion with missing id", () => {
+    const report = {
+      ...makeValidReport(),
+      criteria: [{ status: "PASS", evidence: "ok" }],
+    };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("id must be a non-empty string"))).toBe(true);
+  });
+
+  it("rejects criterion with invalid status", () => {
+    const report = {
+      ...makeValidReport(),
+      criteria: [{ id: "AC-01", status: "UNKNOWN", evidence: "ok" }],
+    };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("status must be one of"))).toBe(true);
+  });
+
+  it("accepts all valid criterion statuses", () => {
+    for (const status of ["PASS", "FAIL", "SKIPPED", "INCONCLUSIVE"]) {
+      const report = {
+        ...makeValidReport(),
+        criteria: [{ id: "AC-01", status, evidence: "ok" }],
+      };
+      const result = validateEvalReport(report);
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  it("rejects criterion with missing evidence", () => {
+    const report = {
+      ...makeValidReport(),
+      criteria: [{ id: "AC-01", status: "PASS" }],
+    };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("evidence must be a string"))).toBe(true);
+  });
+
+  it("accepts empty string evidence", () => {
+    const report = {
+      ...makeValidReport(),
+      criteria: [{ id: "AC-01", status: "PASS", evidence: "" }],
+    };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects duplicate criterion IDs", () => {
+    const report = {
+      ...makeValidReport(),
+      criteria: [
+        { id: "AC-01", status: "PASS", evidence: "ok" },
+        { id: "AC-01", status: "FAIL", evidence: "bad" },
+      ],
+    };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("Duplicate criterion ID"))).toBe(true);
+  });
+
+  it("accepts report with warnings", () => {
+    const report = { ...makeValidReport(), warnings: ["test warning"] };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects non-array warnings", () => {
+    const report = { ...makeValidReport(), warnings: "not-array" };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("warnings must be an array"))).toBe(true);
+  });
+
+  it("rejects non-string warning entries", () => {
+    const report = { ...makeValidReport(), warnings: [42] };
+    const result = validateEvalReport(report);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.some((e) => e.includes("warnings[0]: must be a string"))).toBe(true);
+  });
+});

--- a/server/validation/eval-report.ts
+++ b/server/validation/eval-report.ts
@@ -1,0 +1,108 @@
+import type { EvalReport } from "../types/eval-report.js";
+
+export interface ValidationResult {
+  valid: boolean;
+  errors?: string[];
+}
+
+const VALID_VERDICTS = new Set(["PASS", "FAIL", "INCONCLUSIVE"]);
+const VALID_STATUSES = new Set(["PASS", "FAIL", "SKIPPED", "INCONCLUSIVE"]);
+
+/**
+ * Validate an eval report against the eval-report schema rules.
+ * Hand-written validation for clear error messages — no ajv dependency.
+ */
+export function validateEvalReport(data: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (!data || typeof data !== "object") {
+    return { valid: false, errors: ["Report must be a non-null object"] };
+  }
+
+  const report = data as Record<string, unknown>;
+
+  // 1. storyId
+  if (typeof report.storyId !== "string" || report.storyId.length === 0) {
+    errors.push("storyId must be a non-empty string");
+  }
+
+  // 2. verdict
+  if (typeof report.verdict !== "string" || !VALID_VERDICTS.has(report.verdict)) {
+    errors.push(
+      `verdict must be one of "PASS", "FAIL", "INCONCLUSIVE", got "${String(report.verdict)}"`,
+    );
+  }
+
+  // 3. criteria must be an array
+  if (!Array.isArray(report.criteria)) {
+    errors.push("criteria must be an array");
+    return { valid: false, errors };
+  }
+
+  const criterionIds = new Set<string>();
+
+  for (let i = 0; i < report.criteria.length; i++) {
+    const criterion = report.criteria[i] as Record<string, unknown>;
+    const prefix = `criteria[${i}]`;
+
+    if (!criterion || typeof criterion !== "object") {
+      errors.push(`${prefix}: must be an object`);
+      continue;
+    }
+
+    // 4. id
+    if (typeof criterion.id !== "string" || criterion.id.length === 0) {
+      errors.push(`${prefix}: id must be a non-empty string`);
+    } else {
+      if (criterionIds.has(criterion.id)) {
+        errors.push(`Duplicate criterion ID: "${criterion.id}"`);
+      }
+      criterionIds.add(criterion.id);
+    }
+
+    // 5. status
+    if (
+      typeof criterion.status !== "string" ||
+      !VALID_STATUSES.has(criterion.status)
+    ) {
+      errors.push(
+        `${prefix}: status must be one of "PASS", "FAIL", "SKIPPED", "INCONCLUSIVE", got "${String(criterion.status)}"`,
+      );
+    }
+
+    // 6. evidence (required, must be string)
+    if (typeof criterion.evidence !== "string") {
+      errors.push(`${prefix}: evidence must be a string`);
+    }
+  }
+
+  // 7. warnings (optional, must be array of strings if present)
+  if (report.warnings !== undefined) {
+    if (!Array.isArray(report.warnings)) {
+      errors.push("warnings must be an array if present");
+    } else {
+      for (let i = 0; i < report.warnings.length; i++) {
+        if (typeof report.warnings[i] !== "string") {
+          errors.push(`warnings[${i}]: must be a string`);
+        }
+      }
+    }
+  }
+
+  return errors.length === 0
+    ? { valid: true }
+    : { valid: false, errors };
+}
+
+/**
+ * Type guard: check if validated data is an EvalReport.
+ */
+export function asEvalReport(data: unknown): EvalReport {
+  const result = validateEvalReport(data);
+  if (!result.valid) {
+    throw new Error(
+      `Invalid eval report: ${result.errors?.join("; ") ?? "unknown error"}`,
+    );
+  }
+  return data as EvalReport;
+}


### PR DESCRIPTION
## Summary

- Replace `forge_evaluate` placeholder with real implementation: runs AC shell commands from an execution plan, produces structured eval reports with PASS/FAIL/INCONCLUSIVE per criterion
- Shell command executor with platform-conditional shell (`bash` on Windows), timeout, maxBuffer (10MB), evidence truncation (4K chars tail)
- Story evaluator pipeline: load plan → find story → run ACs sequentially → compute verdict → return report
- 96 tests across 7 files, all passing

## Key Design Decisions

- `child_process.exec` with `{ shell: 'bash' }` on Windows only (D8)
- Timeout → FAIL (not INCONCLUSIVE — CI context rationale in D2)
- INCONCLUSIVE for exec errors (ENOENT, signals) with discrimination logic (D3)
- Evidence: `[stdout, stderr].filter(Boolean).join('\n')`, tail-truncated to 4K (D4)
- `readOnlyHint: false` — tool runs arbitrary shell commands

## Test plan

- [ ] `npx tsc --noEmit` — zero errors
- [ ] `npx vitest run` — 96 tests pass
- [ ] Smoke test: `handleEvaluate({ storyId: 'US-01', planPath: '...' })` returns PASS verdict
- [ ] CI checks pass (build + code-review)