### PR TITLE
fix: calibrate planner prompt with D1 and D2 rules

### DIFF
--- a/server/lib/prompts/planner.ts
+++ b/server/lib/prompts/planner.ts
@@ -55,6 +55,12 @@ Respond with ONLY a JSON object matching this exact schema (execution-plan v3.0.
   - GOOD: "npx tsc && echo PASS" / "node -e \\"process.exit(require('./dist/foo').bar?0:1)\\""
   - BAD: "code is well-structured" / "API responses are reasonable"
 - Commands should work on both Unix and Windows (Git Bash). Prefer node -e for portability.
+- When an AC command checks the output/evidence of another command (e.g., \`r.evidence.includes('...')\`),
+  the checked substring must exactly match what the code will produce. Do not assume wording —
+  if the code says "timed out", the AC must check for "timed out", not "timeout".
+- If an AC command imports from a build output directory (e.g., \`./dist/\`, \`./build/\`),
+  the command must include the build step as a prerequisite (e.g., \`npm run build && node ...\`).
+  Without this, the AC fails in a clean environment where the build output doesn't exist.
 
 ### Mode-Specific Rules (mode: ${mode})
 ${modeRules[mode]}

--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -288,6 +288,34 @@ describe("handlePlan", () => {
     });
   });
 
+  describe("planner prompt calibration rules", () => {
+    it("contains evidence format matching rule (D1)", async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan))
+        .mockResolvedValueOnce(makeCriticResult())
+        .mockResolvedValueOnce(makeCriticResult());
+
+      await handlePlan({ intent: "add button" });
+
+      const firstCall = mockedCallClaude.mock.calls[0][0];
+      expect(firstCall.system).toContain("exactly match");
+    });
+
+    it("contains build prerequisite rule (D2)", async () => {
+      const plan = makeValidPlan();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan))
+        .mockResolvedValueOnce(makeCriticResult())
+        .mockResolvedValueOnce(makeCriticResult());
+
+      await handlePlan({ intent: "add button" });
+
+      const firstCall = mockedCallClaude.mock.calls[0][0];
+      expect(firstCall.system).toContain("build output directory");
+    });
+  });
+
   describe("critic zero findings", () => {
     it("skips corrector when critic finds no issues", async () => {
       const plan = makeValidPlan();


### PR DESCRIPTION
## Summary
- Add evidence format matching rule (D1): AC commands checking output must use exact substrings the code produces
- Add build prerequisite rule (D2): ACs importing from `./dist/` must include `npm run build &&` prefix
- Add 2 test cases verifying new rules appear in planner prompt

These deficiencies were discovered during Phase 2 dogfooding and must be fixed before Phase 3.

## Test plan
- [ ] `grep -q 'exactly match' server/lib/prompts/planner.ts` — D1 rule present
- [ ] `grep -q 'build output directory' server/lib/prompts/planner.ts` — D2 rule present
- [ ] `npx tsc --noEmit` — compiles clean
- [ ] `npx vitest run` — all 98 tests pass