### PR TITLE
refactor: callClaude jsonMode returns parsed JSON

### DIFF
--- a/server/lib/anthropic.ts
+++ b/server/lib/anthropic.ts
@@ -79,6 +79,7 @@ export interface CallClaudeOptions {
 
 export interface CallClaudeResult {
   text: string;
+  parsed?: unknown;
   usage: { inputTokens: number; outputTokens: number };
 }
 
@@ -160,8 +161,8 @@ export async function callClaude(options: CallClaudeOptions): Promise<CallClaude
   };
 
   if (options.jsonMode) {
-    // Validate that the response is parseable JSON
-    extractJson(text); // throws if not valid
+    const parsed = extractJson(text);
+    return { text, parsed, usage };
   }
 
   return { text, usage };


### PR DESCRIPTION
Closes #5

Auto-fix by /housekeep Stage 4.

Added `parsed?: unknown` field to `CallClaudeResult`. When `jsonMode` is true, `callClaude` now stores the result of `extractJson(text)` in the `parsed` field, so callers no longer need to double-parse.