### PR TITLE
feat: improve mode auto-detection with word boundaries

### DIFF
--- a/server/tools/plan.ts
+++ b/server/tools/plan.ts
@@ -42,7 +42,7 @@ const BUGFIX_KEYWORDS = ["fix", "bug", "broken", "crash", "error"];
 function detectMode(intent: string): "feature" | "bugfix" {
   const lower = intent.toLowerCase();
   for (const keyword of BUGFIX_KEYWORDS) {
-    if (lower.includes(keyword)) return "bugfix";
+    if (new RegExp(`\\b${keyword}\\b`).test(lower)) return "bugfix";
   }
   return "feature";
 }


### PR DESCRIPTION
Closes #6

Auto-fix by /housekeep Stage 4.

Replaced `lower.includes(keyword)` with word-boundary regex `\b${keyword}\b` in `detectMode()`, preventing false positives on substrings (e.g., 'prefix' no longer matches 'fix').