### PR TITLE
refactor: route timeout/error evidence through truncateEvidence

### DIFF
--- a/server/lib/executor.ts
+++ b/server/lib/executor.ts
@@ -67,7 +67,7 @@ export function executeCommand(
           resolve({
             id: "",
             status: "FAIL",
-            evidence: `Command timeout after ${timeoutMs}ms`,
+            evidence: truncateEvidence(`Command timeout after ${timeoutMs}ms`),
           });
           return;
         }
@@ -77,7 +77,7 @@ export function executeCommand(
           resolve({
             id: "",
             status: "INCONCLUSIVE",
-            evidence: `Command execution failed: ${error.message}`,
+            evidence: truncateEvidence(`Command execution failed: ${error.message}`),
           });
           return;
         }
@@ -96,7 +96,7 @@ export function executeCommand(
         resolve({
           id: "",
           status: "INCONCLUSIVE",
-          evidence: `Command execution failed: ${error.message}`,
+          evidence: truncateEvidence(`Command execution failed: ${error.message}`),
         });
       },
     );


### PR DESCRIPTION
Closes #26

Auto-fix by /housekeep Stage 4.

Routed timeout and error evidence strings through `truncateEvidence()` in `executor.ts` for consistency with PASS and non-zero-exit FAIL branches.