### PR TITLE
feat: context injection, run records, and enhanced codebase scanning

### DIFF
--- a/server/lib/codebase-scan.test.ts
+++ b/server/lib/codebase-scan.test.ts
@@ -39,6 +39,28 @@ describe("scanCodebase", () => {
     expect(result).toContain("my-project");
   });
 
+  it("extracts structured dependency info from package.json", async () => {
+    await writeFile(
+      join(tempDir, "package.json"),
+      JSON.stringify({
+        name: "test-project",
+        version: "2.0.0",
+        dependencies: { express: "^4.18.0", zod: "^3.25.0" },
+        devDependencies: { vitest: "^4.0.0" },
+        scripts: { test: "vitest run", build: "tsc" },
+      }),
+    );
+
+    const result = await scanCodebase(tempDir);
+    expect(result).toContain("dependencies:");
+    expect(result).toContain("express: ^4.18.0");
+    expect(result).toContain("zod: ^3.25.0");
+    expect(result).toContain("devDependencies:");
+    expect(result).toContain("vitest: ^4.0.0");
+    expect(result).toContain("scripts:");
+    expect(result).toContain("test: vitest run");
+  });
+
   it("skips node_modules", async () => {
     await mkdir(join(tempDir, "node_modules", "some-pkg"), { recursive: true });
     await writeFile(

--- a/server/lib/codebase-scan.ts
+++ b/server/lib/codebase-scan.ts
@@ -78,6 +78,47 @@ async function readHead(filePath: string, maxLines: number): Promise<string> {
 }
 
 /**
+ * Extract dependency names and versions from package.json as structured data.
+ * Returns a formatted section or null if package.json doesn't exist.
+ */
+async function extractDependencies(projectPath: string): Promise<string | null> {
+  try {
+    const content = await readFile(join(projectPath, "package.json"), "utf-8");
+    const pkg = JSON.parse(content);
+    const lines: string[] = [];
+
+    lines.push(`## package.json`);
+    if (pkg.name) lines.push(`name: ${pkg.name}`);
+    if (pkg.version) lines.push(`version: ${pkg.version}`);
+
+    if (pkg.dependencies && Object.keys(pkg.dependencies).length > 0) {
+      lines.push(`\ndependencies:`);
+      for (const [name, version] of Object.entries(pkg.dependencies)) {
+        lines.push(`  ${name}: ${version}`);
+      }
+    }
+
+    if (pkg.devDependencies && Object.keys(pkg.devDependencies).length > 0) {
+      lines.push(`\ndevDependencies:`);
+      for (const [name, version] of Object.entries(pkg.devDependencies)) {
+        lines.push(`  ${name}: ${version}`);
+      }
+    }
+
+    if (pkg.scripts && Object.keys(pkg.scripts).length > 0) {
+      lines.push(`\nscripts:`);
+      for (const [name, cmd] of Object.entries(pkg.scripts)) {
+        lines.push(`  ${name}: ${cmd}`);
+      }
+    }
+
+    return lines.join("\n");
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Scan a project directory and return a text summary for LLM context.
  *
  * @param projectPath - Absolute path to the project root
@@ -105,8 +146,15 @@ export async function scanCodebase(projectPath: string): Promise<string> {
   await listDir(projectPath, projectPath, 0, dirLines);
   sections.push("## Directory Structure\n```\n" + dirLines.join("\n") + "\n```");
 
-  // 2. Key file contents
+  // 2. Structured dependency extraction from package.json
+  const depSection = await extractDependencies(projectPath);
+  if (depSection) {
+    sections.push(depSection);
+  }
+
+  // 3. Key file contents (excluding package.json — already extracted above)
   for (const fileName of KEY_FILES) {
+    if (fileName === "package.json" && depSection) continue;
     const content = await readHead(join(projectPath, fileName), 100);
     if (content) {
       sections.push(
@@ -117,7 +165,7 @@ export async function scanCodebase(projectPath: string): Promise<string> {
 
   let output = sections.join("\n\n");
 
-  // 3. Truncate to cap
+  // 4. Truncate to cap
   if (output.length > SCANNER_CHAR_CAP) {
     output = output.slice(0, SCANNER_CHAR_CAP) + "\n[truncated]";
   }

--- a/server/lib/prompts/planner.test.ts
+++ b/server/lib/prompts/planner.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildPlannerUserMessage,
+  truncateContext,
+  DEFAULT_MAX_CONTEXT_CHARS,
+  type ContextEntry,
+} from "./planner.js";
+
+describe("truncateContext", () => {
+  it("returns all entries when within budget", () => {
+    const entries: ContextEntry[] = [
+      { label: "Patterns", content: "P1: tight scope" },
+      { label: "Anti-patterns", content: "F2: no consequences" },
+    ];
+    const result = truncateContext(entries, 1000);
+    expect(result).toHaveLength(2);
+  });
+
+  it("drops last entries first when exceeding budget", () => {
+    const entries: ContextEntry[] = [
+      { label: "High priority", content: "A".repeat(100) },
+      { label: "Medium priority", content: "B".repeat(100) },
+      { label: "Low priority", content: "C".repeat(100) },
+    ];
+    // Budget fits ~2 entries (each ~110 chars with overhead)
+    const result = truncateContext(entries, 250);
+    expect(result).toHaveLength(2);
+    expect(result[0].label).toBe("High priority");
+    expect(result[1].label).toBe("Medium priority");
+  });
+
+  it("drops entries whole — never mid-truncates", () => {
+    const entries: ContextEntry[] = [
+      { label: "Big entry", content: "X".repeat(500) },
+    ];
+    const result = truncateContext(entries, 100);
+    // The single entry exceeds budget, so it gets dropped entirely
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array for zero budget", () => {
+    const entries: ContextEntry[] = [
+      { label: "Any", content: "content" },
+    ];
+    const result = truncateContext(entries, 0);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array for empty input", () => {
+    const result = truncateContext([], 1000);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("buildPlannerUserMessage", () => {
+  it("includes intent", () => {
+    const msg = buildPlannerUserMessage("add dark mode");
+    expect(msg).toContain("## Intent");
+    expect(msg).toContain("add dark mode");
+  });
+
+  it("includes codebase context when provided", () => {
+    const msg = buildPlannerUserMessage("add button", "## Directory Structure\nsrc/");
+    expect(msg).toContain("## Codebase Context");
+    expect(msg).toContain("src/");
+  });
+
+  it("injects context entries under Additional Context heading", () => {
+    const context: ContextEntry[] = [
+      { label: "Proven patterns", content: "P27: tight scope" },
+      { label: "Anti-patterns", content: "F2: no consequences" },
+    ];
+    const msg = buildPlannerUserMessage("add button", undefined, context);
+    expect(msg).toContain("## Additional Context");
+    expect(msg).toContain("### Proven patterns");
+    expect(msg).toContain("P27: tight scope");
+    expect(msg).toContain("### Anti-patterns");
+    expect(msg).toContain("F2: no consequences");
+  });
+
+  it("truncates context at maxContextChars", () => {
+    const context: ContextEntry[] = [
+      { label: "Small", content: "fits" },
+      { label: "Big", content: "X".repeat(10000) },
+    ];
+    const msg = buildPlannerUserMessage("intent", undefined, context, 100);
+    expect(msg).toContain("### Small");
+    expect(msg).not.toContain("### Big");
+    expect(msg).toContain("1 context entries omitted");
+  });
+
+  it("does not add Additional Context section when context is empty", () => {
+    const msg = buildPlannerUserMessage("intent", undefined, []);
+    expect(msg).not.toContain("Additional Context");
+  });
+
+  it("does not add Additional Context section when context is undefined", () => {
+    const msg = buildPlannerUserMessage("intent");
+    expect(msg).not.toContain("Additional Context");
+  });
+
+  it("uses DEFAULT_MAX_CONTEXT_CHARS when maxContextChars not specified", () => {
+    // Verify the default exists and is a reasonable value
+    expect(DEFAULT_MAX_CONTEXT_CHARS).toBe(50_000);
+  });
+});

--- a/server/lib/prompts/planner.ts
+++ b/server/lib/prompts/planner.ts
@@ -84,17 +84,65 @@ ${modeRules[mode]}
   a path from the provided context, state the assumption explicitly instead of asserting it as fact.`;
 }
 
+/** A labeled context entry injected by the calling agent. */
+export interface ContextEntry {
+  label: string;
+  content: string;
+}
+
+/** Default maximum character budget for injected context. */
+export const DEFAULT_MAX_CONTEXT_CHARS = 50_000;
+
 /**
- * Build the user message for the planner, including intent and optional codebase context.
+ * Truncate context entries to fit within a character budget.
+ * Entries are dropped whole (last first) — never mid-truncated.
+ * The calling agent controls priority via array order: first = highest priority.
+ */
+export function truncateContext(
+  entries: ContextEntry[],
+  maxChars: number,
+): ContextEntry[] {
+  const result: ContextEntry[] = [];
+  let remaining = maxChars;
+
+  for (const entry of entries) {
+    const entrySize = entry.label.length + entry.content.length + 10; // overhead for formatting
+    if (entrySize > remaining) break;
+    result.push(entry);
+    remaining -= entrySize;
+  }
+
+  return result;
+}
+
+/**
+ * Build the user message for the planner, including intent, optional codebase context,
+ * and optional injected context entries.
  */
 export function buildPlannerUserMessage(
   intent: string,
   codebaseSummary?: string,
+  context?: ContextEntry[],
+  maxContextChars?: number,
 ): string {
   let message = `## Intent\n\n${intent}`;
 
   if (codebaseSummary) {
     message += `\n\n## Codebase Context\n\n${codebaseSummary}`;
+  }
+
+  if (context && context.length > 0) {
+    const budget = maxContextChars ?? DEFAULT_MAX_CONTEXT_CHARS;
+    const truncated = truncateContext(context, budget);
+
+    message += `\n\n## Additional Context`;
+    for (const entry of truncated) {
+      message += `\n\n### ${entry.label}\n\n${entry.content}`;
+    }
+
+    if (truncated.length < context.length) {
+      message += `\n\n*[${context.length - truncated.length} context entries omitted due to size limit]*`;
+    }
   }
 
   return message;

--- a/server/lib/run-record.test.ts
+++ b/server/lib/run-record.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { writeRunRecord, type RunRecord } from "./run-record.js";
+
+let tempDir: string;
+
+function makeRunRecord(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    timestamp: "2026-04-06T12:00:00.000Z",
+    tool: "forge_plan",
+    documentTier: null,
+    mode: "feature",
+    tier: "thorough",
+    metrics: {
+      inputTokens: 1000,
+      outputTokens: 500,
+      critiqueRounds: 2,
+      findingsTotal: 5,
+      findingsApplied: 4,
+      findingsRejected: 1,
+      validationRetries: 0,
+      durationMs: 45000,
+    },
+    outcome: "success",
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "forge-run-record-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("writeRunRecord", () => {
+  it("writes a run record JSON file to .forge/runs/", async () => {
+    const record = makeRunRecord();
+    await writeRunRecord(tempDir, record);
+
+    const runsDir = join(tempDir, ".forge", "runs");
+    const files = await readdir(runsDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^forge_plan-.*\.json$/);
+
+    const content = JSON.parse(await readFile(join(runsDir, files[0]), "utf-8"));
+    expect(content.tool).toBe("forge_plan");
+    expect(content.metrics.inputTokens).toBe(1000);
+    expect(content.outcome).toBe("success");
+  });
+
+  it("creates .forge/runs/ directory if it does not exist", async () => {
+    const record = makeRunRecord();
+    await writeRunRecord(tempDir, record);
+
+    const runsDir = join(tempDir, ".forge", "runs");
+    const files = await readdir(runsDir);
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it("produces distinct filenames for concurrent invocations", async () => {
+    const record = makeRunRecord();
+    // Write two records with the same timestamp
+    await Promise.all([
+      writeRunRecord(tempDir, record),
+      writeRunRecord(tempDir, record),
+    ]);
+
+    const runsDir = join(tempDir, ".forge", "runs");
+    const files = await readdir(runsDir);
+    expect(files).toHaveLength(2);
+    expect(files[0]).not.toBe(files[1]);
+  });
+
+  it("includes token counts, finding counts, outcome, and duration", async () => {
+    const record = makeRunRecord({
+      metrics: {
+        inputTokens: 2000,
+        outputTokens: 800,
+        critiqueRounds: 1,
+        findingsTotal: 3,
+        findingsApplied: 2,
+        findingsRejected: 1,
+        validationRetries: 1,
+        durationMs: 30000,
+      },
+    });
+    await writeRunRecord(tempDir, record);
+
+    const runsDir = join(tempDir, ".forge", "runs");
+    const files = await readdir(runsDir);
+    const content = JSON.parse(await readFile(join(runsDir, files[0]), "utf-8"));
+
+    expect(content.metrics.inputTokens).toBe(2000);
+    expect(content.metrics.outputTokens).toBe(800);
+    expect(content.metrics.findingsTotal).toBe(3);
+    expect(content.metrics.findingsApplied).toBe(2);
+    expect(content.metrics.findingsRejected).toBe(1);
+    expect(content.metrics.validationRetries).toBe(1);
+    expect(content.metrics.durationMs).toBe(30000);
+    expect(content.outcome).toBe("success");
+  });
+
+  it("does not crash when write fails (e.g., invalid path)", async () => {
+    const record = makeRunRecord();
+    // This should not throw — it logs and swallows the error
+    await expect(
+      writeRunRecord("/nonexistent/path/xyz", record),
+    ).resolves.toBeUndefined();
+  });
+
+  it("uses Windows-safe filenames (no colons)", async () => {
+    const record = makeRunRecord({
+      timestamp: "2026-04-06T12:30:45.123Z",
+    });
+    await writeRunRecord(tempDir, record);
+
+    const runsDir = join(tempDir, ".forge", "runs");
+    const files = await readdir(runsDir);
+    expect(files[0]).not.toContain(":");
+  });
+});

--- a/server/lib/run-record.ts
+++ b/server/lib/run-record.ts
@@ -1,0 +1,61 @@
+import { writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+/**
+ * A run record captures metrics from a single forge primitive invocation.
+ * Written to `.forge/runs/` for self-improvement analytics across runs.
+ */
+export interface RunRecord {
+  timestamp: string;
+  tool: "forge_plan" | "forge_evaluate" | "forge_generate" | "forge_coordinate";
+  documentTier: "master" | "phase" | "update" | null;
+  mode: "feature" | "bugfix" | "full-project" | null;
+  tier: "quick" | "standard" | "thorough" | null;
+  metrics: {
+    inputTokens: number;
+    outputTokens: number;
+    critiqueRounds: number;
+    findingsTotal: number;
+    findingsApplied: number;
+    findingsRejected: number;
+    validationRetries: number;
+    durationMs: number;
+  };
+  outcome: "success" | "validation-failure" | "api-error" | "timeout";
+}
+
+/**
+ * Generate a Windows-safe filename for a run record.
+ * Format: {tool}-{timestamp}-{suffix}.json
+ * The 4-char hex suffix handles same-millisecond collisions.
+ */
+function makeRunFilename(tool: string, timestamp: string): string {
+  const safeDateStr = timestamp.replace(/[:.]/g, "-");
+  const suffix = randomBytes(2).toString("hex");
+  return `${tool}-${safeDateStr}-${suffix}.json`;
+}
+
+/**
+ * Write a run record to `.forge/runs/`. Creates the directory if needed.
+ * Failure is logged and swallowed — never crashes the tool.
+ */
+export async function writeRunRecord(
+  projectPath: string,
+  record: RunRecord,
+): Promise<void> {
+  try {
+    const runsDir = join(projectPath, ".forge", "runs");
+    await mkdir(runsDir, { recursive: true });
+
+    const filename = makeRunFilename(record.tool, record.timestamp);
+    const filePath = join(runsDir, filename);
+
+    await writeFile(filePath, JSON.stringify(record, null, 2), "utf-8");
+  } catch (err) {
+    console.error(
+      "forge: failed to write run record (continuing):",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}

--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -12,9 +12,15 @@ vi.mock("../lib/codebase-scan.js", () => ({
   scanCodebase: vi.fn(async () => "## Directory Structure\n```\nsrc/\n```"),
 }));
 
+// Mock run-record — don't write real files during tests
+vi.mock("../lib/run-record.js", () => ({
+  writeRunRecord: vi.fn(async () => {}),
+}));
+
 // Import after mocks
 const { callClaude, extractJson } = await import("../lib/anthropic.js");
 const { scanCodebase } = await import("../lib/codebase-scan.js");
+const { writeRunRecord } = await import("../lib/run-record.js");
 const { handlePlan, detectCoupledACs } = await import("./plan.js");
 const { buildPlannerPrompt } = await import("../lib/prompts/planner.js");
 const { buildCriticPrompt } = await import("../lib/prompts/critic.js");
@@ -22,6 +28,7 @@ const { buildCriticPrompt } = await import("../lib/prompts/critic.js");
 const mockedCallClaude = vi.mocked(callClaude);
 const mockedExtractJson = vi.mocked(extractJson);
 const mockedScanCodebase = vi.mocked(scanCodebase);
+const mockedWriteRunRecord = vi.mocked(writeRunRecord);
 
 function makeValidPlan() {
   return {
@@ -447,5 +454,107 @@ describe("critic prompt rules", () => {
   it("includes implementation coupling dimension in round 2 as well", () => {
     const prompt = buildCriticPrompt(2);
     expect(prompt).toContain("Implementation Coupling");
+  });
+});
+
+describe("context injection", () => {
+  it("passes context entries to the planner prompt", async () => {
+    const plan = makeValidPlan();
+    mockedCallClaude
+      .mockResolvedValueOnce(makeCallResult(plan)); // planner only
+
+    await handlePlan({
+      intent: "add button",
+      tier: "quick",
+      context: [
+        { label: "Proven patterns", content: "P27: tight scope" },
+        { label: "Anti-patterns", content: "F2: no consequences" },
+      ],
+    });
+
+    const firstCall = mockedCallClaude.mock.calls[0][0];
+    expect(firstCall.messages[0].content).toContain("Proven patterns");
+    expect(firstCall.messages[0].content).toContain("P27: tight scope");
+    expect(firstCall.messages[0].content).toContain("Anti-patterns");
+  });
+
+  it("respects maxContextChars by dropping last entries first", async () => {
+    const plan = makeValidPlan();
+    mockedCallClaude
+      .mockResolvedValueOnce(makeCallResult(plan));
+
+    await handlePlan({
+      intent: "add button",
+      tier: "quick",
+      context: [
+        { label: "Small", content: "fits" },
+        { label: "Big", content: "X".repeat(10000) },
+      ],
+      maxContextChars: 100,
+    });
+
+    const firstCall = mockedCallClaude.mock.calls[0][0];
+    expect(firstCall.messages[0].content).toContain("Small");
+    expect(firstCall.messages[0].content).not.toContain("Big");
+  });
+
+  it("does not add context section when context is empty or omitted", async () => {
+    const plan = makeValidPlan();
+    mockedCallClaude
+      .mockResolvedValueOnce(makeCallResult(plan));
+
+    await handlePlan({ intent: "add button", tier: "quick" });
+
+    const firstCall = mockedCallClaude.mock.calls[0][0];
+    expect(firstCall.messages[0].content).not.toContain("Additional Context");
+  });
+});
+
+describe("run records", () => {
+  it("writes a run record when projectPath is provided", async () => {
+    const plan = makeValidPlan();
+    mockedCallClaude
+      .mockResolvedValueOnce(makeCallResult(plan)); // planner only
+
+    await handlePlan({ intent: "add button", tier: "quick", projectPath: "/some/path" });
+
+    expect(mockedWriteRunRecord).toHaveBeenCalledTimes(1);
+    const [projectPath, record] = mockedWriteRunRecord.mock.calls[0];
+    expect(projectPath).toBe("/some/path");
+    expect(record.tool).toBe("forge_plan");
+    expect(record.outcome).toBe("success");
+    expect(record.metrics.inputTokens).toBeGreaterThan(0);
+    expect(record.metrics.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not write a run record when projectPath is omitted", async () => {
+    const plan = makeValidPlan();
+    mockedCallClaude
+      .mockResolvedValueOnce(makeCallResult(plan));
+
+    await handlePlan({ intent: "add button", tier: "quick" });
+
+    expect(mockedWriteRunRecord).not.toHaveBeenCalled();
+  });
+
+  it("includes critique metrics in run record", async () => {
+    const plan = makeValidPlan();
+    const findings = [
+      { severity: "MINOR", storyId: "US-01", acId: null, description: "d", suggestedFix: "f" },
+    ];
+
+    mockedCallClaude
+      .mockResolvedValueOnce(makeCallResult(plan)) // planner
+      .mockResolvedValueOnce(makeCriticResult(findings)) // critic-1
+      .mockResolvedValueOnce(makeCorrectorResult(plan, [{ findingIndex: 0, applied: true, reason: "ok" }])) // corrector-1
+      .mockResolvedValueOnce(makeCriticResult()); // critic-2
+
+    await handlePlan({ intent: "add button", projectPath: "/some/path" });
+
+    const [, record] = mockedWriteRunRecord.mock.calls[0];
+    expect(record.metrics.critiqueRounds).toBe(2);
+    expect(record.metrics.findingsTotal).toBe(1);
+    expect(record.metrics.findingsApplied).toBe(1);
+    expect(record.metrics.findingsRejected).toBe(0);
   });
 });

--- a/server/tools/plan.ts
+++ b/server/tools/plan.ts
@@ -1,10 +1,15 @@
 import { z } from "zod";
 import { callClaude, extractJson } from "../lib/anthropic.js";
 import { scanCodebase } from "../lib/codebase-scan.js";
-import { buildPlannerPrompt, buildPlannerUserMessage } from "../lib/prompts/planner.js";
+import {
+  buildPlannerPrompt,
+  buildPlannerUserMessage,
+  type ContextEntry,
+} from "../lib/prompts/planner.js";
 import { buildCriticPrompt, buildCriticUserMessage } from "../lib/prompts/critic.js";
 import { buildCorrectorPrompt, buildCorrectorUserMessage } from "../lib/prompts/corrector.js";
 import { validateExecutionPlan } from "../validation/execution-plan.js";
+import { writeRunRecord, type RunRecord } from "../lib/run-record.js";
 import type { ExecutionPlan } from "../types/execution-plan.js";
 
 /**
@@ -74,6 +79,27 @@ export const planInputSchema = {
     .describe(
       "Critique depth. quick=no critique, standard=1 round, thorough=2 rounds. Default: thorough.",
     ),
+  context: z
+    .array(
+      z.object({
+        label: z.string().describe("Label for this context entry (e.g., 'Proven patterns')"),
+        content: z.string().describe("Content of the context entry"),
+      }),
+    )
+    .optional()
+    .describe(
+      "Additional context entries injected by the calling agent. " +
+      "Array order = priority (first = highest). Entries are dropped whole (last first) " +
+      "when exceeding maxContextChars.",
+    ),
+  maxContextChars: z
+    .number()
+    .positive()
+    .optional()
+    .describe(
+      "Maximum character budget for injected context. Default: 50000. " +
+      "Entries are dropped whole (last first) to stay within budget.",
+    ),
 };
 
 /** Keywords that trigger bugfix mode auto-detection. */
@@ -127,9 +153,11 @@ async function runPlanner(
   codebaseSummary: string | undefined,
   model: string | undefined,
   usage: UsageAccumulator,
-): Promise<ExecutionPlan> {
+  context?: ContextEntry[],
+  maxContextChars?: number,
+): Promise<{ plan: ExecutionPlan; validationRetries: number }> {
   const system = buildPlannerPrompt(mode);
-  const userMessage = buildPlannerUserMessage(intent, codebaseSummary);
+  const userMessage = buildPlannerUserMessage(intent, codebaseSummary, context, maxContextChars);
 
   const result = await callClaude({
     system,
@@ -172,10 +200,10 @@ async function runPlanner(
         `Planner output failed validation after retry: ${retryValidation.errors?.join("; ")}`,
       );
     }
-    return retryParsed as ExecutionPlan;
+    return { plan: retryParsed as ExecutionPlan, validationRetries: 1 };
   }
 
-  return parsed as ExecutionPlan;
+  return { plan: parsed as ExecutionPlan, validationRetries: 0 };
 }
 
 /**
@@ -296,12 +324,17 @@ export async function handlePlan({
   projectPath,
   mode,
   tier,
+  context,
+  maxContextChars,
 }: {
   intent: string;
   projectPath?: string;
   mode?: "feature" | "full-project" | "bugfix";
   tier?: "quick" | "standard" | "thorough";
+  context?: Array<{ label: string; content: string }>;
+  maxContextChars?: number;
 }) {
+  const startTime = Date.now();
   const effectiveMode = mode ?? detectMode(intent);
   const effectiveTier = tier ?? "thorough";
 
@@ -313,8 +346,12 @@ export async function handlePlan({
     codebaseSummary = await scanCodebase(projectPath);
   }
 
-  // Step 2: Run planner
-  let plan = await runPlanner(intent, effectiveMode, codebaseSummary, undefined, usage);
+  // Step 2: Run planner (with context injection)
+  const plannerResult = await runPlanner(
+    intent, effectiveMode, codebaseSummary, undefined, usage, context, maxContextChars,
+  );
+  let plan = plannerResult.plan;
+  const validationRetries = plannerResult.validationRetries;
 
   // Step 3: Critique loop
   const critiqueRounds: Array<{
@@ -378,6 +415,34 @@ export async function handlePlan({
   sections.push(
     `=== USAGE ===\nTotal tokens: ${usage.inputTokens} input / ${usage.outputTokens} output`,
   );
+
+  // Step 6: Write run record
+  const findingsTotal = critiqueRounds.reduce((sum, r) => sum + r.findings.findings.length, 0);
+  const findingsApplied = critiqueRounds.reduce(
+    (sum, r) => sum + r.dispositions.filter((d) => d.applied).length, 0,
+  );
+
+  if (projectPath) {
+    const runRecord: RunRecord = {
+      timestamp: new Date(startTime).toISOString(),
+      tool: "forge_plan",
+      documentTier: null,
+      mode: effectiveMode,
+      tier: effectiveTier,
+      metrics: {
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        critiqueRounds: critiqueRounds.length,
+        findingsTotal,
+        findingsApplied,
+        findingsRejected: findingsTotal - findingsApplied,
+        validationRetries,
+        durationMs: Date.now() - startTime,
+      },
+      outcome: "success",
+    };
+    await writeRunRecord(projectPath, runRecord);
+  }
 
   return {
     content: [


### PR DESCRIPTION
## Summary

- Add `context` and `maxContextChars` parameters to `forge_plan` for injecting memory, KB, and prior plans into the planner prompt. Entries are dropped whole (last first) when exceeding the character budget.
- Enhanced `scanCodebase` to extract structured dependency names+versions, scripts from `package.json` instead of raw text.
- Run records written to `.forge/runs/` after each `forge_plan` invocation, capturing token counts, finding metrics, duration, and outcome for self-improvement analytics.

## Test plan

- [ ] `context` param injects content into planner prompt; truncation drops whole entries (last first) at maxContextChars
- [ ] Codebase scan extracts dependency names+versions from package.json
- [ ] Run record written to `.forge/runs/` as a `.json` file with token counts, findings, outcome, duration
- [ ] Two concurrent invocations produce distinct filenames (random suffix)
- [ ] Windows-safe filenames (no colons)
- [ ] All existing plan.test.ts and evaluate.test.ts tests pass (regression)