### PR TITLE
feat: cross-cutting observability — CostTracker, ProgressReporter, AuditLog, RunContext

### DIFF
--- a/server/lib/audit.test.ts
+++ b/server/lib/audit.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { AuditLog } from "./audit.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "forge-audit-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("AuditLog", () => {
+  it("writes audit entries to .forge/audit/ as JSONL", async () => {
+    const audit = new AuditLog("forge_plan", tempDir);
+    await audit.log({
+      stage: "planner",
+      agentRole: "planner",
+      decision: "generated_plan",
+      reasoning: "Used feature mode",
+    });
+
+    const auditDir = join(tempDir, ".forge", "audit");
+    const files = await readdir(auditDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^forge_plan-.*\.jsonl$/);
+
+    const content = await readFile(join(auditDir, files[0]), "utf-8");
+    const lines = content.trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const entry = JSON.parse(lines[0]);
+    expect(entry.stage).toBe("planner");
+    expect(entry.agentRole).toBe("planner");
+    expect(entry.decision).toBe("generated_plan");
+    expect(entry.timestamp).toBeDefined();
+  });
+
+  it("appends multiple entries to the same file", async () => {
+    const audit = new AuditLog("forge_plan", tempDir);
+    await audit.log({
+      stage: "planner",
+      agentRole: "planner",
+      decision: "generated_plan",
+      reasoning: "Draft",
+    });
+    await audit.log({
+      stage: "critic",
+      agentRole: "critic",
+      decision: "reviewed_plan",
+      reasoning: "Found 3 issues",
+    });
+
+    const auditDir = join(tempDir, ".forge", "audit");
+    const files = await readdir(auditDir);
+    expect(files).toHaveLength(1);
+
+    const content = await readFile(join(auditDir, files[0]), "utf-8");
+    const lines = content.trim().split("\n");
+    expect(lines).toHaveLength(2);
+  });
+
+  it("uses Windows-safe filenames (no colons)", async () => {
+    const audit = new AuditLog("forge_plan", tempDir);
+    await audit.log({
+      stage: "test",
+      agentRole: "test",
+      decision: "test",
+      reasoning: "test",
+    });
+
+    const auditDir = join(tempDir, ".forge", "audit");
+    const files = await readdir(auditDir);
+    expect(files[0]).not.toContain(":");
+  });
+
+  it("does not crash when projectPath is not provided", async () => {
+    const audit = new AuditLog("forge_plan");
+    // Should not throw
+    await audit.log({
+      stage: "test",
+      agentRole: "test",
+      decision: "test",
+      reasoning: "test",
+    });
+    expect(audit.getFilePath()).toBeNull();
+  });
+
+  it("does not crash when write fails", async () => {
+    const audit = new AuditLog("forge_plan", "/nonexistent/path/xyz");
+    // Should not throw — logs warning and continues
+    await expect(
+      audit.log({
+        stage: "test",
+        agentRole: "test",
+        decision: "test",
+        reasoning: "test",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns file path after initialization", async () => {
+    const audit = new AuditLog("forge_plan", tempDir);
+    await audit.log({
+      stage: "test",
+      agentRole: "test",
+      decision: "test",
+      reasoning: "test",
+    });
+
+    const filePath = audit.getFilePath();
+    expect(filePath).not.toBeNull();
+    expect(filePath).toContain("forge_plan");
+    expect(filePath).toContain(".jsonl");
+  });
+});

--- a/server/lib/audit.ts
+++ b/server/lib/audit.ts
@@ -1,0 +1,104 @@
+/**
+ * AuditLog — append-only decision trail for agent actions.
+ *
+ * Persists to `.forge/audit/{tool}-{timestamp}.jsonl` (Windows-safe, no colons).
+ * Failure policy: warn and continue, never crash the tool.
+ */
+
+import { appendFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { readdir } from "node:fs/promises";
+
+export interface AuditEntry {
+  timestamp: string;
+  stage: string;
+  agentRole: string;
+  decision: string;
+  reasoning: string;
+}
+
+/** Warning threshold for audit file count. */
+const FILE_COUNT_WARNING_THRESHOLD = 1000;
+
+export class AuditLog {
+  private toolName: string;
+  private projectPath: string | null;
+  private filePath: string | null = null;
+  private initialized = false;
+
+  constructor(toolName: string, projectPath?: string) {
+    this.toolName = toolName;
+    this.projectPath = projectPath ?? null;
+  }
+
+  /**
+   * Initialize the audit log file. Creates the directory if needed.
+   * Returns false if initialization fails (no projectPath, permission error, etc.).
+   */
+  private async init(): Promise<boolean> {
+    if (this.initialized) return this.filePath !== null;
+    this.initialized = true;
+
+    if (!this.projectPath) return false;
+
+    try {
+      const auditDir = join(this.projectPath, ".forge", "audit");
+      await mkdir(auditDir, { recursive: true });
+
+      // Windows-safe timestamp: replace colons and dots
+      const safeTimestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      this.filePath = join(auditDir, `${this.toolName}-${safeTimestamp}.jsonl`);
+
+      // Check file count and warn if approaching threshold
+      await this.checkFileCount(auditDir);
+
+      return true;
+    } catch (err) {
+      console.error(
+        "forge: failed to initialize audit log (continuing):",
+        err instanceof Error ? err.message : String(err),
+      );
+      return false;
+    }
+  }
+
+  private async checkFileCount(auditDir: string): Promise<void> {
+    try {
+      const files = await readdir(auditDir);
+      if (files.length >= FILE_COUNT_WARNING_THRESHOLD) {
+        console.error(
+          `forge: audit directory has ${files.length} files (~${Math.round(files.length * 2)}KB). ` +
+          `Consider archiving old files: rm .forge/audit/*-2025-*`,
+        );
+      }
+    } catch {
+      // Non-critical — skip count check
+    }
+  }
+
+  /**
+   * Log an audit entry. Failures are swallowed with a warning.
+   */
+  async log(entry: Omit<AuditEntry, "timestamp">): Promise<void> {
+    const ready = await this.init();
+    if (!ready || !this.filePath) return;
+
+    try {
+      const fullEntry: AuditEntry = {
+        timestamp: new Date().toISOString(),
+        ...entry,
+      };
+      await appendFile(this.filePath, JSON.stringify(fullEntry) + "\n", "utf-8");
+    } catch (err) {
+      console.error(
+        "forge: failed to write audit entry (continuing):",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  /** Get the audit file path (null if not initialized or no projectPath). */
+  getFilePath(): string | null {
+    return this.filePath;
+  }
+}

--- a/server/lib/cost.test.ts
+++ b/server/lib/cost.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CostTracker, PRICING_LAST_UPDATED } from "./cost.js";
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CostTracker", () => {
+  it("reports tokens and estimated USD for known models", () => {
+    const tracker = new CostTracker();
+    tracker.recordUsage("planner", 1_000_000, 500_000, "claude-sonnet-4-6");
+
+    expect(tracker.totalInputTokens).toBe(1_000_000);
+    expect(tracker.totalOutputTokens).toBe(500_000);
+    // sonnet: 1M * 3.0/M + 0.5M * 15.0/M = 3.0 + 7.5 = 10.5
+    expect(tracker.totalCostUsd).toBeCloseTo(10.5);
+  });
+
+  it("accumulates across multiple stages", () => {
+    const tracker = new CostTracker();
+    tracker.recordUsage("planner", 100, 50, "claude-sonnet-4-6");
+    tracker.recordUsage("critic", 200, 100, "claude-sonnet-4-6");
+
+    expect(tracker.totalInputTokens).toBe(300);
+    expect(tracker.totalOutputTokens).toBe(150);
+  });
+
+  it("returns null cost for unknown models", () => {
+    const tracker = new CostTracker();
+    tracker.recordUsage("planner", 100, 50, "unknown-model-xyz");
+
+    expect(tracker.totalInputTokens).toBe(100);
+    expect(tracker.totalCostUsd).toBeNull();
+  });
+
+  it("warns on missing token data and records null cost", () => {
+    const tracker = new CostTracker();
+    tracker.recordUsage("planner", null, null);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Missing token data"),
+    );
+    expect(tracker.totalCostUsd).toBeNull();
+  });
+
+  it("warns on undefined token data", () => {
+    const tracker = new CostTracker();
+    tracker.recordUsage("planner", undefined, 50);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Missing token data"),
+    );
+  });
+
+  it("reports isOverBudget when total exceeds budget", () => {
+    const tracker = new CostTracker({ budgetUsd: 0.001 });
+    tracker.recordUsage("planner", 1_000_000, 500_000, "claude-sonnet-4-6");
+
+    expect(tracker.isOverBudget()).toBe(true);
+  });
+
+  it("reports not over budget when under limit", () => {
+    const tracker = new CostTracker({ budgetUsd: 100 });
+    tracker.recordUsage("planner", 100, 50, "claude-sonnet-4-6");
+
+    expect(tracker.isOverBudget()).toBe(false);
+  });
+
+  it("returns false for isOverBudget when no budget set", () => {
+    const tracker = new CostTracker();
+    tracker.recordUsage("planner", 100, 50, "claude-sonnet-4-6");
+
+    expect(tracker.isOverBudget()).toBe(false);
+  });
+
+  it("reports remaining budget in USD", () => {
+    const tracker = new CostTracker({ budgetUsd: 100 });
+    tracker.recordUsage("planner", 1_000_000, 0, "claude-sonnet-4-6");
+
+    // Used $3.0, remaining = $97.0
+    expect(tracker.remainingBudgetUsd()).toBeCloseTo(97.0);
+  });
+
+  it("returns null for remainingBudgetUsd when no budget set", () => {
+    const tracker = new CostTracker();
+    expect(tracker.remainingBudgetUsd()).toBeNull();
+  });
+
+  it("includes OAuth label in summary", () => {
+    const tracker = new CostTracker({ isOAuth: true });
+    const summary = tracker.summarize();
+
+    expect(summary.isOAuthAuth).toBe(true);
+  });
+
+  it("provides stage breakdown in summary", () => {
+    const tracker = new CostTracker();
+    tracker.recordUsage("planner", 100, 50, "claude-sonnet-4-6");
+    tracker.recordUsage("critic", 200, 100, "claude-sonnet-4-6");
+
+    const summary = tracker.summarize();
+    expect(summary.breakdown).toHaveLength(2);
+    expect(summary.breakdown[0].stage).toBe("planner");
+    expect(summary.breakdown[1].stage).toBe("critic");
+  });
+
+  it("defaults to sonnet pricing when no model specified", () => {
+    const tracker = new CostTracker();
+    tracker.recordUsage("planner", 1_000_000, 0);
+
+    // sonnet input: 1M * 3.0/M = 3.0
+    expect(tracker.totalCostUsd).toBeCloseTo(3.0);
+  });
+
+  it("has a valid PRICING_LAST_UPDATED date", () => {
+    const date = new Date(PRICING_LAST_UPDATED);
+    expect(date.toString()).not.toBe("Invalid Date");
+  });
+});

--- a/server/lib/cost.ts
+++ b/server/lib/cost.ts
@@ -1,0 +1,144 @@
+/**
+ * CostTracker — accumulates token usage per stage and estimates USD cost.
+ *
+ * Advisory only: isOverBudget() and remainingBudgetUsd() inform the caller
+ * but never force-stop. Force-stopping mid-generation produces corrupt partial
+ * output that wastes all tokens spent so far.
+ */
+
+/** Hardcoded pricing per million tokens (USD). */
+const PRICING = {
+  "claude-sonnet-4-6": { inputPerMillion: 3.0, outputPerMillion: 15.0 },
+  "claude-opus-4-6": { inputPerMillion: 15.0, outputPerMillion: 75.0 },
+  "claude-haiku-4-5": { inputPerMillion: 0.8, outputPerMillion: 4.0 },
+} as const;
+
+/** When this date is more than 90 days old, emit a staleness warning. */
+export const PRICING_LAST_UPDATED = "2025-05-01";
+
+type PricingModel = keyof typeof PRICING;
+
+function isPricingModel(model: string): model is PricingModel {
+  return model in PRICING;
+}
+
+export interface StageUsage {
+  stage: string;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number | null;
+}
+
+export interface CostSummary {
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number | null;
+  breakdown: StageUsage[];
+  isOAuthAuth: boolean;
+}
+
+export class CostTracker {
+  private stages: StageUsage[] = [];
+  private budgetUsd: number | null;
+  private isOAuth: boolean;
+  private stalePricingWarned = false;
+
+  constructor(options: { budgetUsd?: number; isOAuth?: boolean } = {}) {
+    this.budgetUsd = options.budgetUsd ?? null;
+    this.isOAuth = options.isOAuth ?? false;
+    this.checkPricingStaleness();
+  }
+
+  private checkPricingStaleness(): void {
+    const updatedDate = new Date(PRICING_LAST_UPDATED);
+    const daysSinceUpdate = Math.floor(
+      (Date.now() - updatedDate.getTime()) / (1000 * 60 * 60 * 24),
+    );
+    if (daysSinceUpdate > 90 && !this.stalePricingWarned) {
+      console.error(
+        `forge: Pricing data is ${daysSinceUpdate} days old; estimates may be inaccurate.`,
+      );
+      this.stalePricingWarned = true;
+    }
+  }
+
+  /**
+   * Record token usage for a stage.
+   * If usage fields are missing (null/undefined), logs a warning per P45
+   * and records estimatedCostUsd as null.
+   */
+  recordUsage(
+    stage: string,
+    inputTokens: number | undefined | null,
+    outputTokens: number | undefined | null,
+    model?: string,
+  ): void {
+    if (inputTokens == null || outputTokens == null) {
+      console.error(
+        `forge: Missing token data for stage "${stage}"; cost estimate unavailable.`,
+      );
+      this.stages.push({
+        stage,
+        inputTokens: inputTokens ?? 0,
+        outputTokens: outputTokens ?? 0,
+        estimatedCostUsd: null,
+      });
+      return;
+    }
+
+    let costUsd: number | null = null;
+    const effectiveModel = model ?? "claude-sonnet-4-6";
+    if (isPricingModel(effectiveModel)) {
+      const pricing = PRICING[effectiveModel];
+      costUsd =
+        (inputTokens / 1_000_000) * pricing.inputPerMillion +
+        (outputTokens / 1_000_000) * pricing.outputPerMillion;
+    }
+
+    this.stages.push({
+      stage,
+      inputTokens,
+      outputTokens,
+      estimatedCostUsd: costUsd,
+    });
+  }
+
+  /** Total input tokens across all stages. */
+  get totalInputTokens(): number {
+    return this.stages.reduce((sum, s) => sum + s.inputTokens, 0);
+  }
+
+  /** Total output tokens across all stages. */
+  get totalOutputTokens(): number {
+    return this.stages.reduce((sum, s) => sum + s.outputTokens, 0);
+  }
+
+  /** Total estimated cost, or null if any stage had missing data. */
+  get totalCostUsd(): number | null {
+    if (this.stages.some((s) => s.estimatedCostUsd === null)) return null;
+    return this.stages.reduce((sum, s) => sum + (s.estimatedCostUsd ?? 0), 0);
+  }
+
+  /** Advisory: is the total cost over the configured budget? */
+  isOverBudget(): boolean {
+    if (this.budgetUsd === null || this.totalCostUsd === null) return false;
+    return this.totalCostUsd > this.budgetUsd;
+  }
+
+  /** Advisory: remaining budget in USD (null if no budget set or cost unknown). */
+  remainingBudgetUsd(): number | null {
+    if (this.budgetUsd === null || this.totalCostUsd === null) return null;
+    return this.budgetUsd - this.totalCostUsd;
+  }
+
+  /** Get a full cost summary. */
+  summarize(): CostSummary {
+    return {
+      inputTokens: this.totalInputTokens,
+      outputTokens: this.totalOutputTokens,
+      estimatedCostUsd: this.totalCostUsd,
+      breakdown: [...this.stages],
+      isOAuthAuth: this.isOAuth,
+    };
+  }
+}

--- a/server/lib/progress.test.ts
+++ b/server/lib/progress.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ProgressReporter } from "./progress.js";
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ProgressReporter", () => {
+  it("logs stage progress to stderr with correct count", () => {
+    const reporter = new ProgressReporter("forge_plan", [
+      "Scanning codebase",
+      "Running planner",
+      "Running critic",
+    ]);
+
+    reporter.begin("Running planner");
+    expect(console.error).toHaveBeenCalledWith(
+      "forge_plan: [2/3] Running planner...",
+    );
+  });
+
+  it("logs first stage as [1/N]", () => {
+    const reporter = new ProgressReporter("forge_plan", [
+      "Scanning codebase",
+      "Running planner",
+    ]);
+
+    reporter.begin("Scanning codebase");
+    expect(console.error).toHaveBeenCalledWith(
+      "forge_plan: [1/2] Scanning codebase...",
+    );
+  });
+
+  it("tracks completed stages with duration", () => {
+    const reporter = new ProgressReporter("forge_plan", ["Stage A"]);
+    reporter.begin("Stage A");
+    reporter.complete("Stage A");
+
+    const results = reporter.getResults();
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe("Stage A");
+    expect(results[0].status).toBe("completed");
+    expect(results[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("tracks failed stages", () => {
+    const reporter = new ProgressReporter("forge_plan", ["Stage A"]);
+    reporter.begin("Stage A");
+    reporter.fail("Stage A");
+
+    const results = reporter.getResults();
+    expect(results[0].status).toBe("failed");
+  });
+
+  it("tracks skipped stages with 0 duration", () => {
+    const reporter = new ProgressReporter("forge_plan", ["Stage A"]);
+    reporter.skip("Stage A");
+
+    const results = reporter.getResults();
+    expect(results[0].status).toBe("skipped");
+    expect(results[0].durationMs).toBe(0);
+  });
+
+  it("handles unknown stages by appending dynamically", () => {
+    const reporter = new ProgressReporter("forge_plan", ["Stage A"]);
+    reporter.begin("Unexpected Stage");
+
+    expect(console.error).toHaveBeenCalledWith(
+      "forge_plan: [2/2] Unexpected Stage...",
+    );
+    expect(reporter.totalStages).toBe(2);
+  });
+
+  it("reports correct total stages", () => {
+    const reporter = new ProgressReporter("forge_plan", [
+      "A", "B", "C", "D",
+    ]);
+    expect(reporter.totalStages).toBe(4);
+  });
+});

--- a/server/lib/progress.ts
+++ b/server/lib/progress.ts
@@ -1,0 +1,68 @@
+/**
+ * ProgressReporter — dynamic stage-based progress logging to stderr.
+ *
+ * Emits lines like: `forge_plan: [2/4] Running critic round 1...`
+ * Stage list is built at runtime based on tier/config.
+ */
+
+export interface StageResult {
+  name: string;
+  durationMs: number;
+  status: "completed" | "failed" | "skipped";
+}
+
+export class ProgressReporter {
+  private toolName: string;
+  private stages: string[];
+  private currentIndex = 0;
+  private results: StageResult[] = [];
+  private stageStartTime: number | null = null;
+
+  constructor(toolName: string, stages: string[]) {
+    this.toolName = toolName;
+    this.stages = stages;
+  }
+
+  /** Begin a stage, logging progress to stderr. */
+  begin(stageName: string): void {
+    this.currentIndex = this.stages.indexOf(stageName);
+    if (this.currentIndex === -1) {
+      // Unknown stage — append dynamically
+      this.stages.push(stageName);
+      this.currentIndex = this.stages.length - 1;
+    }
+    this.stageStartTime = Date.now();
+    const stageNum = this.currentIndex + 1;
+    const total = this.stages.length;
+    console.error(`${this.toolName}: [${stageNum}/${total}] ${stageName}...`);
+  }
+
+  /** Mark the current stage as completed. */
+  complete(stageName: string): void {
+    const durationMs = this.stageStartTime ? Date.now() - this.stageStartTime : 0;
+    this.results.push({ name: stageName, durationMs, status: "completed" });
+    this.stageStartTime = null;
+  }
+
+  /** Mark a stage as failed (partial progress on error). */
+  fail(stageName: string): void {
+    const durationMs = this.stageStartTime ? Date.now() - this.stageStartTime : 0;
+    this.results.push({ name: stageName, durationMs, status: "failed" });
+    this.stageStartTime = null;
+  }
+
+  /** Mark a stage as skipped (e.g., critique skipped in quick tier). */
+  skip(stageName: string): void {
+    this.results.push({ name: stageName, durationMs: 0, status: "skipped" });
+  }
+
+  /** Get all stage results. */
+  getResults(): StageResult[] {
+    return [...this.results];
+  }
+
+  /** Get the total number of expected stages. */
+  get totalStages(): number {
+    return this.stages.length;
+  }
+}

--- a/server/lib/run-context.test.ts
+++ b/server/lib/run-context.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { CallClaudeResult } from "./anthropic.js";
+
+// Mock the anthropic module
+vi.mock("./anthropic.js", () => ({
+  callClaude: vi.fn(),
+}));
+
+// Mock audit to avoid file I/O
+vi.mock("./audit.js", () => {
+  return {
+    AuditLog: class MockAuditLog {
+      log = vi.fn(async () => {});
+      getFilePath = vi.fn(() => null);
+    },
+  };
+});
+
+const { callClaude } = await import("./anthropic.js");
+const { RunContext, trackedCallClaude } = await import("./run-context.js");
+
+const mockedCallClaude = vi.mocked(callClaude);
+
+function makeResult(inputTokens: number, outputTokens: number): CallClaudeResult {
+  return {
+    text: '{"result": "ok"}',
+    usage: { inputTokens, outputTokens },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("RunContext", () => {
+  it("bundles cost, progress, and audit", () => {
+    const ctx = new RunContext({
+      toolName: "forge_plan",
+      stages: ["planner", "critic"],
+    });
+
+    expect(ctx.cost).toBeDefined();
+    expect(ctx.progress).toBeDefined();
+    expect(ctx.audit).toBeDefined();
+    expect(ctx.toolName).toBe("forge_plan");
+  });
+});
+
+describe("trackedCallClaude", () => {
+  it("calls callClaude and records token usage", async () => {
+    const ctx = new RunContext({
+      toolName: "forge_plan",
+      stages: ["planner"],
+    });
+
+    mockedCallClaude.mockResolvedValueOnce(makeResult(500, 200));
+
+    const result = await trackedCallClaude(ctx, "planner", "planner", {
+      system: "test",
+      messages: [{ role: "user", content: "test" }],
+    });
+
+    expect(result.usage.inputTokens).toBe(500);
+    expect(ctx.cost.totalInputTokens).toBe(500);
+    expect(ctx.cost.totalOutputTokens).toBe(200);
+  });
+
+  it("reports progress (begin + complete)", async () => {
+    const ctx = new RunContext({
+      toolName: "forge_plan",
+      stages: ["planner", "critic"],
+    });
+
+    mockedCallClaude.mockResolvedValueOnce(makeResult(100, 50));
+
+    await trackedCallClaude(ctx, "planner", "planner", {
+      system: "test",
+      messages: [{ role: "user", content: "test" }],
+    });
+
+    const results = ctx.progress.getResults();
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe("planner");
+    expect(results[0].status).toBe("completed");
+    expect(console.error).toHaveBeenCalledWith(
+      "forge_plan: [1/2] planner...",
+    );
+  });
+
+  it("marks progress as failed and re-throws on error", async () => {
+    const ctx = new RunContext({
+      toolName: "forge_plan",
+      stages: ["planner"],
+    });
+
+    mockedCallClaude.mockRejectedValueOnce(new Error("API error"));
+
+    await expect(
+      trackedCallClaude(ctx, "planner", "planner", {
+        system: "test",
+        messages: [{ role: "user", content: "test" }],
+      }),
+    ).rejects.toThrow("API error");
+
+    const results = ctx.progress.getResults();
+    expect(results[0].status).toBe("failed");
+  });
+
+  it("logs audit entry on success", async () => {
+    const ctx = new RunContext({
+      toolName: "forge_plan",
+      stages: ["planner"],
+    });
+
+    mockedCallClaude.mockResolvedValueOnce(makeResult(100, 50));
+
+    await trackedCallClaude(ctx, "planner", "planner", {
+      system: "test",
+      messages: [{ role: "user", content: "test" }],
+    });
+
+    expect(ctx.audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: "planner",
+        agentRole: "planner",
+        decision: "call_complete",
+      }),
+    );
+  });
+
+  it("logs audit entry on failure", async () => {
+    const ctx = new RunContext({
+      toolName: "forge_plan",
+      stages: ["planner"],
+    });
+
+    mockedCallClaude.mockRejectedValueOnce(new Error("timeout"));
+
+    try {
+      await trackedCallClaude(ctx, "planner", "planner", {
+        system: "test",
+        messages: [{ role: "user", content: "test" }],
+      });
+    } catch {
+      // expected
+    }
+
+    expect(ctx.audit.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: "planner",
+        decision: "call_failed",
+        reasoning: "timeout",
+      }),
+    );
+  });
+
+  it("accumulates cost across multiple tracked calls", async () => {
+    const ctx = new RunContext({
+      toolName: "forge_plan",
+      stages: ["planner", "critic", "corrector"],
+    });
+
+    mockedCallClaude
+      .mockResolvedValueOnce(makeResult(100, 50))
+      .mockResolvedValueOnce(makeResult(200, 100))
+      .mockResolvedValueOnce(makeResult(150, 75));
+
+    await trackedCallClaude(ctx, "planner", "planner", {
+      system: "s",
+      messages: [{ role: "user", content: "u" }],
+    });
+    await trackedCallClaude(ctx, "critic", "critic", {
+      system: "s",
+      messages: [{ role: "user", content: "u" }],
+    });
+    await trackedCallClaude(ctx, "corrector", "corrector", {
+      system: "s",
+      messages: [{ role: "user", content: "u" }],
+    });
+
+    expect(ctx.cost.totalInputTokens).toBe(450);
+    expect(ctx.cost.totalOutputTokens).toBe(225);
+    expect(ctx.progress.getResults()).toHaveLength(3);
+  });
+});

--- a/server/lib/run-context.ts
+++ b/server/lib/run-context.ts
@@ -1,0 +1,82 @@
+/**
+ * RunContext — bundles CostTracker + ProgressReporter + AuditLog.
+ *
+ * `trackedCallClaude` wraps `callClaude` to auto-track token usage,
+ * report progress, and audit decisions. callClaude stays pure —
+ * observability is layered on top.
+ */
+
+import { callClaude, type CallClaudeOptions, type CallClaudeResult } from "./anthropic.js";
+import { CostTracker } from "./cost.js";
+import { ProgressReporter } from "./progress.js";
+import { AuditLog } from "./audit.js";
+
+export interface RunContextOptions {
+  toolName: string;
+  projectPath?: string;
+  stages: string[];
+  budgetUsd?: number;
+  isOAuth?: boolean;
+}
+
+export class RunContext {
+  readonly cost: CostTracker;
+  readonly progress: ProgressReporter;
+  readonly audit: AuditLog;
+  readonly toolName: string;
+
+  constructor(options: RunContextOptions) {
+    this.toolName = options.toolName;
+    this.cost = new CostTracker({
+      budgetUsd: options.budgetUsd,
+      isOAuth: options.isOAuth,
+    });
+    this.progress = new ProgressReporter(options.toolName, options.stages);
+    this.audit = new AuditLog(options.toolName, options.projectPath);
+  }
+}
+
+/**
+ * Wrapper around callClaude that auto-tracks token usage and logs audit entries.
+ * callClaude itself remains pure — this function adds observability on top.
+ */
+export async function trackedCallClaude(
+  ctx: RunContext,
+  stageName: string,
+  agentRole: string,
+  options: CallClaudeOptions,
+): Promise<CallClaudeResult> {
+  ctx.progress.begin(stageName);
+
+  try {
+    const result = await callClaude(options);
+
+    ctx.cost.recordUsage(
+      stageName,
+      result.usage.inputTokens,
+      result.usage.outputTokens,
+      options.model,
+    );
+
+    await ctx.audit.log({
+      stage: stageName,
+      agentRole,
+      decision: "call_complete",
+      reasoning: `${result.usage.inputTokens} input / ${result.usage.outputTokens} output tokens`,
+    });
+
+    ctx.progress.complete(stageName);
+    return result;
+  } catch (err) {
+    ctx.progress.fail(stageName);
+
+    await ctx.audit.log({
+      stage: stageName,
+      agentRole,
+      decision: "call_failed",
+      reasoning: err instanceof Error ? err.message : String(err),
+    });
+
+    throw err;
+  }
+}

--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { CallClaudeResult } from "../lib/anthropic.js";
 
-// Mock the anthropic module before importing plan
+// Mock the anthropic module
 vi.mock("../lib/anthropic.js", () => ({
   callClaude: vi.fn(),
   extractJson: vi.fn((text: string) => JSON.parse(text)),
@@ -17,10 +17,59 @@ vi.mock("../lib/run-record.js", () => ({
   writeRunRecord: vi.fn(async () => {}),
 }));
 
+// Mock run-context — trackedCallClaude delegates to the mocked callClaude
+// and accumulates tokens for cost.summarize()
+vi.mock("../lib/run-context.js", async () => {
+  const { callClaude: mockedClaude } = await import("../lib/anthropic.js");
+
+  class MockRunContext {
+    _inputTokens = 0;
+    _outputTokens = 0;
+    cost = {
+      summarize: () => ({
+        inputTokens: (this as any)._inputTokens ?? 0,
+        outputTokens: (this as any)._outputTokens ?? 0,
+        estimatedCostUsd: 0.001,
+        breakdown: [],
+        isOAuthAuth: false,
+      }),
+      recordUsage: vi.fn(),
+    };
+    progress = { begin: vi.fn(), complete: vi.fn(), skip: vi.fn(), fail: vi.fn(), getResults: () => [] };
+    audit = { log: vi.fn(async () => {}) };
+    toolName = "forge_plan";
+
+    constructor() {
+      // Bind summarize to the instance
+      const self = this;
+      this.cost.summarize = () => ({
+        inputTokens: self._inputTokens,
+        outputTokens: self._outputTokens,
+        estimatedCostUsd: 0.001,
+        breakdown: [],
+        isOAuthAuth: false,
+      });
+    }
+  }
+
+  return {
+    RunContext: MockRunContext,
+    trackedCallClaude: vi.fn(async (ctx: any, _stage: string, _role: string, options: any) => {
+      const result = await mockedClaude(options);
+      if (ctx && result.usage) {
+        ctx._inputTokens = (ctx._inputTokens ?? 0) + result.usage.inputTokens;
+        ctx._outputTokens = (ctx._outputTokens ?? 0) + result.usage.outputTokens;
+      }
+      return result;
+    }),
+  };
+});
+
 // Import after mocks
 const { callClaude, extractJson } = await import("../lib/anthropic.js");
 const { scanCodebase } = await import("../lib/codebase-scan.js");
 const { writeRunRecord } = await import("../lib/run-record.js");
+// trackedCallClaude is mocked — import not needed for direct use
 const { handlePlan, detectCoupledACs } = await import("./plan.js");
 const { buildPlannerPrompt } = await import("../lib/prompts/planner.js");
 const { buildCriticPrompt } = await import("../lib/prompts/critic.js");

--- a/server/tools/plan.ts
+++ b/server/tools/plan.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { callClaude, extractJson } from "../lib/anthropic.js";
+import { extractJson } from "../lib/anthropic.js";
 import { scanCodebase } from "../lib/codebase-scan.js";
 import {
   buildPlannerPrompt,
@@ -10,6 +10,7 @@ import { buildCriticPrompt, buildCriticUserMessage } from "../lib/prompts/critic
 import { buildCorrectorPrompt, buildCorrectorUserMessage } from "../lib/prompts/corrector.js";
 import { validateExecutionPlan } from "../validation/execution-plan.js";
 import { writeRunRecord, type RunRecord } from "../lib/run-record.js";
+import { RunContext, trackedCallClaude } from "../lib/run-context.js";
 import type { ExecutionPlan } from "../types/execution-plan.js";
 
 /**
@@ -139,11 +140,6 @@ interface CorrectorOutput {
   }>;
 }
 
-interface UsageAccumulator {
-  inputTokens: number;
-  outputTokens: number;
-}
-
 /**
  * Run the planner agent to produce a draft execution plan.
  */
@@ -152,21 +148,19 @@ async function runPlanner(
   mode: "feature" | "full-project" | "bugfix",
   codebaseSummary: string | undefined,
   model: string | undefined,
-  usage: UsageAccumulator,
+  ctx: RunContext,
   context?: ContextEntry[],
   maxContextChars?: number,
 ): Promise<{ plan: ExecutionPlan; validationRetries: number }> {
   const system = buildPlannerPrompt(mode);
   const userMessage = buildPlannerUserMessage(intent, codebaseSummary, context, maxContextChars);
 
-  const result = await callClaude({
+  const result = await trackedCallClaude(ctx, "Running planner", "planner", {
     system,
     messages: [{ role: "user", content: userMessage }],
     model,
     jsonMode: true,
   });
-  usage.inputTokens += result.usage.inputTokens;
-  usage.outputTokens += result.usage.outputTokens;
 
   const parsed = extractJson(result.text);
   const validation = validateExecutionPlan(parsed);
@@ -177,7 +171,7 @@ async function runPlanner(
       "forge_plan: planner output failed validation, retrying with feedback:",
       validation.errors,
     );
-    const retryResult = await callClaude({
+    const retryResult = await trackedCallClaude(ctx, "Retrying planner (validation)", "planner", {
       system,
       messages: [
         { role: "user", content: userMessage },
@@ -190,8 +184,6 @@ async function runPlanner(
       model,
       jsonMode: true,
     });
-    usage.inputTokens += retryResult.usage.inputTokens;
-    usage.outputTokens += retryResult.usage.outputTokens;
 
     const retryParsed = extractJson(retryResult.text);
     const retryValidation = validateExecutionPlan(retryParsed);
@@ -213,20 +205,18 @@ async function runCritic(
   plan: ExecutionPlan,
   round: 1 | 2,
   model: string | undefined,
-  usage: UsageAccumulator,
+  ctx: RunContext,
 ): Promise<CritiqueFindings> {
   const system = buildCriticPrompt(round);
   const planJson = JSON.stringify(plan, null, 2);
 
   try {
-    const result = await callClaude({
+    const result = await trackedCallClaude(ctx, `Running critic round ${round}`, "critic", {
       system,
       messages: [{ role: "user", content: buildCriticUserMessage(planJson) }],
       model,
       jsonMode: true,
     });
-    usage.inputTokens += result.usage.inputTokens;
-    usage.outputTokens += result.usage.outputTokens;
 
     const parsed = extractJson(result.text) as CritiqueFindings;
     if (!parsed.findings || !Array.isArray(parsed.findings)) {
@@ -250,14 +240,14 @@ async function runCorrector(
   plan: ExecutionPlan,
   findings: CritiqueFindings,
   model: string | undefined,
-  usage: UsageAccumulator,
+  ctx: RunContext,
 ): Promise<{ plan: ExecutionPlan; dispositions: CorrectorOutput["dispositions"] }> {
   const system = buildCorrectorPrompt();
   const planJson = JSON.stringify(plan, null, 2);
   const findingsJson = JSON.stringify(findings, null, 2);
 
   try {
-    const result = await callClaude({
+    const result = await trackedCallClaude(ctx, "Running corrector", "corrector", {
       system,
       messages: [
         { role: "user", content: buildCorrectorUserMessage(planJson, findingsJson) },
@@ -265,8 +255,6 @@ async function runCorrector(
       model,
       jsonMode: true,
     });
-    usage.inputTokens += result.usage.inputTokens;
-    usage.outputTokens += result.usage.outputTokens;
 
     const parsed = extractJson(result.text) as CorrectorOutput;
 
@@ -338,17 +326,35 @@ export async function handlePlan({
   const effectiveMode = mode ?? detectMode(intent);
   const effectiveTier = tier ?? "thorough";
 
-  const usage: UsageAccumulator = { inputTokens: 0, outputTokens: 0 };
+  // Build dynamic stage list based on tier
+  const stages = ["Scanning codebase", "Running planner"];
+  if (effectiveTier !== "quick") {
+    const maxRounds = effectiveTier === "thorough" ? 2 : 1;
+    for (let r = 1; r <= maxRounds; r++) {
+      stages.push(`Running critic round ${r}`);
+      stages.push("Running corrector");
+    }
+  }
+
+  const ctx = new RunContext({
+    toolName: "forge_plan",
+    projectPath,
+    stages,
+  });
 
   // Step 1: Optional codebase scan
   let codebaseSummary: string | undefined;
   if (projectPath) {
+    ctx.progress.begin("Scanning codebase");
     codebaseSummary = await scanCodebase(projectPath);
+    ctx.progress.complete("Scanning codebase");
+  } else {
+    ctx.progress.skip("Scanning codebase");
   }
 
   // Step 2: Run planner (with context injection)
   const plannerResult = await runPlanner(
-    intent, effectiveMode, codebaseSummary, undefined, usage, context, maxContextChars,
+    intent, effectiveMode, codebaseSummary, undefined, ctx, context, maxContextChars,
   );
   let plan = plannerResult.plan;
   const validationRetries = plannerResult.validationRetries;
@@ -363,7 +369,7 @@ export async function handlePlan({
     const maxRounds = effectiveTier === "thorough" ? 2 : 1;
 
     for (let round = 1; round <= maxRounds; round++) {
-      const findings = await runCritic(plan, round as 1 | 2, undefined, usage);
+      const findings = await runCritic(plan, round as 1 | 2, undefined, ctx);
 
       if (findings.findings.length === 0) {
         critiqueRounds.push({ findings, dispositions: [] });
@@ -374,7 +380,7 @@ export async function handlePlan({
         plan,
         findings,
         undefined,
-        usage,
+        ctx,
       );
       plan = correctedPlan;
       critiqueRounds.push({ findings, dispositions });
@@ -412,8 +418,14 @@ export async function handlePlan({
     sections.push(critiqueSummary);
   }
 
+  const costSummary = ctx.cost.summarize();
+  const costLabel = costSummary.isOAuthAuth ? "equivalent API cost" : "estimated cost";
+  const costStr = costSummary.estimatedCostUsd !== null
+    ? `$${costSummary.estimatedCostUsd.toFixed(4)} ${costLabel}`
+    : "cost unknown (missing token data)";
+
   sections.push(
-    `=== USAGE ===\nTotal tokens: ${usage.inputTokens} input / ${usage.outputTokens} output`,
+    `=== USAGE ===\nTotal tokens: ${costSummary.inputTokens} input / ${costSummary.outputTokens} output\n${costStr}`,
   );
 
   // Step 6: Write run record
@@ -430,8 +442,8 @@ export async function handlePlan({
       mode: effectiveMode,
       tier: effectiveTier,
       metrics: {
-        inputTokens: usage.inputTokens,
-        outputTokens: usage.outputTokens,
+        inputTokens: costSummary.inputTokens,
+        outputTokens: costSummary.outputTokens,
         critiqueRounds: critiqueRounds.length,
         findingsTotal,
         findingsApplied,


### PR DESCRIPTION
## Summary

- **CostTracker** (`server/lib/cost.ts`): Token accounting with hardcoded pricing for Claude models, advisory budget (never force-stops), warns on missing token data (P45), and stale pricing (>90 days).
- **ProgressReporter** (`server/lib/progress.ts`): Dynamic stage list, emits `forge_plan: [2/4] Running critic round 1...` to stderr. Tracks completed/failed/skipped stages with duration.
- **AuditLog** (`server/lib/audit.ts`): Append-only JSONL decision trail in `.forge/audit/`. Failure-tolerant (warn + continue). Windows-safe filenames. 1000-file warning threshold.
- **RunContext** (`server/lib/run-context.ts`): Bundles CostTracker + ProgressReporter + AuditLog. `trackedCallClaude` wraps `callClaude` for auto token tracking, progress logging, and audit entries.
- **Migration**: All 4 `callClaude` sites in `plan.ts` (planner, validation-retry, critic, corrector) migrated to `trackedCallClaude`.

## Test plan

- [ ] CostTracker reports tokens + estimated USD (or "equivalent API cost" for OAuth)
- [ ] CostTracker warns on missing token data (does not silently default to 0)
- [ ] ProgressReporter logs to stderr with correct stage count for active tier
- [ ] AuditLog writes to .forge/audit/ with Windows-safe filename; write failure doesn't crash
- [ ] trackedCallClaude accumulates cost, reports progress, logs audit entries
- [ ] All 4 callClaude sites in plan.ts migrated to trackedCallClaude
- [ ] All existing plan.test.ts and evaluate.test.ts tests pass (regression)