### PR TITLE
fix: Windows compat & test resilience (#60, #61, #62)

### DIFF
--- a/server/lib/codebase-scan.test.ts
+++ b/server/lib/codebase-scan.test.ts
@@ -104,7 +104,9 @@ describe("scanCodebase", () => {
   });
 
   it("throws for non-existent path", async () => {
-    await expect(scanCodebase("/nonexistent/path/xyz")).rejects.toThrow(
+    // Use an absolute path that doesn't exist on any platform
+    const fakePath = join(tmpdir(), "nonexistent-forge-test-" + Date.now());
+    await expect(scanCodebase(fakePath)).rejects.toThrow(
       "does not exist",
     );
   });

--- a/server/lib/test-utils.ts
+++ b/server/lib/test-utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared test utilities for forge-harness integration tests.
+ */
+
+/**
+ * Extract JSON from forge_plan output text.
+ * Output format: "=== HEADER ===\n\n{json}\n\n=== NEXT SECTION ==="
+ * The JSON is the first valid JSON object/array after the header.
+ */
+export function extractPlanJson(text: string): string {
+  const jsonStart = text.indexOf("{");
+  if (jsonStart === -1) throw new Error("No JSON found in output");
+
+  let depth = 0;
+  for (let i = jsonStart; i < text.length; i++) {
+    if (text[i] === "{") depth++;
+    else if (text[i] === "}") depth--;
+    if (depth === 0) return text.slice(jsonStart, i + 1);
+  }
+  throw new Error("Unbalanced JSON in output");
+}
+
+/**
+ * Find a mock call whose first argument's messages contain ALL of the
+ * specified content strings. Useful for identifying specific LLM calls
+ * without relying on fragile index positions.
+ */
+export function findCallByContent(
+  mockCalls: Array<[any, ...any[]]>,
+  contentMatches: string[],
+): any {
+  const match = mockCalls.find(([arg]) => {
+    const text = arg?.messages?.[0]?.content ?? "";
+    return contentMatches.every((s) => text.includes(s));
+  });
+  if (!match) {
+    throw new Error(
+      `No mock call found containing all of: ${contentMatches.join(", ")}`,
+    );
+  }
+  return match[0];
+}

--- a/server/tools/dogfood-divergence.test.ts
+++ b/server/tools/dogfood-divergence.test.ts
@@ -169,7 +169,7 @@ const DOGFOOD_PLAN: ExecutionPlan = {
           id: "AC-02",
           description: "Integration tests pass",
           command:
-            "npx vitest run server/tools/three-tier-integration.test.ts --reporter=verbose 2>&1 | tail -5 | head -1",
+            "npx vitest run server/tools/three-tier-integration.test.ts --reporter=verbose",
         },
       ],
       affectedPaths: ["server/tools/three-tier-integration.test.ts"],
@@ -182,12 +182,12 @@ const DOGFOOD_PLAN: ExecutionPlan = {
         {
           id: "AC-01",
           description: "plan.test.ts passes (core regression gate)",
-          command: "npx vitest run server/tools/plan.test.ts 2>&1 | tail -3 | head -1",
+          command: "npx vitest run server/tools/plan.test.ts --reporter=verbose",
         },
         {
           id: "AC-02",
           description: "evaluate.test.ts passes (eval regression gate)",
-          command: "npx vitest run server/tools/evaluate.test.ts 2>&1 | tail -3 | head -1",
+          command: "npx vitest run server/tools/evaluate.test.ts --reporter=verbose",
         },
       ],
       affectedPaths: [],

--- a/server/tools/three-tier-integration.test.ts
+++ b/server/tools/three-tier-integration.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { CallClaudeResult } from "../lib/anthropic.js";
+import { extractPlanJson, findCallByContent } from "../lib/test-utils.js";
 
 // ── Mocks (same pattern as plan.test.ts / evaluate.test.ts) ──
 
@@ -218,26 +219,6 @@ function makePhasePlan(phaseId: string) {
   };
 }
 
-/**
- * Extract JSON from forge_plan output text.
- * Output format: "=== HEADER ===\n\n{json}\n\n=== NEXT SECTION ==="
- * The JSON is the first valid JSON object/array after the header.
- */
-function extractPlanJson(text: string): string {
-  // Find the first { that starts a JSON object in the output
-  const jsonStart = text.indexOf("{");
-  if (jsonStart === -1) throw new Error("No JSON found in output");
-
-  // Walk forward to find the matching closing brace
-  let depth = 0;
-  for (let i = jsonStart; i < text.length; i++) {
-    if (text[i] === "{") depth++;
-    else if (text[i] === "}") depth--;
-    if (depth === 0) return text.slice(jsonStart, i + 1);
-  }
-  throw new Error("Unbalanced JSON in output");
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -319,7 +300,11 @@ describe("three-tier integration: PRD → master → phase → coherence", () =>
     expect(evalReport.gaps).toHaveLength(0);
 
     // Verify the coherence LLM call received all three tiers
-    const coherenceCall = mockedCallClaude.mock.calls[2][0]; // 3rd LLM call
+    const coherenceCall = findCallByContent(mockedCallClaude.mock.calls, [
+      "Product Requirements Document",
+      "Master Plan",
+      "Phase PH-01",
+    ]);
     expect(coherenceCall.messages[0].content).toContain("Product Requirements Document");
     expect(coherenceCall.messages[0].content).toContain("Master Plan");
     expect(coherenceCall.messages[0].content).toContain("Phase PH-01");
@@ -527,7 +512,10 @@ describe("three-tier integration: PRD → master → phase → coherence", () =>
     expect(evalReport.gaps).toHaveLength(0);
 
     // Verify both phases were included in the LLM prompt
-    const coherenceCall = mockedCallClaude.mock.calls[3][0]; // 4th call
+    const coherenceCall = findCallByContent(mockedCallClaude.mock.calls, [
+      "Phase PH-01",
+      "Phase PH-04",
+    ]);
     expect(coherenceCall.messages[0].content).toContain("Phase PH-01");
     expect(coherenceCall.messages[0].content).toContain("Phase PH-04");
   });


### PR DESCRIPTION
## Summary
- **Fix failing test**: `codebase-scan.test.ts` "throws for non-existent path" now uses a platform-safe temp path instead of Unix-only `/nonexistent/path/xyz` that resolves as drive-root-relative on Windows
- **#60**: Replace Unix-only `tail`/`head` pipes in dogfood AC commands with plain `vitest --reporter=verbose`
- **#61**: Extract shared `extractPlanJson()` and `findCallByContent()` into `server/lib/test-utils.ts`
- **#62**: Replace magic `mock.calls[N]` indices with content-based matching via `findCallByContent()`

## Test plan
- [x] All 280 tests pass locally (`npx vitest run` — 16 files, 280 tests)
- [x] No `tail` or `head` commands remain in dogfood-divergence.test.ts
- [x] No `mock.calls[2]` or `mock.calls[3]` patterns in three-tier-integration.test.ts
- [x] `extractPlanJson` importable from shared `server/lib/test-utils.ts`

Closes #60, closes #61, closes #62