### PR TITLE
fix: rebuild stale dist/ via postinstall + MCP stdio smoke test + CI drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,38 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - run: npm ci --ignore-scripts
-      - run: npm run build
-      - run: npm test
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build (tsc compiles server/ → dist/)
+        run: npm run build
+
+      - name: dist/ drift guard (no ghost stubs outside PH-01 coordinator)
+        shell: bash
+        run: |
+          if [ ! -f dist/index.js ]; then
+            echo "ERROR: dist/index.js is missing after npm run build"
+            exit 1
+          fi
+          # The forge_coordinate source is a legitimate pre-PH-01 stub, and
+          # the smoke test source itself contains the ghost-pattern regex.
+          # Everything else must be free of "not yet implemented".
+          GHOSTS=$(grep -rl "not yet implemented" dist --include="*.js" 2>/dev/null \
+            | grep -v "^dist/tools/coordinate\.js$" \
+            | grep -v "^dist/smoke/" || true)
+          if [ -n "$GHOSTS" ]; then
+            echo "ERROR: stub strings found in non-exempt dist/ files:"
+            echo "$GHOSTS"
+            echo ""
+            echo "This means dist/ was built from a stale server/tools/*.ts,"
+            echo "or a new stub handler was added without a smoke-test exemption."
+            echo "See docs/primitive-backlog.md §Build/Release Rigor."
+            exit 1
+          fi
+          echo "dist/ drift guard: PASS (no unexpected ghost strings)"
+
+      - name: Tests (unit + MCP smoke, vitest discovers server/**/*.test.ts)
+        run: npm test
 
       - name: Validate commit message
         if: github.event_name == 'push'

--- a/docs/primitive-backlog.md
+++ b/docs/primitive-backlog.md
@@ -390,3 +390,31 @@ All rejected fields are documented here with the rationale that killed them — 
 **Config fields in advisory-mode coordinate should shape output, not gate execution.** If a proposal caps a resource, defends against a failure mode, or modifies state, it doesn't belong in the config file — it belongs either in MCP input args (per-call control) or in a separate escalation primitive (autonomous mode v2). This principle held for all 5 rejected fields and can be applied to future proposals to avoid re-litigation.
 
 **Full implementation spec:** `.ai-workspace/plans/2026-04-09-forge-coordinate-implementation.md` PH-04 US-01.5 and the `Config File Schema` reference section.
+
+## Build/Release Rigor
+
+### Local-dist freshness incident + postinstall decision (2026-04-09)
+
+**Incident:** S3 dogfood halted at PH01-US-00a because a client Claude Code session calling `forge_generate` received the Phase-0 `"forge_generate for \"${storyId}\": not yet implemented. Phase 3 required."` stub string, despite `server/tools/generate.ts` being fully implemented and unit-tested for weeks. Expanding the audit to the other three tools showed `dist/tools/generate.js` was a 14-line Phase-0 stub while `server/tools/generate.ts` was a ~200-line real handler using `assembleGenerateResultWithContext`. `dist/tools/coordinate.js` also returned a ghost string, but in that case the source (`server/tools/coordinate.ts`) is still a legitimate pre-PH-01 stub — the dist was not stale, it was correctly reflecting an intentionally unimplemented handler.
+
+**Root cause:** `dist/` has been gitignored since the initial commit — it was **never** checked into git at any point. Each contributor builds dist/ locally via `npm run build`. Nothing forced that build to stay fresh when `server/tools/*.ts` was edited. Between the last local `tsc` run (~Apr 6) and the S3 kickoff (Apr 9), `server/tools/generate.ts` had been rewritten end-to-end, but no `npm run build` was run on the contributor's machine, so the MCP client session at Apr 9 still loaded the stale Phase-0 stub from disk. Critically, **none of the existing unit tests caught this** because every test in `server/**/*.test.ts` imports the TypeScript source directly via vitest's TS transformer — they never boot the compiled `dist/index.js` through the MCP stdio transport. The failure mode was structurally invisible to the test suite.
+
+**What the original "never check in build artifacts" rule would not have prevented:** this incident. That rule was already satisfied; the bug still happened. The real missing invariant was: **any artifact the MCP server loads at startup must be regenerated automatically on every `npm install`, and must be exercised through the real transport boundary at least once in CI before being trusted.**
+
+**Fix applied in PR `fix/dist-rebuild-and-postinstall`:**
+
+1. **`package.json postinstall` now chains `npm run build`** — every `npm install` rebuilds dist/ from current source. Any contributor who pulls master and runs `npm install` immediately has a fresh dist/; no separate build step to forget. The existing `scripts/install-hooks.cjs` call is preserved via `&&` chaining.
+2. **New MCP stdio smoke test at `server/smoke/mcp-surface.test.ts`** — spawns `node dist/index.js` as a subprocess, connects via `@modelcontextprotocol/sdk/client/stdio.js`, calls `listTools()` and `callTool()` on all four primitives. Asserts every response body is non-empty and does NOT match `/not yet implemented/i`, with a documented exemption for `forge_coordinate` (source is still a stub until PH-01 ships). Also asserts `forge_generate`'s listTools schema has ≥5 input properties — the stub schema had 1 (`storyId`), the real schema has 14, so schema-level drift is caught even before callTool runs. Runtime ~0.7s.
+3. **New CI step `dist/ drift guard`** — a grep-based belt-and-suspenders check that fails the build if any `dist/**/*.js` file contains `"not yet implemented"` outside the two allowed paths (`dist/tools/coordinate.js` and `dist/smoke/`). Redundant with the vitest smoke test on the happy path, but catches the failure mode where the smoke test is skipped, disabled, or broken. Runs on both `ubuntu-latest` and `windows-latest` in the existing matrix.
+
+**Design rule (ratified by this incident):** Every primitive must be exercised through its real transport boundary in CI before being considered shipped. Vitest handler tests that import `server/tools/*.ts` directly are **necessary but not sufficient** — they cannot see stdio framing bugs, JSON-RPC serialization drift, `.mcp.json` wiring mistakes, or stale compiled artifacts. When a new primitive is added (or the coordinator flips from stub to real in PH-01), its smoke-test entry must be added / updated in the same PR. The CI drift guard and the vitest smoke test together enforce this mechanically.
+
+**Verification dance after this PR merges:** The user must run `git pull && npm install` on their working copy (not just `git pull`) — the `npm install` is what triggers the new `postinstall` hook that regenerates dist/. After that, restart the Claude Code session (MCP servers load once at session start), then make a throwaway `forge_generate({storyId: "SMOKE-TEST"})` call to confirm the running MCP process is serving the rebuilt dist/. Only after that throwaway call returns a non-stub response should S3 work resume.
+
+**Lesson for future primitives:** A test suite that is 100% green while the shipped artifact is a 14-line stub is a canonical F46-class "loud data, silent dashboard" failure. The fix is not more tests inside the same layer — it's a test at the next layer out. For an MCP server, that layer is the stdio transport boundary. For a CLI, it would be the process-spawn boundary. For a library, it would be the published package. **Dogfood-from-S1 is the enforcement mechanism** — if every primitive's S1 session must make a real client call to its own MCP tool, incidents like this one surface in hours instead of days.
+
+**Related:**
+- `server/smoke/mcp-surface.test.ts` — the smoke test
+- `.github/workflows/ci.yml` — drift guard + named steps
+- `package.json` — postinstall chain
+- 2026-04-09 S3 mailbox thread (`forge-plan ↔ lucky-iris` on S3 blocker) — full incident trail

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js",
     "test": "vitest run",
     "lint": "eslint server/",
-    "postinstall": "node scripts/install-hooks.cjs"
+    "postinstall": "node scripts/install-hooks.cjs && npm run build"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",

--- a/server/smoke/mcp-surface.test.ts
+++ b/server/smoke/mcp-surface.test.ts
@@ -1,0 +1,147 @@
+/**
+ * MCP surface smoke test.
+ *
+ * Spawns `node dist/index.js` as a subprocess, connects via the MCP stdio
+ * client, and exercises the full transport stack end-to-end. Designed to
+ * catch failure modes that vitest unit tests on `server/tools/*.ts` cannot
+ * see by construction:
+ *
+ *   1. dist/ drift — dist/tools/*.js compiled from an older server/tools/*.ts
+ *      than what is currently on disk. Symptom: client calls land on stub
+ *      handlers that return "not yet implemented" strings.
+ *   2. stdio framing / JSON-RPC serialization bugs in the transport glue.
+ *   3. .mcp.json wiring mistakes (wrong command, wrong cwd, wrong entry).
+ *
+ * Incident driving this test: on 2026-04-09 a client Claude Code session
+ * received Phase-0 "not yet implemented" stubs from forge_generate and
+ * forge_plan despite server/tools/*.ts being fully implemented and unit-
+ * tested — dist/ had not been rebuilt in ~2 days and no test exercised the
+ * built artifact through the real MCP transport. See docs/primitive-backlog.md
+ * §Build/Release Rigor for the full narrative.
+ *
+ * Per-tool expectation map
+ * ────────────────────────
+ * forge_plan, forge_evaluate, forge_generate
+ *   MUST NOT return a body matching /not yet implemented/i and MUST return
+ *   a non-empty body. These three are real handlers in source — any ghost
+ *   string means dist/ is stale.
+ *
+ * forge_coordinate
+ *   Source is still a legitimate pre-PH-01 stub ("not yet implemented. Phase
+ *   4 required."). Exempt from the ghost-string assertion until PH-01 ships.
+ *   When PH-01 flips this file, delete COORDINATE_STUB_EXEMPT and the
+ *   `if (!COORDINATE_STUB_EXEMPT)` gate below — the exemption becomes a hard
+ *   failure the moment the real coordinator lands.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { resolve } from "node:path";
+
+// TODO(PH-01 ship): delete this constant and the guarded assertion below.
+const COORDINATE_STUB_EXEMPT = true;
+
+const GHOST_PATTERN = /not yet implemented/i;
+const CONNECT_TIMEOUT_MS = 10_000;
+
+function bodyFromResult(result: unknown): string {
+  const content = (result as { content?: Array<{ type: string; text?: string }> }).content;
+  return content?.map((c) => c.text ?? "").join("\n") ?? "";
+}
+
+describe("MCP surface smoke", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    const projectRoot = process.cwd();
+    const serverPath = resolve(projectRoot, "dist", "index.js");
+
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [serverPath],
+      cwd: projectRoot,
+      stderr: "pipe",
+    });
+
+    client = new Client(
+      { name: "forge-smoke", version: "0.0.0" },
+      { capabilities: {} },
+    );
+
+    await client.connect(transport);
+  }, CONNECT_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (client) {
+      await client.close();
+    }
+  });
+
+  it("lists all 4 forge tools", async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "forge_coordinate",
+      "forge_evaluate",
+      "forge_generate",
+      "forge_plan",
+    ]);
+  });
+
+  it("forge_generate schema exposes more than the stub's single field (dist drift canary)", async () => {
+    const { tools } = await client.listTools();
+    const generate = tools.find((t) => t.name === "forge_generate");
+    expect(generate).toBeDefined();
+    const schema = generate!.inputSchema as { properties?: Record<string, unknown> };
+    const propCount = Object.keys(schema.properties ?? {}).length;
+    // The Phase-0 stub schema is `{ storyId }` — exactly one property.
+    // The real schema has storyId, planJson, planPath, projectPath, evalReport,
+    // iteration, maxIterations, previousScores, fileHashes, previousFileHashes,
+    // baselineDiagnostics, prdContent, masterPlanContent, phasePlanContent
+    // (14 fields). Anything below 5 is almost certainly a stale stub.
+    expect(propCount).toBeGreaterThanOrEqual(5);
+  });
+
+  it.each([
+    { name: "forge_plan" },
+    { name: "forge_evaluate" },
+    { name: "forge_generate" },
+  ])("$name dispatches to a real (non-stub) handler", async ({ name }) => {
+    // Call with empty input. Real handlers reject at Zod validation (before
+    // any Claude API call or filesystem work) and return a validation error
+    // body — non-empty and not a ghost string. A stale stub for these three
+    // tools would either still return the ghost string or satisfy validation
+    // trivially and return the ghost string; in both cases this assertion
+    // catches it.
+    let bodyText = "";
+    try {
+      const result = await client.callTool({ name, arguments: {} });
+      bodyText = bodyFromResult(result);
+    } catch (err) {
+      // The MCP client throws on isError:true results in some SDK versions;
+      // the thrown message is the body we want to inspect.
+      bodyText = err instanceof Error ? err.message : String(err);
+    }
+    expect(bodyText.length).toBeGreaterThan(0);
+    expect(bodyText).not.toMatch(GHOST_PATTERN);
+  });
+
+  it("forge_coordinate dispatches (stub exempt until PH-01 ships)", async () => {
+    let bodyText = "";
+    try {
+      const result = await client.callTool({
+        name: "forge_coordinate",
+        arguments: { planPath: "nonexistent-smoke.json" },
+      });
+      bodyText = bodyFromResult(result);
+    } catch (err) {
+      bodyText = err instanceof Error ? err.message : String(err);
+    }
+    expect(bodyText.length).toBeGreaterThan(0);
+    if (!COORDINATE_STUB_EXEMPT) {
+      expect(bodyText).not.toMatch(GHOST_PATTERN);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the 2026-04-09 S3 dogfood blocker where a client Claude Code session received Phase-0 `forge_generate: "not yet implemented. Phase 3 required."` stub strings despite `server/tools/generate.ts` being fully implemented and unit-tested for weeks. Adds three mechanical enforcements against the failure mode, plus a durable backlog entry documenting the incident and the corrected root-cause narrative.

Coordinated with forge-plan via the mailbox thread on 2026-04-09. This PR is strictly the build-system fix; PH-01 implementation resumes on `feat/forge-coordinate-ph-01` after merge + local `npm install` + session restart.

## Root cause — corrected from the initial theory

The initial theory in the mailbox thread was "dist/ was checked into git and drifted." The audit during this PR revealed that theory is **wrong**: `dist/` has been gitignored since the initial commit `f4aecd5` and has **never** been tracked on any branch (`git ls-files dist/` returns empty; `git log --all --diff-filter=A -- 'dist/*'` returns empty). The real mechanism:

- Every contributor builds `dist/` locally via `npm run build`
- Nothing forced that build to stay fresh when `server/tools/*.ts` was edited
- Between the last local build (Apr 6) and S3 kickoff (Apr 9), `server/tools/generate.ts` was rewritten end-to-end, but no `npm run build` was run on the contributor's machine
- The MCP client session at Apr 9 loaded whatever happened to be on local disk — a stale 14-line Phase-0 stub
- **No existing unit test caught this** because every `server/**/*.test.ts` imports TypeScript source directly via vitest; none boot `dist/index.js` through the MCP stdio transport. Structurally invisible to the test suite.

The original "never check build artifacts into git" rule was already satisfied and still did not prevent the bug. The real missing invariant (ratified in `docs/primitive-backlog.md` Build/Release Rigor section in this PR) is: **any artifact the MCP server loads at startup must be regenerated automatically on every `npm install`, and must be exercised through the real transport boundary at least once in CI before being trusted.**

## dist/ audit — evidence captured before fix

Pre-fix state of `dist/tools/*.js` vs `server/tools/*.ts`:

| Tool | dist lines | source lines | Ghost in dist? | Ghost in source? | Verdict |
|---|---|---|---|---|---|
| `generate` | **14 (stub)** | ~200 (real) | **YES** | NO | **STALE — drift confirmed** |
| `plan` | 706 | 1048 | NO | NO | **Fresh** (706 to 706 unchanged after rebuild; 70% TS-to-JS compile ratio is normal) |
| `evaluate` | 359 | 414 | NO | NO | Content changed post-rebuild (359 to 310) but no ghost string was ever present; likely intermediate-state drift |
| `coordinate` | 16 (stub) | 16 (stub) | YES | **YES** | **Not stale** — source is a legitimate pre-PH-01 stub |

**The only unambiguously-drifted tool was `forge_generate`.** The initial blocker report conflated `plan` and `evaluate` into the drift set based on line-count deltas; post-rebuild inspection shows those were coincidence. The fix is correct regardless — the three enforcement layers below prevent any variant of the drift class.

## Changes (4 commits)

### `a05f45d` — `build: run tsc on postinstall to keep dist/ fresh`
`package.json` postinstall now chains `npm run build` after the existing `scripts/install-hooks.cjs` call. Every `npm install` regenerates `dist/` from current source. No other files touched.

### `efa2974` — `test: add MCP surface smoke test spawning dist/index.js over stdio`
New file `server/smoke/mcp-surface.test.ts` (+147 lines) spawns `node dist/index.js` as a subprocess via `@modelcontextprotocol/sdk/client/stdio.js` and exercises the full MCP transport stack end-to-end. Runtime ~0.7s locally; picked up by the existing vitest `server/**/*.test.ts` include pattern without config changes.

**Per-tool expectation map** (documented inline):
- `forge_plan`, `forge_evaluate`, `forge_generate`: MUST NOT return text matching the ghost-string regex, MUST return non-empty body
- `forge_coordinate`: non-empty body only, ghost-string assertion gated behind `COORDINATE_STUB_EXEMPT = true` with a `TODO(PH-01 ship)` comment. **PH-01's ship PR must flip this constant**, turning the assertion into a hard gate that coordinate cannot silently regress.
- Schema-level drift canary: `forge_generate`'s listTools schema must expose >=5 input properties (stub = 1 field; real = 14 fields)

### `ecc419a` — `ci: add dist/ drift guard + name existing steps`
`.github/workflows/ci.yml` gets a new step between build and test: a grep-based belt-and-suspenders check that fails CI if any `dist/**/*.js` file contains the ghost string outside the two allowed paths (`dist/tools/coordinate.js` and `dist/smoke/`). Also gives the existing install/build/test steps explicit `name:` labels for CI log clarity. Runs on both `ubuntu-latest` and `windows-latest` via the existing matrix.

### `c3975d6` — `docs: backlog Build/Release Rigor section + local-dist freshness incident`
New `Build/Release Rigor` section in `docs/primitive-backlog.md` (+28 lines). Full incident narrative with the corrected root cause (NOT "checked in and drifted" — "gitignored, never tracked, never CI-exercised through transport"), fix description, design rule, verification dance for the user post-merge, and the F46-class lesson for future primitives.

**Narrative delta from forge-plan's template:** The template dictated "Root cause: dist/ was checked into git as a build artifact." The audit contradicts that claim (see Root Cause section above). I rewrote the backlog entry to match reality while preserving the template's structure (incident / root cause / fix / design rule / lesson). Flagging explicitly here for stateless review — if you disagree with the rewrite, happy to iterate.

## Test plan
- [x] `npx vitest run server/smoke/` — 6/6 pass (659ms)
- [x] `npx vitest run` (full suite) — 20 files / 387 tests pass
- [x] `grep -rl "not yet implemented" dist --include="*.js"` filtered through exclusions — empty (drift guard would pass)
- [x] `git ls-files dist/` — empty (confirming dist was never tracked)
- [x] Three-way confirmation dist was never in git history (`git log --all --diff-filter=A -- 'dist/*'` also empty)
- [ ] CI matrix (ubuntu + windows) passes on this PR — **will verify from the PR page after push**
- [ ] **Post-merge verification dance** (user must run):
  - [ ] `git checkout master && git pull`
  - [ ] `npm install` (triggers postinstall, which rebuilds dist/)
  - [ ] Restart Claude Code session (MCP servers load once at start)
  - [ ] Throwaway `forge_generate` call with a smoke-test storyId via MCP tool — response must not be a stub
  - [ ] Only after verification, rebase `feat/forge-coordinate-ph-01` on new master and resume PH01-US-00a

## Things for the stateless reviewer (forge-plan) to check

1. **Is the corrected root-cause narrative acceptable?** The dictated template said "dist/ was checked into git" — the audit says it never was. The backlog entry was rewritten accordingly. If you want the original template language kept, happy to revert; it just will not match what `git log` shows.
2. **`COORDINATE_STUB_EXEMPT` stance** — `forge_coordinate` was exempted from the ghost-string assertion because its source is still a pre-PH-01 stub. The alternative would be to fail the smoke test on coordinate until PH-01 ships, blocking every PR in the meantime. The exemption is clearly marked with a `TODO(PH-01 ship)` comment that the PH-01 PR must remove.
3. **Drift guard false-positive handling** — the grep step excludes `dist/tools/coordinate.js` (legitimate stub) and `dist/smoke/` (smoke test contains the regex pattern). Any additional exclusion requires a new PR touching ci.yml — this is intentional to force explicit review.
4. **Verification dance includes `npm install` between merge and restart** — not in the original instructions but strictly required because dist/ only rebuilds when `postinstall` runs, which requires `npm install`. Flagging so the user knows to run it.
5. **4 commits vs 3** — the extra is the docs commit. Kept separate from ci for review granularity. Happy to squash if you prefer strictly 3.

## Not in this PR (per forge-plan's instructions)

- No changes to `server/tools/*.ts` — source is clean, no "improvements" while in there
- No coordinate / PH-01 work — this PR is strictly build system + smoke test + backlog doc
- No mid-PR restart attempts
