### PR TITLE
fix(codebase-scan): prune .claude/worktrees from walker (F-01)

### DIFF
--- a/server/lib/codebase-scan.test.ts
+++ b/server/lib/codebase-scan.test.ts
@@ -88,6 +88,31 @@ describe("scanCodebase", () => {
     expect(result).not.toContain("dist");
   });
 
+  it("skips .claude/worktrees but keeps the rest of .claude (F-01 dogfood fix)", async () => {
+    // .claude/worktrees holds stale Claude Code scratch copies of the repo.
+    // Pre-fix, the walker descended into every worktree and ate ~70% of the
+    // brief's codebase-context budget per the F-01 dogfood finding.
+    await mkdir(join(tempDir, ".claude", "worktrees", "stale-worktree", "server"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(tempDir, ".claude", "worktrees", "stale-worktree", "server", "noise.ts"),
+      "// stale scratch copy",
+    );
+    // A real .claude/skills/ subdir should still be scanned — the prune is
+    // surgical to /worktrees, not the whole .claude tree.
+    await mkdir(join(tempDir, ".claude", "skills", "my-skill"), { recursive: true });
+    await writeFile(
+      join(tempDir, ".claude", "skills", "my-skill", "SKILL.md"),
+      "# real skill",
+    );
+
+    const result = await scanCodebase(tempDir);
+    expect(result).not.toContain("stale-worktree");
+    expect(result).not.toContain(".claude/worktrees");
+    expect(result).toContain(".claude/skills");
+  });
+
   it("respects max depth", async () => {
     // Create deeply nested structure: d1/d2/d3/d4/d5/d6/deep.txt
     // depth 0=d1, 1=d2, 2=d3, 3=d4, 4=d5 (MAX_DEPTH=4), d6 should be excluded

--- a/server/lib/codebase-scan.ts
+++ b/server/lib/codebase-scan.ts
@@ -7,7 +7,7 @@ export const SCANNER_CHAR_CAP = 16_000;
 /** Maximum directory recursion depth. Tunable. */
 const MAX_DEPTH = 4;
 
-/** Directories to skip during scan. */
+/** Directories to skip during scan (matched by basename anywhere in the tree). */
 const SKIP_DIRS = new Set([
   "node_modules",
   "dist",
@@ -17,6 +17,18 @@ const SKIP_DIRS = new Set([
   "__pycache__",
   ".next",
   "coverage",
+]);
+
+/**
+ * Path-relative directories to skip (matched against the path from project root,
+ * with forward slashes). Used for nested noise directories that share a basename
+ * with legitimate user dirs — e.g. `.claude/worktrees` (Claude Code scratch),
+ * `.git/worktrees` (defensive symmetry; .git is already pruned by SKIP_DIRS but
+ * keeping this entry documents intent). F-01 dogfood finding.
+ */
+const SKIP_PATHS = new Set([
+  ".claude/worktrees",
+  ".git/worktrees",
 ]);
 
 /** Key files to read contents of (first 100 lines each). */
@@ -57,6 +69,7 @@ async function listDir(
 
     if (entry.isDirectory()) {
       if (SKIP_DIRS.has(entry.name)) continue;
+      if (SKIP_PATHS.has(relPath)) continue;
       lines.push(`${indent}${relPath}/`);
       await listDir(fullPath, rootDir, depth + 1, lines);
     } else {


### PR DESCRIPTION
## Summary

- Add path-relative `SKIP_PATHS` set to the codebase-scan walker to prune `.claude/worktrees` and `.git/worktrees` (defensive)
- `SKIP_DIRS` matches by basename, which is too coarse for nested noise dirs whose basename (`worktrees`) might exist legitimately in some projects
- New fixture test asserts `.claude/skills/my-skill/` is still scanned while `.claude/worktrees/stale-worktree/` is pruned — surgical, not blanket

## Why

Surfaced as **F-01** in the forge_coordinate S3 dogfood findings log (`.ai-workspace/plans/forge-coordinate-dogfood-findings.md`). On the PH01-US-00a brief assembly run, the walker descended into 7 stale `.claude/worktrees/<adjective-name>/` subtrees (each a full repo copy from prior `/ship` runs) and consumed ~3500 of ~4900 brief tokens before reaching the real `server/` tree. The `[truncated]` marker fired before signal. Every subsequent dogfood story would have inherited the same brief shape — fix mid-stream is the high-ROI move.

forge-plan triage approved this as fix-now (vs deferred): it improves brief quality without changing brief contract, so F-02 (reference patterns) and F-04 (canonicalization wording) stay deferred to post-S3 to keep the S7 baseline measurement stable.

## Test plan

- [x] `npx vitest run server/lib/codebase-scan.test.ts` — 12/12 pass (1 new test)
- [x] `npx vitest run` — 388/388 full suite green
- [x] `npx tsc --noEmit` — clean
- [ ] CI windows-latest matrix passes (the new test uses `mkdir({recursive: true})` and `join()` — Windows-safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)