### PR TITLE
fix(executor): resolve absolute bash.exe on Windows (F-05 ship-blocker)

### DIFF
--- a/server/lib/executor.smoke.test.ts
+++ b/server/lib/executor.smoke.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Integration smoke test for executor.ts — runs REAL child_process.exec
+ * with NO mocks. Designed specifically to catch F-05 (Windows spawn bash
+ * ENOENT) which the heavily-mocked executor.test.ts could not surface
+ * because every prior test asserted "we passed shell: 'bash' to exec()"
+ * (intent) instead of "exec() actually spawned a shell and ran a command"
+ * (outcome).
+ *
+ * This file MUST NOT mock node:child_process, node:os, or node:fs.
+ * If you find yourself adding mocks here, create a new file instead.
+ *
+ * The integration tests run on every platform in CI (ubuntu-latest +
+ * windows-latest, both already in .github/workflows/ci.yml). On Windows,
+ * the bash resolver path is exercised end-to-end. On Unix, the default
+ * shell path is exercised end-to-end.
+ */
+import { describe, it, expect } from "vitest";
+import { executeCommand } from "./executor.js";
+
+describe("executor integration smoke (real exec, no mocks) — F-05 regression guard", () => {
+  it("runs `echo` end-to-end and returns PASS with the echoed output", async () => {
+    const result = await executeCommand("echo forge-smoke-ok", {});
+
+    // The cryptic F-05 failure mode was: status=INCONCLUSIVE,
+    // evidence="Command execution failed: spawn bash ENOENT". This
+    // assertion would have flipped red on the broken Windows code path.
+    expect(result.status).toBe("PASS");
+    expect(result.evidence).toContain("forge-smoke-ok");
+  });
+
+  it("runs a bash-syntax command end-to-end (test -f && echo)", async () => {
+    // This exercises the bash-wrapping behavior on Windows: `test -f`
+    // and `&&` are bash-isms that would fail under cmd.exe but work
+    // under any real bash invocation. On Unix it runs through the
+    // default shell. On Windows it runs through the resolved Git Bash.
+    // package.json is guaranteed to exist at the project root (cwd).
+    const result = await executeCommand(
+      "test -f package.json && echo file-exists",
+      {},
+    );
+
+    expect(result.status).toBe("PASS");
+    expect(result.evidence).toContain("file-exists");
+  });
+
+  it("returns FAIL (not INCONCLUSIVE) for a real non-zero exit code", async () => {
+    // F-05 muddied the FAIL/INCONCLUSIVE distinction because every command
+    // returned INCONCLUSIVE before even running. This test asserts the
+    // verdict pipeline distinguishes "command ran and exited 1" (FAIL)
+    // from "command could not be spawned" (INCONCLUSIVE).
+    const result = await executeCommand("exit 1", {});
+
+    expect(result.status).toBe("FAIL");
+  });
+});

--- a/server/lib/executor.test.ts
+++ b/server/lib/executor.test.ts
@@ -1,19 +1,31 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("node:child_process", () => ({
   exec: vi.fn(),
+  execSync: vi.fn(),
 }));
 
 vi.mock("node:os", () => ({
   platform: vi.fn(() => "linux"),
 }));
 
-import { exec } from "node:child_process";
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(() => false),
+}));
+
+import { exec, execSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { platform } from "node:os";
-import { executeCommand } from "./executor.js";
+import {
+  executeCommand,
+  resolveWindowsBashPath,
+  _resetWindowsBashPathCacheForTesting,
+} from "./executor.js";
 
 const mockedExec = vi.mocked(exec);
+const mockedExecSync = vi.mocked(execSync);
 const mockedPlatform = vi.mocked(platform);
+const mockedExistsSync = vi.mocked(existsSync);
 
 function simulateExec(
   error: Error | null,
@@ -99,15 +111,48 @@ describe("executeCommand", () => {
     expect(result.evidence).toContain("[truncated]");
   });
 
-  it("uses bash shell on Windows", async () => {
+  it("uses resolved absolute bash path on Windows (F-05 fix)", async () => {
+    // Pre-fix: passed `shell: "bash"` literal which Node's spawn cannot
+    // resolve on Windows -> spawn bash ENOENT on every AC.
+    // Post-fix: resolves to an absolute path via FORGE_BASH_PATH / `where bash`
+    // / common Git Bash install paths.
+    _resetWindowsBashPathCacheForTesting();
     mockedPlatform.mockReturnValue("win32" as ReturnType<typeof platform>);
+    process.env.FORGE_BASH_PATH = "C:\\Program Files\\Git\\bin\\bash.exe";
+    mockedExistsSync.mockReturnValue(true);
     simulateExec(null, "", "");
+
     await executeCommand("echo test", {});
+
     expect(mockedExec).toHaveBeenCalledWith(
       "echo test",
-      expect.objectContaining({ shell: "bash" }),
+      expect.objectContaining({
+        shell: "C:\\Program Files\\Git\\bin\\bash.exe",
+      }),
       expect.any(Function),
     );
+
+    delete process.env.FORGE_BASH_PATH;
+    _resetWindowsBashPathCacheForTesting();
+  });
+
+  it("rejects with actionable error on Windows when bash cannot be resolved (F-05)", async () => {
+    _resetWindowsBashPathCacheForTesting();
+    mockedPlatform.mockReturnValue("win32" as ReturnType<typeof platform>);
+    delete process.env.FORGE_BASH_PATH;
+    mockedExistsSync.mockReturnValue(false);
+    mockedExecSync.mockImplementation(() => {
+      throw new Error("where: command failed");
+    });
+
+    await expect(executeCommand("echo test", {})).rejects.toThrow(
+      /requires Git Bash on Windows.*FORGE_BASH_PATH/s,
+    );
+    // Critical: ensure the failure is loud (one rejection) NOT silent
+    // (every AC returning INCONCLUSIVE with "spawn bash ENOENT").
+    expect(mockedExec).not.toHaveBeenCalled();
+
+    _resetWindowsBashPathCacheForTesting();
   });
 
   it("does not force bash shell on Linux", async () => {
@@ -141,5 +186,90 @@ describe("executeCommand", () => {
     simulateExec(null, "output", "");
     const result = await executeCommand("cmd", {});
     expect(result.evidence).toBe("output");
+  });
+});
+
+describe("resolveWindowsBashPath (F-05 dogfood fix)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetWindowsBashPathCacheForTesting();
+    delete process.env.FORGE_BASH_PATH;
+  });
+
+  afterEach(() => {
+    delete process.env.FORGE_BASH_PATH;
+    _resetWindowsBashPathCacheForTesting();
+  });
+
+  it("returns FORGE_BASH_PATH when env var is set and file exists", () => {
+    process.env.FORGE_BASH_PATH = "D:\\msys64\\usr\\bin\\bash.exe";
+    mockedExistsSync.mockImplementation(
+      (p) => p === "D:\\msys64\\usr\\bin\\bash.exe",
+    );
+
+    expect(resolveWindowsBashPath()).toBe("D:\\msys64\\usr\\bin\\bash.exe");
+    expect(mockedExecSync).not.toHaveBeenCalled(); // env var short-circuits `where`
+  });
+
+  it("throws if FORGE_BASH_PATH points at a non-existent file", () => {
+    process.env.FORGE_BASH_PATH = "Z:\\does\\not\\exist\\bash.exe";
+    mockedExistsSync.mockReturnValue(false);
+
+    expect(() => resolveWindowsBashPath()).toThrow(
+      /FORGE_BASH_PATH is set.*does not exist/,
+    );
+  });
+
+  it("falls back to `where bash` when FORGE_BASH_PATH is unset", () => {
+    mockedExecSync.mockReturnValue(
+      "C:\\Program Files\\Git\\bin\\bash.exe\r\nC:\\Windows\\System32\\bash.exe\r\n",
+    );
+    mockedExistsSync.mockImplementation(
+      (p) => p === "C:\\Program Files\\Git\\bin\\bash.exe",
+    );
+
+    expect(resolveWindowsBashPath()).toBe(
+      "C:\\Program Files\\Git\\bin\\bash.exe",
+    );
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      "where bash",
+      expect.objectContaining({ encoding: "utf-8" }),
+    );
+  });
+
+  it("falls back to common Git Bash install paths when `where bash` fails", () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error("'where' is not recognized");
+    });
+    mockedExistsSync.mockImplementation(
+      (p) => p === "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+    );
+
+    expect(resolveWindowsBashPath()).toBe(
+      "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+    );
+  });
+
+  it("throws actionable error when no resolution strategy succeeds", () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    mockedExistsSync.mockReturnValue(false);
+
+    expect(() => resolveWindowsBashPath()).toThrow(
+      /requires Git Bash on Windows.*git-scm\.com\/download\/win.*FORGE_BASH_PATH/s,
+    );
+  });
+
+  it("caches the first successful resolution (idempotent across calls)", () => {
+    process.env.FORGE_BASH_PATH = "C:\\Program Files\\Git\\bin\\bash.exe";
+    mockedExistsSync.mockReturnValue(true);
+
+    const first = resolveWindowsBashPath();
+    delete process.env.FORGE_BASH_PATH;
+    mockedExistsSync.mockReturnValue(false);
+    const second = resolveWindowsBashPath();
+
+    expect(second).toBe(first);
   });
 });

--- a/server/lib/executor.ts
+++ b/server/lib/executor.ts
@@ -1,10 +1,106 @@
-import { exec } from "node:child_process";
+import { exec, execSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { platform } from "node:os";
 import type { CriterionResult } from "../types/eval-report.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024; // 10 MB
 const EVIDENCE_CHAR_CAP = 4_000;
+
+/**
+ * Cached resolved bash.exe absolute path on Windows. Resolution is expensive
+ * (calls `where bash` + multiple stat checks) so we cache the first success.
+ * Failures are NOT cached so a user can install Git Bash and retry without
+ * restarting the MCP server. F-05 dogfood fix.
+ */
+let cachedWindowsBashPath: string | undefined;
+
+const WINDOWS_BASH_FALLBACK_PATHS = [
+  "C:\\Program Files\\Git\\bin\\bash.exe",
+  "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+];
+
+/**
+ * Resolve an absolute Windows path to bash.exe, throwing a clear actionable
+ * error if none can be found. Resolution order:
+ *   1. FORGE_BASH_PATH environment variable (escape hatch for non-standard installs)
+ *   2. `where bash` (Windows-native PATH lookup; finds Git Bash if installed via the official installer)
+ *   3. Common Git for Windows install paths
+ *
+ * F-05 root cause: passing `shell: "bash"` to child_process.exec on Windows
+ * fails with `spawn bash ENOENT` because Node's spawn does NOT consult the
+ * Windows PATH environment variable for bare executable names — it only
+ * resolves absolute paths or `.exe`/`.cmd`/`.bat` names with extension.
+ * Fix: resolve "bash" to its absolute path BEFORE passing to exec, using
+ * Windows-native lookup mechanisms.
+ *
+ * Why not `shell: true`? Because that would interpret AC commands through
+ * cmd.exe/PowerShell, breaking Unix-style commands (`grep`, `2>/dev/null`,
+ * `\|` alternation) AND introducing shell-injection risk for any AC string
+ * containing `$`, backticks, or other metacharacters.
+ *
+ * @internal — exported only for testing
+ */
+export function resolveWindowsBashPath(): string {
+  if (cachedWindowsBashPath) return cachedWindowsBashPath;
+
+  // 1. Explicit env var override
+  const envPath = process.env.FORGE_BASH_PATH;
+  if (envPath) {
+    if (!existsSync(envPath)) {
+      throw new Error(
+        `forge_evaluate: FORGE_BASH_PATH is set to "${envPath}" but that file does not exist.`,
+      );
+    }
+    cachedWindowsBashPath = envPath;
+    return envPath;
+  }
+
+  // 2. `where bash` — Windows native PATH lookup
+  try {
+    const out = execSync("where bash", {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const first = out
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .find((s) => s.length > 0 && existsSync(s));
+    if (first) {
+      cachedWindowsBashPath = first;
+      return first;
+    }
+  } catch {
+    // `where` not available, returned non-zero, or all paths invalid — fall through
+  }
+
+  // 3. Common Git for Windows install paths
+  for (const candidate of WINDOWS_BASH_FALLBACK_PATHS) {
+    if (existsSync(candidate)) {
+      cachedWindowsBashPath = candidate;
+      return candidate;
+    }
+  }
+
+  // 4. Loud failure with actionable next steps
+  throw new Error(
+    "forge_evaluate requires Git Bash on Windows but bash.exe was not found. " +
+      "Searched: $FORGE_BASH_PATH (unset), `where bash` (no result), " +
+      `${WINDOWS_BASH_FALLBACK_PATHS.join(", ")} (none exist). ` +
+      "Install Git for Windows from https://git-scm.com/download/win " +
+      "or set FORGE_BASH_PATH=<absolute path to bash.exe>.",
+  );
+}
+
+/**
+ * Reset the cached Windows bash path. Test-only — production callers must not
+ * use this; the cache exists to amortize per-process resolution cost.
+ *
+ * @internal
+ */
+export function _resetWindowsBashPathCacheForTesting(): void {
+  cachedWindowsBashPath = undefined;
+}
 
 export interface ExecuteOptions {
   timeoutMs?: number;
@@ -38,9 +134,20 @@ export function executeCommand(
   const maxBuffer = options.maxBuffer ?? DEFAULT_MAX_BUFFER;
   const cwd = options.cwd ?? process.cwd();
 
-  const shellOption = platform() === "win32" ? { shell: "bash" as const } : {};
+  return new Promise<CriterionResult>((resolve, reject) => {
+    let shellOption: { shell: string } | object = {};
+    if (platform() === "win32") {
+      try {
+        shellOption = { shell: resolveWindowsBashPath() };
+      } catch (err) {
+        // F-05 fix: surface the resolver error as a rejection so the caller's
+        // outer try/catch sees a single clear "Git Bash not installed" message
+        // instead of N cryptic per-AC `spawn bash ENOENT` results.
+        reject(err);
+        return;
+      }
+    }
 
-  return new Promise<CriterionResult>((resolve) => {
     exec(
       command,
       {


### PR DESCRIPTION
## Summary

- **CRITICAL Windows bug fix.** `forge_evaluate` story mode was 100% broken on Windows: every AC returned `INCONCLUSIVE` with `spawn bash ENOENT`, regardless of actual correctness
- Root cause: `executor.ts` passed `shell: "bash"` (string literal) to `child_process.exec` on win32. Node's spawn does NOT consult Windows PATH for bare executable names — it requires absolute paths or `.exe` names with extension
- Fix: new `resolveWindowsBashPath()` with 3-tier resolution (`FORGE_BASH_PATH` env var → `where bash` → common Git for Windows install paths). Throws ONE loud actionable error if all fail (not N silent INCONCLUSIVE results)
- Net new test coverage: **+9 tests, +1 file** (6 resolver unit tests + 2 updated/new Windows behavior tests + 3 unmocked smoke tests in `executor.smoke.test.ts`)

## Why this is a ship-blocker

1. **NFR-C05 "Windows compatibility" was false in practice.** PRD declares `windows-latest` in CI and the primary author's dev env IS Windows 11 / Git Bash MINGW64. Yet the primitive that executes every AC command could not spawn a shell there.
2. **Phantom retry escalations.** A coordinator running in advisory mode would see every story's INCONCLUSIVE verdict, count it toward `retryCount` per REQ-04 v1.1 ("Retry counter includes INCONCLUSIVE"), exhaust all 3 retries on stories that are actually passing, and produce phantom `failed` classifications + spurious `needs-replan` escalations. Universal Windows breakage masquerading as "flaky eval" — the worst kind of bug.
3. **S3 dogfood loop integrity.** S7 divergence measurement against the 80-item baseline requires the verdict function to work. Pre-fix, the entire dogfood loop was degraded — implementers MUST manually run AC commands via the harness Bash tool, defeating "prove don't claim".

Logged as **F-05** in `.ai-workspace/plans/forge-coordinate-dogfood-findings.md` (CRITICAL severity) and triaged by forge-plan as a ship-blocker requiring immediate fix-PR off master before PH01-US-00b begins.

## Why NOT `shell: true`

Switching to `{ shell: true }` would route AC commands through cmd.exe / PowerShell instead of bash, which:
1. Breaks Unix-syntax ACs (`grep`, `2>/dev/null`, `\|` alternation) — all of which appear in the PH-01 phase plan today
2. **Introduces a shell-injection vector** for any AC string containing `$`, backticks, or `&&`. AC commands are user-supplied content from execution plan files, not trusted input. A platform-branched absolute-path fix preserves existing exec semantics on every OS while only fixing the broken path lookup.

## Why this bug wasn't caught earlier (the meta-finding)

The pre-existing `executor.test.ts:102` tested the Windows code path — but with `node:child_process` fully mocked. It asserted `mockedExec.toHaveBeenCalledWith(..., { shell: "bash" }, ...)` — i.e., verified the SHELL OPTION WAS PASSED, not that `exec` could actually spawn that shell. **Tested-the-mock-not-the-contract** — a textbook hive-mind anti-pattern. The fix adds an unmocked smoke-test file (`executor.smoke.test.ts`) that runs real `exec` end-to-end. This is the test class whose absence created the F-05 blindspot.

## Test plan

- [x] `npx vitest run server/lib/executor.test.ts server/lib/executor.smoke.test.ts` — 23/23 pass on Windows 11 / Git Bash MINGW64
- [x] `npx vitest run` — 397/397 full suite green (388 baseline + 9 new)
- [x] `npx tsc --noEmit` — clean
- [x] **End-to-end proof on the broken env:** smoke test `"test -f package.json && echo file-exists"` passes on the primary author's Windows dev env, the same env where F-05 was originally surfaced during PH01-US-00a verification
- [ ] CI windows-latest matrix passes (already in `.github/workflows/ci.yml:16`, no CI changes needed)
- [ ] CI ubuntu-latest matrix passes (smoke test runs on Linux too, exercising the non-Windows code path)

## Test breakdown (+9 new)

1. `resolveWindowsBashPath` (6 tests, mocked):
   - Returns FORGE_BASH_PATH when env var set + file exists
   - Throws if FORGE_BASH_PATH points at non-existent file
   - Falls back to `where bash` when env var unset
   - Falls back to common Git Bash paths when `where bash` fails
   - Throws actionable error when all strategies fail
   - Caches first success (idempotent across calls)
2. `executeCommand` Windows behavior (2 tests, mocked):
   - Uses resolved absolute bash path on Windows (replaces old "uses bash shell" test)
   - Rejects with actionable error when bash unavailable (proves "loud" failure mode)
3. `executor.smoke.test.ts` (3 tests, **NO mocks** — F-05 regression guard):
   - Runs `echo` end-to-end, asserts PASS + output captured
   - Runs `test -f package.json && echo` (bash-syntax) end-to-end
   - Runs `exit 1` end-to-end, asserts FAIL (not INCONCLUSIVE) — distinguishes "command ran and failed" from "command could not spawn"

## Sequencing

This is the second of 2 fix PRs forge-plan triaged from S3 dogfood findings. Order:
1. ⏳ #121 (F-01: codebase-scan worktree prune) — independent, ready to merge
2. ⏳ this PR (F-05) — independent, ready to merge
3. After both merge: rebase `feat/forge-coordinate-ph-01` on new master, resume PH01-US-00b

🤖 Generated with [Claude Code](https://claude.com/claude-code)