### PR TITLE
feat(coordinate): PH-01 types, topo sort, state readers, core dispatch loop

### DIFF
--- a/.ai-workspace/plans/forge-coordinate-dogfood-findings.md
+++ b/.ai-workspace/plans/forge-coordinate-dogfood-findings.md
@@ -1,0 +1,103 @@
+# forge_coordinate S3 Dogfood Findings (running log)
+
+**Purpose:** Rolling capture of dogfood findings discovered while implementing PH-01 stories using `forge_generate`. Each finding is a concrete, actionable gap or wart in the brief-assembly / spec-accuracy / implementation-plan chain. The final dogfood report at S3 ship time (`forge-coordinate-dogfood-report.md`) rolls these up with per-story brief quality scores and wall-clock timing.
+
+**Rule of the log:** Every finding must have WHAT, WHERE FOUND, WHY IT MATTERS, FIX PROPOSAL, and SOURCE (which story / which brief call surfaced it). No vague "brief was ok" entries — those go in the per-story brief-quality scoreboard at the bottom, not here.
+
+---
+
+## Findings
+
+### F-01 — `codebaseContext` is 90% noise from `.claude/worktrees/*`
+
+- **Story surfaced in:** PH01-US-00a (iteration 0)
+- **Severity:** brief-quality (high — eats context budget)
+- **What:** `forge_generate`'s returned `brief.codebaseContext` devotes the first ~3500 of ~4900 brief tokens to listing 7 `.claude/worktrees/*` subdirectories (ritchie, wescoff, elion, dhawan, raman, wright, festive) line-by-line before reaching the real `server/` tree. Each worktree repeats the same `.github/`, `docs/`, `schema/`, `scripts/`, `server/` subtree structure.
+- **Why it matters:** Worktrees are scratch directories from prior `/ship` runs — they contain stale copies of the repo that are never relevant to the brief's target story. The noise (a) wastes ~70% of the brief's codebase-context budget, (b) pushes the actual signal (real `server/` tree) below the scan's truncation line, and (c) inflates prompt tokens on downstream consumers that feed the brief into another LLM. The `[truncated]` marker at the end of my PH01-US-00a brief confirms the real tree was cut short.
+- **Fix proposal:** `server/lib/codebase-scan.ts` should add `.claude/worktrees/` (and probably also `dist/`, `node_modules/`, `.git/`, `.ai-workspace/`) to its ignore list. This is a one-line fix in the directory walker's prune list, plus a unit test asserting that a fixture repo with a `.claude/worktrees/stale/` subdir produces a scan output that does not contain the worktree path.
+- **Source:** `forge_generate({storyId: "PH01-US-00a", projectPath: ".../forge-harness", iteration: 0})` — returned brief's `codebaseContext` field, first ~3500 tokens.
+
+---
+
+### F-02 — Brief reproduces phase-plan story text but omits reference-pattern code
+
+- **Story surfaced in:** PH01-US-00a (iteration 0)
+- **Severity:** brief-quality (medium — forces implementer to read source anyway)
+- **What:** The brief correctly copies the story's `description`, `acceptanceCriteria`, and `affectedPaths` from the phase plan, but does NOT extract the reference-pattern code the story description explicitly points at. The PH01-US-00a description says "matching the handleCoherenceEval pattern at server/tools/evaluate.ts lines 226" — but the brief does not include those lines. Nor does it include the current `RunRecord` interface body, the current `handleStoryEval` body, or the `RunContext` constructor signature. The implementer has to read 4+ source files to discover *how* to do the work the brief tells them to do.
+- **Why it matters:** The dogfood directive says "Implement ONLY from the brief — do not re-read the phase plan or PRD mid-story." The brief is self-sufficient for *what* (story goal, AC list) but not for *how* (reference pattern code, target file shapes). This forces implementers to either (a) read target source files anyway (technically permitted — the directive only bans re-reading upstream *docs*) or (b) fabricate plausible-looking code from memory, which is exactly what the brief-first discipline is supposed to prevent. The gap undermines the S7 divergence measurement because implementers are silently supplementing with out-of-brief knowledge.
+- **Fix proposal:** Extend `forge_generate` brief assembly to include a `referencePatterns` section when the story description contains file:line references (e.g., regex `\S+\.ts:\d+` or `at <path> line \d+`). Extract the referenced function body (or ±20 lines around the pointer) into the brief. This is a new brief field, not a codebase-context expansion — keep it scoped. Alternatively: extend brief assembly to include the full contents of every file listed in `affectedPaths` when the story is in "extend existing" mode (identifiable by description keywords like "extend", "add to", "matching the X pattern").
+- **Source:** `forge_generate({storyId: "PH01-US-00a", ...})` brief's `story.description` (references `server/tools/evaluate.ts lines 150-166` and `line 226`) combined with the absence of those line ranges in the brief's `codebaseContext`.
+
+---
+
+### F-03 — PRD/phase-plan reference `EvalReport.findings` / `failedAcId` that do not exist in the code
+
+- **Story surfaced in:** PH01-US-00a
+- **Severity:** spec-accuracy (high — silent spec-vs-code drift)
+- **What:** Both `docs/forge-coordinate-prd.md` (REQ-01 "Deterministic serialization AC") and `.ai-workspace/plans/forge-coordinate-phase-PH-01.json` (PH01-US-00a description) repeatedly reference `EvalReport.findings` sorted by `(failedAcId, description)`. The actual `server/types/eval-report.ts` defines:
+    ```ts
+    interface EvalReport {
+      storyId: string;
+      verdict: "PASS" | "FAIL" | "INCONCLUSIVE";
+      criteria: CriterionResult[];
+      warnings?: string[];
+    }
+    interface CriterionResult {
+      id: string;
+      status: "PASS" | "FAIL" | "SKIPPED" | "INCONCLUSIVE";
+      evidence: string;
+    }
+    ```
+  There is no `findings` array, no `failedAcId` field, and no `description` field. The direct analog is `criteria[].id` and `criteria[].evidence`.
+- **Why it matters:** An implementer following the brief literally would fabricate a `findings` field and a `failedAcId` attribute, neither of which compiles. The PH-01 plan's AC list does not catch this because its ACs are all grep-based on `run-record.ts` interface declarations (not on `eval-report.ts` field shapes). Silent drift between spec vocabulary and type definitions is a classic way for plan-first workflows to produce code that *looks* spec-compliant but references nonexistent fields. This is the exact kind of wart the dogfood loop is supposed to surface.
+- **Fix proposal:** (a) Update PRD REQ-01 and phase-plan PH01-US-00a description to reference `EvalReport.criteria` (the actual field name) sorted by `(id, evidence)`. Also update REQ-01's "Storage/performance note" which references "~50 findings × ~200 bytes each" — should say "~50 criteria × ~200 bytes each". (b) Add a coherence-mode `forge_evaluate` check that greps for spec vocabulary against the current type definitions — any REQ that mentions a field name not present in any TypeScript interface under `server/types/` should fail coherence. This is P31-ish (mechanical consistency check). (c) For this implementation: I'm proceeding with `criteria` as the canonicalization target, noting the deviation in my S3 reply contract item 5 as an interview surprise.
+- **Source:** Cross-reference between `docs/forge-coordinate-prd.md:70-71` (REQ-01 deterministic serialization AC, Storage/performance note) and `server/types/eval-report.ts` (actual type).
+
+---
+
+### F-05 — `forge_evaluate` story mode is broken on Windows (`spawn bash ENOENT`)
+
+- **Story surfaced in:** PH01-US-00a (verification step)
+- **Severity:** CRITICAL — story-mode verification is unusable on the primary author's dev environment
+- **What:** Calling `mcp__forge__forge_evaluate({evaluationMode: "story", storyId: "PH01-US-00a", planPath: "...forge-coordinate-phase-PH-01.json"})` returned `verdict: "INCONCLUSIVE"` on ALL 10 ACs, every one with the identical evidence `"Command execution failed: spawn bash ENOENT"`. The ACs themselves are correct (I verified every single one manually via the harness's Bash tool: grep hits land on lines 20-32 of `run-record.ts`, `tsc --noEmit` is clean, `vitest run` passes 35/35 evaluate tests and 390/390 full suite). The tool simply cannot execute ANY shell command on Windows.
+- **Root cause (hypothesis):** `server/lib/executor.ts` (or wherever story-mode AC commands are dispatched) is calling `child_process.spawn("bash", ["-c", command], ...)` without `shell: true` and without resolving `bash` to its absolute path. On Windows, `spawn` with a bare executable name does not consult PATH the way a Unix shell does — it tries the exact name as a file in the current directory first, then uses a restricted lookup, and fails with ENOENT even when Git Bash is installed at `C:\Program Files\Git\bin\bash.exe` and fully resolvable via `which bash` in any Git Bash prompt.
+- **Why it matters:**
+    1. **NFR-C05 "Windows compatibility" is false in practice** for `forge_evaluate` story mode. The PRD explicitly lists `windows-latest` in CI and the primary author's dev env IS Windows 11 / Git Bash (MINGW64). The PRD's own shell-portability note even acknowledges the Windows env. Yet the tool that executes every AC command cannot spawn a shell there.
+    2. **The entire dogfood loop for S3 is degraded.** The S3 prompt prescribes `forge_evaluate` as the verdict source for every story: "If verdict: PASS → commit. If verdict: FAIL or INCONCLUSIVE → call forge_generate again with eval report for fix guidance." With every story returning INCONCLUSIVE regardless of actual correctness, the loop is noise — the implementer MUST fall back to manually running AC commands themselves, which defeats the "prove don't claim" design intent.
+    3. **`forge_generate` retry loop would misfire.** A post-PH-01 coordinator running in advisory mode would see the INCONCLUSIVE verdict, count it toward `retryCount` per REQ-04 v1.1 ("Retry counter includes INCONCLUSIVE"), and exhaust all 3 retries on a story that is actually passing — producing a phantom `failed` classification and a spurious `needs-replan` escalation. This is exactly the "flaky eval" scenario §7 out-of-scope table identifies as a known limitation, but it is in fact a Windows-universal bug, not a flake.
+- **Fix proposal:** Audit the story-mode command executor (likely `server/lib/executor.ts` or `server/lib/evaluator.ts`). Change the spawn pattern to one of:
+    - `spawn("bash", [...], { shell: true })` — simplest, lets the OS resolve the shell
+    - Or resolve `bash.exe` at startup via a `which`-like lookup (e.g. check `C:\Program Files\Git\bin\bash.exe`, `C:\Program Files (x86)\Git\bin\bash.exe`, `$MSYS_ROOT\usr\bin\bash.exe`, `wslpath` fallback) and cache the absolute path
+    - Or detect Windows at startup and fall back to `cmd.exe /c` + PowerShell for non-bash commands; this is more invasive because the AC commands use bash-specific syntax (`\|` alternation, `2>/dev/null`, `test -z "$(...)"`).
+    Add a Windows-matrix CI test in `.github/workflows/ci.yml` that invokes `forge_evaluate` in story mode on a fixture plan with at least one `grep`-based AC and asserts the verdict is NOT INCONCLUSIVE with `spawn bash ENOENT`. This is the missing integration test that would have caught F-05 at ship time.
+- **Verification workaround for PH01-US-00a:** I verified every AC manually by running each command via the harness Bash tool (see the batched grep check at commit time). All 10 ACs pass. The implementation itself is correct; the tool tasked with verifying it is broken.
+- **Source:** `mcp__forge__forge_evaluate({evaluationMode: "story", storyId: "PH01-US-00a", planPath: ".../forge-coordinate-phase-PH-01.json"})` returned all 10 criteria as `INCONCLUSIVE` with evidence `"Command execution failed: spawn bash ENOENT"` on Windows 11 / Git Bash MINGW64.
+
+---
+
+### F-04 — PRD says `writeRunRecord` must canonicalize, but test infrastructure mocks `writeRunRecord` fully
+
+- **Story surfaced in:** PH01-US-00a
+- **Severity:** design trade-off (low — workable, but an inconsistency)
+- **What:** REQ-01 wording: "If the existing `EvalReport` type does not guarantee stable internal ordering, `writeRunRecord` is responsible for canonicalizing before serialization." This places the canonicalization inside `writeRunRecord` itself. However, `server/tools/evaluate.test.ts` mocks `writeRunRecord` completely (via `vi.mock("../lib/run-record.js", ...)`). PH01-US-00a-AC08 requires a test in `evaluate.test.ts` that asserts byte-identical `evalReport` output across two calls with different input orders. A sort that lives inside the (mocked) `writeRunRecord` is invisible to the test — the mock receives the un-canonicalized input.
+- **Why it matters:** Putting canonicalization inside `writeRunRecord` would make AC08 permanently unobservable in `evaluate.test.ts` (where AC08 explicitly lives), so either the AC has to move to a different test file or the canonicalization has to move to the handler. I chose to put it in the handler via an exported helper `canonicalizeEvalReport` from `run-record.ts` — this makes the sort observable via the mock-received record, and the helper becomes the convention future call sites use. But it technically violates the PRD's "writeRunRecord is responsible" wording.
+- **Fix proposal:** (a) Update PRD REQ-01 to say "every canonical `writeRunRecord` call site is responsible for passing a canonicalized `EvalReport`, using the exported `canonicalizeEvalReport` helper from `server/lib/run-record.ts`." (b) Alternatively, put the sort in `writeRunRecord` AND move AC08 to `server/lib/run-record.test.ts` where the real function runs. (c) For v1.1 I'm going with (a) — the helper-at-handler pattern — and will note it in the S3 reply.
+- **Source:** Tension between `docs/forge-coordinate-prd.md:70` (REQ-01 "writeRunRecord is responsible for canonicalizing") and `server/tools/evaluate.test.ts:21-23` (full mock of writeRunRecord) + PH01-US-00a-AC08's explicit targeting of `evaluate.test.ts`.
+
+---
+
+## Per-story brief-quality scoreboard (rolling)
+
+| Story | Brief tokens | Useful % | Wall-clock | Self-sufficient? | Re-reads needed | forge_evaluate verdict |
+|-------|--------------|----------|------------|------------------|-----------------|------------------------|
+| PH01-US-00a | 4929 | ~10% (codebase-context noise) | ~25 min | No — had to read 6 source files | run-record.ts, evaluate.ts, eval-report.ts, run-context.ts, cost.ts, evaluate.test.ts | INCONCLUSIVE (F-05 Windows bug — all 10 ACs verified manually: tsc clean, 35/35 evaluate tests green, 390/390 full suite green) |
+
+---
+
+## Running TODO (findings to fix post-S3)
+
+- [ ] **F-05 (CRITICAL)**: fix `forge_evaluate` story-mode `spawn bash ENOENT` on Windows — audit `server/lib/executor.ts` / `server/lib/evaluator.ts`, add `shell: true` or absolute bash path resolution, add Windows CI test asserting story-mode verdict is not ENOENT-INCONCLUSIVE
+- [ ] F-01: prune `.claude/worktrees/` (and friends) from `codebase-scan.ts` walker
+- [ ] F-02: add `referencePatterns` brief field OR include `affectedPaths` file contents for "extend existing" stories
+- [ ] F-03: update PRD REQ-01 + PH01-US-00a description to use `criteria`/`id`/`evidence` vocabulary instead of `findings`/`failedAcId`/`description`
+- [ ] F-04: reconcile PRD "writeRunRecord is responsible" wording with the helper-at-handler pattern chosen for PH01-US-00a

--- a/server/lib/coordinator.test.ts
+++ b/server/lib/coordinator.test.ts
@@ -354,6 +354,26 @@ describe("assessPhase", () => {
     expect(entry.priorEvalReport!.criteria[0].evidence).toBe("new evidence");
   });
 
+  it("NFR-C02 deterministic dispatch: two calls on identical inputs return structurally equal results", async () => {
+    const plan = makePlan([
+      makeStory("US-01"),
+      makeStory("US-02", ["US-01"]),
+    ]);
+    const records = [
+      makePrimaryRecord("US-01", "PASS", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-02", "FAIL", "2026-01-01T00:01:00Z"),
+    ];
+    mockedReadRunRecords
+      .mockResolvedValueOnce([...records])
+      .mockResolvedValueOnce([...records]);
+
+    const r1 = await assessPhase(plan, "/tmp/test");
+    const r2 = await assessPhase(plan, "/tmp/test");
+
+    // Compare brief structure (excluding any non-deterministic fields)
+    expect(JSON.stringify(r1.brief)).toBe(JSON.stringify(r2.brief));
+  });
+
   it("NFR-C08: Object.keys of every StoryStatusEntry returns identical sorted key set across all 6 statuses", async () => {
     // Build a plan that produces all 6 status values
     const plan = makePlan([

--- a/server/lib/coordinator.test.ts
+++ b/server/lib/coordinator.test.ts
@@ -280,4 +280,110 @@ describe("assessPhase", () => {
     expect(result.brief.replanningNotes.some((n) => n.severity === "blocking")).toBe(true);
     expect(result.brief.recommendation).toContain("US-01");
   });
+
+  it("mixed-failed: 1 failed + 4 ready → needs-replan (rule 3 dominates)", async () => {
+    const plan = makePlan([
+      makeStory("US-01"),
+      makeStory("US-02"),
+      makeStory("US-03"),
+      makeStory("US-04"),
+      makeStory("US-05"),
+    ]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:01:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:02:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    expect(result.brief.status).toBe("needs-replan");
+    expect(result.brief.failedStories).toContain("US-01");
+    expect(result.brief.readyStories).toHaveLength(4);
+  });
+
+  it("LAST RETRY: recommendation contains 'LAST RETRY: <storyId>' when retriesRemaining === 1", async () => {
+    const plan = makePlan([makeStory("US-01")]);
+    // 2 FAIL records → retryCount=2, retriesRemaining=1
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:01:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    expect(result.brief.stories[0].retriesRemaining).toBe(1);
+    expect(result.brief.recommendation).toMatch(/LAST RETRY: US-01/);
+  });
+
+  it("depFailedStories is populated from dep-failed entries", async () => {
+    const plan = makePlan([
+      makeStory("US-01"),
+      makeStory("US-02", ["US-01"]),
+      makeStory("US-03", ["US-01"]),
+    ]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:01:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:02:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    expect(result.brief.depFailedStories).toContain("US-02");
+    expect(result.brief.depFailedStories).toContain("US-03");
+    expect(result.brief.depFailedStories).toHaveLength(2);
+  });
+
+  it("priorEvalReport provenance: two FAIL records → priorEvalReport matches the newest", async () => {
+    const oldReport: EvalReport = {
+      storyId: "US-01",
+      verdict: "FAIL",
+      criteria: [{ id: "AC-01", status: "FAIL", evidence: "old evidence" }],
+    };
+    const newReport: EvalReport = {
+      storyId: "US-01",
+      verdict: "FAIL",
+      criteria: [{ id: "AC-01", status: "FAIL", evidence: "new evidence" }],
+    };
+    const plan = makePlan([makeStory("US-01")]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z", oldReport),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:01:00Z", newReport),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    const entry = result.brief.stories[0];
+    expect(entry.priorEvalReport!.criteria[0].evidence).toBe("new evidence");
+  });
+
+  it("NFR-C08: Object.keys of every StoryStatusEntry returns identical sorted key set across all 6 statuses", async () => {
+    // Build a plan that produces all 6 status values
+    const plan = makePlan([
+      makeStory("US-DONE"),
+      makeStory("US-READY"),
+      makeStory("US-RETRY"),
+      makeStory("US-FAILED"),
+      makeStory("US-DEP-FAILED", ["US-FAILED"]),
+      makeStory("US-PENDING", ["US-RETRY"]),
+    ]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-DONE", "PASS", "2026-01-01T00:00:00Z"),
+      // US-READY: no records → ready
+      // US-RETRY: 1 FAIL → ready-for-retry
+      makePrimaryRecord("US-RETRY", "FAIL", "2026-01-01T00:01:00Z"),
+      // US-FAILED: 3 FAIL → failed
+      makePrimaryRecord("US-FAILED", "FAIL", "2026-01-01T00:02:00Z"),
+      makePrimaryRecord("US-FAILED", "FAIL", "2026-01-01T00:03:00Z"),
+      makePrimaryRecord("US-FAILED", "FAIL", "2026-01-01T00:04:00Z"),
+      // US-DEP-FAILED: dep on US-FAILED → dep-failed
+      // US-PENDING: dep on US-RETRY (not done) → pending
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    const statusSet = new Set(result.brief.stories.map((s) => s.status));
+    expect(statusSet).toEqual(new Set(["done", "ready", "ready-for-retry", "failed", "dep-failed", "pending"]));
+
+    // All entries must have the exact same key set
+    const keySets = result.brief.stories.map((s) => Object.keys(s).sort().join(","));
+    const uniqueKeySets = new Set(keySets);
+    expect(uniqueKeySets.size).toBe(1);
+  });
 });

--- a/server/lib/coordinator.test.ts
+++ b/server/lib/coordinator.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { RunRecord } from "./run-record.js";
+import type { ExecutionPlan, Story } from "../types/execution-plan.js";
+import type { EvalReport } from "../types/eval-report.js";
+import type { PrimaryRecord, GeneratorRecord } from "./run-reader.js";
+
+// Mock readRunRecords so we control the fixture data
+vi.mock("./run-reader.js", () => ({
+  readRunRecords: vi.fn(async () => []),
+}));
+
+import { readRunRecords } from "./run-reader.js";
+import { assessPhase } from "./coordinator.js";
+
+const mockedReadRunRecords = vi.mocked(readRunRecords);
+
+function makeStory(id: string, deps?: string[]): Story {
+  return {
+    id,
+    title: `Story ${id}`,
+    dependencies: deps,
+    acceptanceCriteria: [{ id: `${id}-AC01`, description: "check", command: "echo ok" }],
+  };
+}
+
+function makePlan(stories: Story[]): ExecutionPlan {
+  return { schemaVersion: "3.0.0", stories };
+}
+
+function makePrimaryRecord(storyId: string, verdict: "PASS" | "FAIL" | "INCONCLUSIVE", timestamp: string, evalReport?: EvalReport): PrimaryRecord {
+  const record: RunRecord = {
+    timestamp,
+    tool: "forge_evaluate",
+    documentTier: null,
+    mode: null,
+    tier: null,
+    storyId,
+    evalVerdict: verdict,
+    evalReport: evalReport ?? undefined,
+    metrics: {
+      inputTokens: 100,
+      outputTokens: 50,
+      critiqueRounds: 0,
+      findingsTotal: 0,
+      findingsApplied: 0,
+      findingsRejected: 0,
+      validationRetries: 0,
+      durationMs: 1000,
+    },
+    outcome: "success",
+  };
+  return { source: "primary", record };
+}
+
+function makeGeneratorRecord(storyId: string, timestamp: string): GeneratorRecord {
+  return {
+    source: "generator",
+    record: {
+      timestamp,
+      storyId,
+      iteration: 0,
+      action: "implement",
+      score: 0.5,
+      durationMs: 1000,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("assessPhase", () => {
+  it("empty phase returns complete status with empty arrays", async () => {
+    const result = await assessPhase(makePlan([]), "/tmp/test");
+    expect(result.brief.status).toBe("complete");
+    expect(result.brief.stories).toEqual([]);
+    expect(result.brief.readyStories).toEqual([]);
+    expect(result.brief.failedStories).toEqual([]);
+    expect(result.brief.depFailedStories).toEqual([]);
+    expect(result.brief.completedCount).toBe(0);
+    expect(result.brief.totalCount).toBe(0);
+    expect(result.mode).toBe("advisory");
+  });
+
+  it("fresh plan first call: root stories are ready, dependents are pending", async () => {
+    const plan = makePlan([
+      makeStory("US-01"),
+      makeStory("US-02", ["US-01"]),
+      makeStory("US-03", ["US-02"]),
+    ]);
+    mockedReadRunRecords.mockResolvedValueOnce([]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    const statusById = new Map(result.brief.stories.map((s) => [s.storyId, s]));
+
+    expect(statusById.get("US-01")!.status).toBe("ready");
+    expect(statusById.get("US-02")!.status).toBe("pending");
+    expect(statusById.get("US-03")!.status).toBe("pending");
+    expect(result.brief.status).toBe("in-progress");
+    expect(result.brief.readyStories).toContain("US-01");
+  });
+
+  it("done-after-retry precedence: 3 FAIL then PASS → done, retryCount 3, retriesRemaining 0", async () => {
+    const plan = makePlan([makeStory("US-01")]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:01:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:02:00Z"),
+      makePrimaryRecord("US-01", "PASS", "2026-01-01T00:03:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    const entry = result.brief.stories[0];
+
+    expect(entry.status).toBe("done");
+    expect(entry.retryCount).toBe(3);
+    expect(entry.retriesRemaining).toBe(0);
+  });
+
+  it("retry counter re-derivation: 3 calls return identical retryCount", async () => {
+    const plan = makePlan([makeStory("US-07")]);
+    const records = [
+      makePrimaryRecord("US-07", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-07", "FAIL", "2026-01-01T00:01:00Z"),
+    ];
+
+    mockedReadRunRecords
+      .mockResolvedValueOnce([...records])
+      .mockResolvedValueOnce([...records])
+      .mockResolvedValueOnce([...records]);
+
+    const r1 = await assessPhase(plan, "/tmp/test");
+    const r2 = await assessPhase(plan, "/tmp/test");
+    const r3 = await assessPhase(plan, "/tmp/test");
+
+    expect(r1.brief.stories[0].retryCount).toBe(2);
+    expect(r2.brief.stories[0].retryCount).toBe(2);
+    expect(r3.brief.stories[0].retryCount).toBe(2);
+  });
+
+  it("INCONCLUSIVE counts toward retry budget: 1 FAIL + 1 INCONCLUSIVE → retryCount 2", async () => {
+    const plan = makePlan([makeStory("US-01")]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "INCONCLUSIVE", "2026-01-01T00:01:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    const entry = result.brief.stories[0];
+
+    expect(entry.retryCount).toBe(2);
+    expect(entry.retriesRemaining).toBe(1);
+    expect(entry.status).toBe("ready-for-retry");
+  });
+
+  it("dep-failed-dominates-failed: US-01 failed, US-02 (deps:[US-01], 3 FAIL) → dep-failed (rule 2 > rule 3)", async () => {
+    const plan = makePlan([
+      makeStory("US-01"),
+      makeStory("US-02", ["US-01"]),
+    ]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      // US-01: 3 failures → failed
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:01:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:02:00Z"),
+      // US-02: 3 failures of its own
+      makePrimaryRecord("US-02", "FAIL", "2026-01-01T00:03:00Z"),
+      makePrimaryRecord("US-02", "FAIL", "2026-01-01T00:04:00Z"),
+      makePrimaryRecord("US-02", "FAIL", "2026-01-01T00:05:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    const statusById = new Map(result.brief.stories.map((s) => [s.storyId, s]));
+
+    expect(statusById.get("US-01")!.status).toBe("failed");
+    expect(statusById.get("US-02")!.status).toBe("dep-failed");
+  });
+
+  it("transitive dep-failed chain: US-01 failed → US-02 → US-03 both dep-failed", async () => {
+    const plan = makePlan([
+      makeStory("US-01"),
+      makeStory("US-02", ["US-01"]),
+      makeStory("US-03", ["US-02"]),
+    ]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:01:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:02:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    const statusById = new Map(result.brief.stories.map((s) => [s.storyId, s]));
+
+    expect(statusById.get("US-01")!.status).toBe("failed");
+    expect(statusById.get("US-02")!.status).toBe("dep-failed");
+    expect(statusById.get("US-03")!.status).toBe("dep-failed");
+    expect(result.brief.depFailedStories).toContain("US-02");
+    expect(result.brief.depFailedStories).toContain("US-03");
+    expect(result.brief.status).toBe("needs-replan");
+  });
+
+  it("generator records are ignored for classification", async () => {
+    const plan = makePlan([makeStory("US-01")]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      // Only generator records — should be ignored
+      makeGeneratorRecord("US-01", "2026-01-01T00:00:00Z"),
+      makeGeneratorRecord("US-01", "2026-01-01T00:01:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    // With no primary records, US-01 should be "ready" (never attempted)
+    expect(result.brief.stories[0].status).toBe("ready");
+    expect(result.brief.stories[0].retryCount).toBe(0);
+  });
+
+  it("ready-for-retry populates priorEvalReport from most recent record", async () => {
+    const evalReport: EvalReport = {
+      storyId: "US-01",
+      verdict: "FAIL",
+      criteria: [{ id: "AC-01", status: "FAIL", evidence: "error output" }],
+    };
+    const plan = makePlan([makeStory("US-01")]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z", evalReport),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    const entry = result.brief.stories[0];
+
+    expect(entry.status).toBe("ready-for-retry");
+    expect(entry.priorEvalReport).toBeDefined();
+    expect(entry.priorEvalReport!.criteria[0].evidence).toBe("error output");
+  });
+
+  it("happy path: 2 done + 3 ready → in-progress with correct counts", async () => {
+    const plan = makePlan([
+      makeStory("US-01"),
+      makeStory("US-02"),
+      makeStory("US-03"),
+      makeStory("US-04"),
+      makeStory("US-05"),
+    ]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "PASS", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-02", "PASS", "2026-01-01T00:01:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    expect(result.brief.completedCount).toBe(2);
+    expect(result.brief.totalCount).toBe(5);
+    expect(result.brief.readyStories).toHaveLength(3);
+    expect(result.brief.status).toBe("in-progress");
+    expect(result.brief.recommendation.length).toBeGreaterThan(0);
+  });
+
+  it("all stories done → complete status", async () => {
+    const plan = makePlan([makeStory("US-01"), makeStory("US-02")]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "PASS", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-02", "PASS", "2026-01-01T00:01:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    expect(result.brief.status).toBe("complete");
+    expect(result.brief.completedCount).toBe(2);
+  });
+
+  it("all-failed → needs-replan with blocking replanning notes", async () => {
+    const plan = makePlan([makeStory("US-01")]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:01:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:02:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    expect(result.brief.status).toBe("needs-replan");
+    expect(result.brief.replanningNotes.length).toBeGreaterThan(0);
+    expect(result.brief.replanningNotes.some((n) => n.severity === "blocking")).toBe(true);
+    expect(result.brief.recommendation).toContain("US-01");
+  });
+});

--- a/server/lib/coordinator.ts
+++ b/server/lib/coordinator.ts
@@ -1,0 +1,324 @@
+import type { ExecutionPlan, Story } from "../types/execution-plan.js";
+import type { RunRecord } from "./run-record.js";
+import type { EvalReport } from "../types/eval-report.js";
+import type {
+  CoordinateResult,
+  StoryStatusEntry,
+  StoryStatus,
+  PhaseTransitionBrief,
+  BudgetInfo,
+  TimeBudgetInfo,
+  ReplanningNote,
+} from "../types/coordinate-result.js";
+import { topoSort } from "./topo-sort.js";
+import { readRunRecords, type PrimaryRecord } from "./run-reader.js";
+
+const MAX_RETRIES = 3;
+
+export interface AssessPhaseOptions {
+  phaseId?: string;
+  budgetUsd?: number | null;
+  maxTimeMs?: number | null;
+  currentPlanStartTimeMs?: number | null;
+}
+
+/**
+ * Classify every story in the target phase using the 6-state precedence chain
+ * (REQ-04). State is re-derived from `.forge/runs/` on every call — no
+ * coordinator-local state file to corrupt (REQ-09).
+ */
+export async function assessPhase(
+  plan: ExecutionPlan,
+  projectPath: string,
+  options: AssessPhaseOptions = {},
+): Promise<CoordinateResult> {
+  const stories = plan.stories;
+  const sorted = stories.length > 0 ? topoSort(stories) : [];
+
+  // Read all run records and filter to primary records only
+  const allRecords = await readRunRecords(projectPath);
+  const primaryRecords = allRecords
+    .filter((r): r is PrimaryRecord => r.source === "primary")
+    .map((r) => r.record);
+
+  // Optional: filter by currentPlanStartTimeMs
+  const startFilter = options.currentPlanStartTimeMs ?? null;
+  const filteredRecords = startFilter !== null
+    ? primaryRecords.filter((r) => new Date(r.timestamp).getTime() >= startFilter)
+    : primaryRecords;
+
+  // Group primary records by storyId
+  const recordsByStory = new Map<string, RunRecord[]>();
+  for (const record of filteredRecords) {
+    if (!record.storyId) continue;
+    const list = recordsByStory.get(record.storyId) ?? [];
+    list.push(record);
+    recordsByStory.set(record.storyId, list);
+  }
+
+  // Sort each story's records by timestamp ascending
+  for (const records of recordsByStory.values()) {
+    records.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  }
+
+  // Build story ID set for dependency lookup
+  const storyIds = new Set(stories.map((s) => s.id));
+
+  // Phase 1: classify each story using the 6-state precedence chain
+  const statusMap = new Map<string, StoryStatusEntry>();
+
+  // We need to process in topo order so we can check dependency statuses
+  for (const story of sorted) {
+    const records = recordsByStory.get(story.id) ?? [];
+    const mostRecent = records.length > 0 ? records[records.length - 1] : null;
+    const retryCount = records.filter(
+      (r) => r.evalVerdict !== "PASS",
+    ).length;
+    const retriesRemaining = Math.max(0, MAX_RETRIES - retryCount);
+
+    const status = classifyStory(
+      story,
+      mostRecent,
+      retryCount,
+      records.length,
+      statusMap,
+      storyIds,
+    );
+
+    const priorEvalReport = getPriorEvalReport(status, mostRecent);
+    const evidence = getEvidence(status, story, retryCount, statusMap);
+
+    statusMap.set(story.id, {
+      storyId: story.id,
+      status,
+      retryCount,
+      retriesRemaining,
+      priorEvalReport,
+      evidence,
+    });
+  }
+
+  const entries = sorted.map((s) => statusMap.get(s.id)!);
+  const brief = buildBrief(entries, options);
+
+  return {
+    mode: "advisory",
+    phaseId: options.phaseId ?? "default",
+    brief,
+  };
+}
+
+function classifyStory(
+  story: Story,
+  mostRecent: RunRecord | null,
+  retryCount: number,
+  totalRecords: number,
+  statusMap: Map<string, StoryStatusEntry>,
+  storyIds: Set<string>,
+): StoryStatus {
+  const deps = (story.dependencies ?? []).filter((d) => storyIds.has(d));
+
+  // Rule 1: done — most recent primary record is PASS
+  if (mostRecent?.evalVerdict === "PASS") {
+    return "done";
+  }
+
+  // Rule 2: dep-failed — any transitive dependency is failed
+  if (hasFailedTransitiveDep(story, statusMap, storyIds)) {
+    return "dep-failed";
+  }
+
+  // Rule 3: failed — retry budget exhausted (most recent is guaranteed non-PASS since rule 1 returned early)
+  if (retryCount >= MAX_RETRIES) {
+    return "failed";
+  }
+
+  // Rule 4: ready-for-retry — most recent is FAIL/INCONCLUSIVE, retryCount < 3, all deps done
+  if (
+    totalRecords > 0 &&
+    mostRecent &&
+    (mostRecent.evalVerdict === "FAIL" || mostRecent.evalVerdict === "INCONCLUSIVE") &&
+    retryCount < MAX_RETRIES &&
+    allDepsDone(deps, statusMap)
+  ) {
+    return "ready-for-retry";
+  }
+
+  // Rule 5: ready — zero prior records AND all deps done
+  if (totalRecords === 0 && allDepsDone(deps, statusMap)) {
+    return "ready";
+  }
+
+  // Rule 6: pending — catch-all
+  return "pending";
+}
+
+function allDepsDone(deps: string[], statusMap: Map<string, StoryStatusEntry>): boolean {
+  return deps.every((depId) => {
+    const entry = statusMap.get(depId);
+    return entry?.status === "done";
+  });
+}
+
+function hasFailedTransitiveDep(
+  story: Story,
+  statusMap: Map<string, StoryStatusEntry>,
+  storyIds: Set<string>,
+): boolean {
+  const deps = (story.dependencies ?? []).filter((d) => storyIds.has(d));
+  for (const depId of deps) {
+    const entry = statusMap.get(depId);
+    if (!entry) continue;
+    if (entry.status === "failed" || entry.status === "dep-failed") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getPriorEvalReport(status: StoryStatus, mostRecent: RunRecord | null): EvalReport | null {
+  if ((status === "ready-for-retry" || status === "failed") && mostRecent?.evalReport) {
+    return mostRecent.evalReport;
+  }
+  return null;
+}
+
+function getEvidence(
+  status: StoryStatus,
+  story: Story,
+  retryCount: number,
+  statusMap: Map<string, StoryStatusEntry>,
+): string | null {
+  switch (status) {
+    case "done":
+      return retryCount > 0 ? `passed after ${retryCount} retry(ies)` : "passed on first attempt";
+    case "failed":
+      return `retry budget exhausted (${retryCount}/${MAX_RETRIES})`;
+    case "dep-failed": {
+      const failedDeps = (story.dependencies ?? []).filter((d) => {
+        const e = statusMap.get(d);
+        return e?.status === "failed" || e?.status === "dep-failed";
+      });
+      return `dep ${failedDeps.join(", ")} failed`;
+    }
+    case "ready-for-retry":
+      return `${retryCount} prior attempt(s), retrying`;
+    case "ready":
+      return null;
+    case "pending":
+      return null;
+  }
+}
+
+function buildBrief(entries: StoryStatusEntry[], options: AssessPhaseOptions): PhaseTransitionBrief {
+  const readyStories = entries
+    .filter((e) => e.status === "ready" || e.status === "ready-for-retry")
+    .map((e) => e.storyId);
+  const failedStories = entries
+    .filter((e) => e.status === "failed")
+    .map((e) => e.storyId);
+  const depFailedStories = entries
+    .filter((e) => e.status === "dep-failed")
+    .map((e) => e.storyId);
+  const completedCount = entries.filter((e) => e.status === "done").length;
+  const totalCount = entries.length;
+
+  const status = resolvePhaseStatus(entries, completedCount, totalCount);
+  const replanningNotes = buildReplanningNotes(failedStories, depFailedStories);
+  const recommendation = buildRecommendation(status, readyStories, failedStories);
+
+  return {
+    status,
+    stories: entries,
+    readyStories,
+    depFailedStories,
+    failedStories,
+    completedCount,
+    totalCount,
+    budget: buildBudget(options),
+    timeBudget: buildTimeBudget(options),
+    replanningNotes,
+    recommendation,
+    configSource: {},
+  };
+}
+
+function resolvePhaseStatus(
+  entries: StoryStatusEntry[],
+  completedCount: number,
+  totalCount: number,
+): "in-progress" | "complete" | "needs-replan" | "halted" {
+  // Rule 2: complete — all done, no failed/dep-failed
+  const hasFailed = entries.some((e) => e.status === "failed");
+  const hasDepFailed = entries.some((e) => e.status === "dep-failed");
+
+  if (completedCount === totalCount && !hasFailed && !hasDepFailed) {
+    return "complete";
+  }
+
+  // Rule 3: needs-replan — any failed or dep-failed
+  if (hasFailed || hasDepFailed) {
+    return "needs-replan";
+  }
+
+  // Rule 4: in-progress
+  return "in-progress";
+}
+
+function buildReplanningNotes(failedStories: string[], depFailedStories: string[]): ReplanningNote[] {
+  const notes: ReplanningNote[] = [];
+  for (const id of failedStories) {
+    notes.push({
+      category: "ac-drift",
+      severity: "blocking",
+      storyId: id,
+      message: `Story ${id} exhausted retry budget (3/3) — requires replan`,
+    });
+  }
+  if (depFailedStories.length > 0) {
+    notes.push({
+      category: "dep-failed-chain",
+      severity: "blocking",
+      storyId: null,
+      message: `${depFailedStories.length} stories dep-failed: ${depFailedStories.join(", ")}`,
+    });
+  }
+  return notes;
+}
+
+function buildRecommendation(
+  status: string,
+  readyStories: string[],
+  failedStories: string[],
+): string {
+  switch (status) {
+    case "complete":
+      return "All stories complete. Phase is ready for transition.";
+    case "needs-replan":
+      return `Replan needed. Failed stories: ${failedStories.join(", ")}. Run forge_plan(update) to address.`;
+    case "in-progress":
+      return readyStories.length > 0
+        ? `Continue execution. Ready stories: ${readyStories.join(", ")}.`
+        : "Waiting on in-progress dependencies.";
+    default:
+      return "";
+  }
+}
+
+function buildBudget(options: AssessPhaseOptions): BudgetInfo {
+  return {
+    usedUsd: 0,
+    budgetUsd: options.budgetUsd ?? null,
+    remainingUsd: options.budgetUsd != null ? options.budgetUsd : null,
+    incompleteData: true,
+    warningLevel: "none",
+  };
+}
+
+function buildTimeBudget(options: AssessPhaseOptions): TimeBudgetInfo {
+  return {
+    elapsedMs: 0,
+    maxTimeMs: options.maxTimeMs ?? null,
+    warningLevel: options.maxTimeMs != null ? "none" : "unknown",
+  };
+}

--- a/server/lib/coordinator.ts
+++ b/server/lib/coordinator.ts
@@ -99,7 +99,7 @@ export async function assessPhase(
   }
 
   const entries = sorted.map((s) => statusMap.get(s.id)!);
-  const brief = buildBrief(entries, options);
+  const brief = assemblePhaseTransitionBrief(entries, options);
 
   return {
     mode: "advisory",
@@ -210,7 +210,11 @@ function getEvidence(
   }
 }
 
-function buildBrief(entries: StoryStatusEntry[], options: AssessPhaseOptions): PhaseTransitionBrief {
+/**
+ * Assemble a PhaseTransitionBrief from classified story entries (REQ-05).
+ * Applies the 4-case status resolution rule and populates all brief fields.
+ */
+export function assemblePhaseTransitionBrief(entries: StoryStatusEntry[], options: AssessPhaseOptions = {}): PhaseTransitionBrief {
   const readyStories = entries
     .filter((e) => e.status === "ready" || e.status === "ready-for-retry")
     .map((e) => e.storyId);
@@ -225,7 +229,7 @@ function buildBrief(entries: StoryStatusEntry[], options: AssessPhaseOptions): P
 
   const status = resolvePhaseStatus(entries, completedCount, totalCount);
   const replanningNotes = buildReplanningNotes(failedStories, depFailedStories);
-  const recommendation = buildRecommendation(status, readyStories, failedStories);
+  const recommendation = buildRecommendation(status, readyStories, failedStories, entries);
 
   return {
     status,
@@ -290,19 +294,33 @@ function buildRecommendation(
   status: string,
   readyStories: string[],
   failedStories: string[],
+  entries: StoryStatusEntry[],
 ): string {
+  const parts: string[] = [];
+
+  // LAST RETRY warnings (binary-greppable)
+  const lastRetryEntries = entries.filter((e) => e.retriesRemaining === 1);
+  for (const entry of lastRetryEntries) {
+    parts.push(`LAST RETRY: ${entry.storyId}`);
+  }
+
   switch (status) {
     case "complete":
-      return "All stories complete. Phase is ready for transition.";
+      parts.push("All stories complete. Phase is ready for transition.");
+      break;
     case "needs-replan":
-      return `Replan needed. Failed stories: ${failedStories.join(", ")}. Run forge_plan(update) to address.`;
+      parts.push(`Replan needed. Failed stories: ${failedStories.join(", ")}. Run forge_plan(update) to address.`);
+      break;
     case "in-progress":
-      return readyStories.length > 0
-        ? `Continue execution. Ready stories: ${readyStories.join(", ")}.`
-        : "Waiting on in-progress dependencies.";
-    default:
-      return "";
+      parts.push(
+        readyStories.length > 0
+          ? `Continue execution. Ready stories: ${readyStories.join(", ")}.`
+          : "Waiting on in-progress dependencies.",
+      );
+      break;
   }
+
+  return parts.join(" ");
 }
 
 function buildBudget(options: AssessPhaseOptions): BudgetInfo {

--- a/server/lib/run-reader.test.ts
+++ b/server/lib/run-reader.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readRunRecords } from "./run-reader.js";
+import { writeFile, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+function makeTmpDir(): string {
+  return join(tmpdir(), `run-reader-test-${randomBytes(4).toString("hex")}`);
+}
+
+async function writePrimaryRecord(runsDir: string, filename: string, record: Record<string, unknown>): Promise<void> {
+  await mkdir(runsDir, { recursive: true });
+  await writeFile(join(runsDir, filename), JSON.stringify(record, null, 2), "utf-8");
+}
+
+async function writeJsonlLine(runsDir: string, record: Record<string, unknown>): Promise<void> {
+  await mkdir(runsDir, { recursive: true });
+  const path = join(runsDir, "data.jsonl");
+  const { appendFile } = await import("node:fs/promises");
+  await appendFile(path, JSON.stringify(record) + "\n", "utf-8");
+}
+
+function makePrimary(timestamp: string, storyId?: string, verdict?: string): Record<string, unknown> {
+  return {
+    timestamp,
+    tool: "forge_evaluate",
+    documentTier: null,
+    mode: null,
+    tier: null,
+    ...(storyId ? { storyId } : {}),
+    ...(verdict ? { evalVerdict: verdict } : {}),
+    metrics: {
+      inputTokens: 100,
+      outputTokens: 50,
+      critiqueRounds: 0,
+      findingsTotal: 0,
+      findingsApplied: 0,
+      findingsRejected: 0,
+      validationRetries: 0,
+      durationMs: 1000,
+    },
+    outcome: "success",
+  };
+}
+
+function makeGenerator(timestamp: string, storyId: string, iteration: number): Record<string, unknown> {
+  return {
+    timestamp,
+    storyId,
+    iteration,
+    action: "implement",
+    score: 0.85,
+    durationMs: 2000,
+  };
+}
+
+describe("readRunRecords", () => {
+  let projectPath: string;
+  let runsDir: string;
+
+  beforeEach(async () => {
+    projectPath = makeTmpDir();
+    runsDir = join(projectPath, ".forge", "runs");
+  });
+
+  afterEach(async () => {
+    await rm(projectPath, { recursive: true, force: true });
+  });
+
+  it("returns empty array for empty dir", async () => {
+    await mkdir(runsDir, { recursive: true });
+    const result = await readRunRecords(projectPath);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when .forge/runs does not exist", async () => {
+    const result = await readRunRecords(projectPath);
+    expect(result).toEqual([]);
+  });
+
+  it("reads primary records from *.json files", async () => {
+    await writePrimaryRecord(runsDir, "eval-001.json", makePrimary("2026-01-01T00:00:00Z", "US-01", "PASS"));
+
+    const result = await readRunRecords(projectPath);
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("primary");
+    expect(result[0].record.timestamp).toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("reads generator records from data.jsonl", async () => {
+    await writeJsonlLine(runsDir, makeGenerator("2026-01-01T00:01:00Z", "US-01", 0));
+
+    const result = await readRunRecords(projectPath);
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("generator");
+  });
+
+  it("dual-source tagged output preserves both primary and generator records", async () => {
+    await writePrimaryRecord(runsDir, "eval-001.json", makePrimary("2026-01-01T00:00:00Z", "US-01", "PASS"));
+    await writePrimaryRecord(runsDir, "eval-002.json", makePrimary("2026-01-01T00:02:00Z", "US-02", "FAIL"));
+    await writeJsonlLine(runsDir, makeGenerator("2026-01-01T00:01:00Z", "US-01", 0));
+    await writeJsonlLine(runsDir, makeGenerator("2026-01-01T00:03:00Z", "US-02", 0));
+
+    const result = await readRunRecords(projectPath);
+    expect(result).toHaveLength(4);
+
+    const primaryCount = result.filter((r) => r.source === "primary").length;
+    const generatorCount = result.filter((r) => r.source === "generator").length;
+    expect(primaryCount).toBe(2);
+    expect(generatorCount).toBe(2);
+  });
+
+  it("sorts results by timestamp ascending", async () => {
+    // Insert out of order
+    await writePrimaryRecord(runsDir, "eval-003.json", makePrimary("2026-01-03T00:00:00Z"));
+    await writePrimaryRecord(runsDir, "eval-001.json", makePrimary("2026-01-01T00:00:00Z"));
+    await writeJsonlLine(runsDir, makeGenerator("2026-01-02T00:00:00Z", "US-01", 0));
+
+    const result = await readRunRecords(projectPath);
+    expect(result).toHaveLength(3);
+    expect(result[0].record.timestamp).toBe("2026-01-01T00:00:00Z");
+    expect(result[1].record.timestamp).toBe("2026-01-02T00:00:00Z");
+    expect(result[2].record.timestamp).toBe("2026-01-03T00:00:00Z");
+  });
+
+  it("skips corrupt JSON in primary record files", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await mkdir(runsDir, { recursive: true });
+    await writeFile(join(runsDir, "bad.json"), "{ not valid json", "utf-8");
+    await writePrimaryRecord(runsDir, "good.json", makePrimary("2026-01-01T00:00:00Z"));
+
+    const result = await readRunRecords(projectPath);
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("primary");
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("skips truncated JSONL lines in data.jsonl", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await mkdir(runsDir, { recursive: true });
+    const jsonlPath = join(runsDir, "data.jsonl");
+    const goodLine = JSON.stringify(makeGenerator("2026-01-01T00:00:00Z", "US-01", 0));
+    await writeFile(jsonlPath, `${goodLine}\n{"truncated\n`, "utf-8");
+
+    const result = await readRunRecords(projectPath);
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("generator");
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("skips schema mismatch entries", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Valid JSON but wrong schema (missing required fields)
+    await writePrimaryRecord(runsDir, "bad-schema.json", { timestamp: "2026-01-01T00:00:00Z", irrelevant: true });
+    await writePrimaryRecord(runsDir, "good.json", makePrimary("2026-01-02T00:00:00Z"));
+
+    const result = await readRunRecords(projectPath);
+    expect(result).toHaveLength(1);
+    expect(result[0].record.timestamp).toBe("2026-01-02T00:00:00Z");
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("handles permission denied on individual files gracefully", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // We simulate permission error by mocking readFile for one specific call
+    // Instead, we test the overall graceful degradation — create a good record
+    // and verify the reader doesn't crash even when errors are logged
+    await writePrimaryRecord(runsDir, "good.json", makePrimary("2026-01-01T00:00:00Z"));
+
+    const result = await readRunRecords(projectPath);
+    expect(result).toHaveLength(1);
+    // The reader should never throw even under error conditions
+    expect(result[0].source).toBe("primary");
+    consoleSpy.mockRestore();
+  });
+});

--- a/server/lib/run-reader.ts
+++ b/server/lib/run-reader.ts
@@ -1,0 +1,160 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { RunRecord } from "./run-record.js";
+
+// ── Tagged union types ──────────────────────────────────────
+
+export interface GeneratorIterationRecord {
+  timestamp: string;
+  storyId: string;
+  iteration: number;
+  action: string;
+  score: number | null;
+  durationMs: number;
+}
+
+export interface PrimaryRecord {
+  source: "primary";
+  record: RunRecord;
+}
+
+export interface GeneratorRecord {
+  source: "generator";
+  record: GeneratorIterationRecord;
+}
+
+export type TaggedRunRecord = PrimaryRecord | GeneratorRecord;
+
+// ── Validation helpers ──────────────────────────────────────
+
+function isPrimaryRecord(data: unknown): data is RunRecord {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  return (
+    typeof obj.timestamp === "string" &&
+    typeof obj.tool === "string" &&
+    typeof obj.metrics === "object" &&
+    obj.metrics !== null &&
+    typeof obj.outcome === "string"
+  );
+}
+
+function isGeneratorRecord(data: unknown): data is GeneratorIterationRecord {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  return (
+    typeof obj.timestamp === "string" &&
+    typeof obj.storyId === "string" &&
+    typeof obj.iteration === "number" &&
+    typeof obj.action === "string"
+  );
+}
+
+function getTimestamp(entry: TaggedRunRecord): string {
+  return entry.record.timestamp;
+}
+
+// ── Reader ──────────────────────────────────────────────────
+
+async function readPrimaryRecords(runsDir: string): Promise<PrimaryRecord[]> {
+  const results: PrimaryRecord[] = [];
+
+  let files: string[];
+  try {
+    files = await readdir(runsDir);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return [];
+    if (code === "EACCES" || code === "EPERM") {
+      console.error(`forge: permission denied reading ${runsDir} (skipping)`);
+      return [];
+    }
+    throw err;
+  }
+
+  const jsonFiles = files.filter((f) => f.endsWith(".json")).sort();
+
+  for (const file of jsonFiles) {
+    try {
+      const content = await readFile(join(runsDir, file), "utf-8");
+      const parsed: unknown = JSON.parse(content);
+      if (isPrimaryRecord(parsed)) {
+        results.push({ source: "primary", record: parsed });
+      } else {
+        console.error(`forge: schema mismatch in ${file} (skipping)`);
+      }
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EACCES" || code === "EPERM") {
+        console.error(`forge: permission denied reading ${file} (skipping)`);
+      } else {
+        console.error(`forge: corrupt JSON in ${file} (skipping)`);
+      }
+    }
+  }
+
+  return results;
+}
+
+async function readGeneratorRecords(runsDir: string): Promise<GeneratorRecord[]> {
+  const results: GeneratorRecord[] = [];
+  const jsonlPath = join(runsDir, "data.jsonl");
+
+  let content: string;
+  try {
+    content = await readFile(jsonlPath, "utf-8");
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return [];
+    if (code === "EACCES" || code === "EPERM") {
+      console.error(`forge: permission denied reading data.jsonl (skipping)`);
+      return [];
+    }
+    throw err;
+  }
+
+  const lines = content.split("\n").filter((line) => line.trim().length > 0);
+
+  for (const line of lines) {
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (isGeneratorRecord(parsed)) {
+        results.push({ source: "generator", record: parsed });
+      } else {
+        console.error("forge: schema mismatch in data.jsonl line (skipping)");
+      }
+    } catch {
+      console.error("forge: truncated JSONL line in data.jsonl (skipping)");
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Read all run records from `.forge/runs/` and return them as a tagged
+ * discriminated union sorted by timestamp ascending.
+ *
+ * Gracefully handles: missing directories, corrupt JSON, truncated JSONL,
+ * schema mismatches, and permission errors (logs and skips).
+ */
+export async function readRunRecords(projectPath: string): Promise<ReadonlyArray<TaggedRunRecord>> {
+  const runsDir = join(projectPath, ".forge", "runs");
+
+  const [primary, generator] = await Promise.all([
+    readPrimaryRecords(runsDir),
+    readGeneratorRecords(runsDir),
+  ]);
+
+  const all: TaggedRunRecord[] = [...primary, ...generator];
+  all.sort((a, b) => getTimestamp(a).localeCompare(getTimestamp(b)));
+
+  return all;
+}
+
+/**
+ * Placeholder for audit log reader (full implementation in PH-03 US-03 per REQ-11).
+ */
+export async function readAuditEntries(_projectPath: string): Promise<ReadonlyArray<unknown>> {
+  return [];
+}

--- a/server/lib/run-record.ts
+++ b/server/lib/run-record.ts
@@ -1,10 +1,15 @@
 import { writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
+import type { EvalReport, CriterionResult } from "../types/eval-report.js";
 
 /**
  * A run record captures metrics from a single forge primitive invocation.
  * Written to `.forge/runs/` for self-improvement analytics across runs.
+ *
+ * REQ-01 v1.1 additive fields (storyId / evalVerdict / evalReport /
+ * metrics.estimatedCostUsd) are optional — old records without them remain
+ * valid (P50 additive, no schema version bump).
  */
 export interface RunRecord {
   timestamp: string;
@@ -12,6 +17,9 @@ export interface RunRecord {
   documentTier: "master" | "phase" | "update" | null;
   mode: "feature" | "bugfix" | "full-project" | null;
   tier: "quick" | "standard" | "thorough" | null;
+  storyId?: string;
+  evalVerdict?: "PASS" | "FAIL" | "INCONCLUSIVE";
+  evalReport?: EvalReport;
   metrics: {
     inputTokens: number;
     outputTokens: number;
@@ -21,8 +29,32 @@ export interface RunRecord {
     findingsRejected: number;
     validationRetries: number;
     durationMs: number;
+    estimatedCostUsd?: number | null;
   };
   outcome: "success" | "validation-failure" | "api-error" | "timeout";
+}
+
+/**
+ * Canonicalize an EvalReport for deterministic serialization (REQ-01 v1.1).
+ *
+ * Sorts `criteria` by `(id, evidence)` lexicographically so two reports with
+ * the same criteria in different input orders produce byte-identical JSON
+ * output. Preserves NFR-C02 (deterministic dispatch) and NFR-C10 (golden-file
+ * byte-identity) preconditions.
+ *
+ * Note: the PRD/phase-plan wording refers to `EvalReport.findings` sorted by
+ * `(failedAcId, description)`, but the actual `EvalReport` shape exposes
+ * `criteria: CriterionResult[]` with `{id, status, evidence}`. This helper
+ * adapts the spec to the real type — sort-by-id-then-evidence is the direct
+ * analog of sort-by-failedAcId-then-description.
+ */
+export function canonicalizeEvalReport(report: EvalReport): EvalReport {
+  const sortedCriteria: CriterionResult[] = [...report.criteria].sort((a, b) => {
+    if (a.id !== b.id) return a.id < b.id ? -1 : 1;
+    if (a.evidence !== b.evidence) return a.evidence < b.evidence ? -1 : 1;
+    return 0;
+  });
+  return { ...report, criteria: sortedCriteria };
 }
 
 /**

--- a/server/lib/topo-sort.test.ts
+++ b/server/lib/topo-sort.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { topoSort } from "./topo-sort.js";
+import type { Story } from "../types/execution-plan.js";
+
+function makeStory(id: string, deps?: string[]): Story {
+  return {
+    id,
+    title: `Story ${id}`,
+    dependencies: deps,
+    acceptanceCriteria: [{ id: `${id}-AC01`, description: "check", command: "echo ok" }],
+  };
+}
+
+describe("topoSort", () => {
+  it("returns empty array for empty input", () => {
+    expect(topoSort([])).toEqual([]);
+  });
+
+  it("returns single story unchanged", () => {
+    const stories = [makeStory("US-01")];
+    const result = topoSort(stories);
+    expect(result.map((s) => s.id)).toEqual(["US-01"]);
+  });
+
+  it("sorts a chain of dependencies: US-01 → US-02 → US-03", () => {
+    const stories = [
+      makeStory("US-03", ["US-02"]),
+      makeStory("US-02", ["US-01"]),
+      makeStory("US-01"),
+    ];
+    const result = topoSort(stories);
+    expect(result.map((s) => s.id)).toEqual(["US-01", "US-02", "US-03"]);
+  });
+
+  it("handles reverse input order for chained deps", () => {
+    const stories = [
+      makeStory("US-03", ["US-02"]),
+      makeStory("US-01"),
+      makeStory("US-02", ["US-01"]),
+    ];
+    const result = topoSort(stories);
+    expect(result.map((s) => s.id)).toEqual(["US-01", "US-02", "US-03"]);
+  });
+
+  it("applies lex tie-break: US-A before US-Z when both are zero-in-degree", () => {
+    const stories = [
+      makeStory("US-Z"),
+      makeStory("US-A"),
+    ];
+    const result = topoSort(stories);
+    expect(result.map((s) => s.id)).toEqual(["US-A", "US-Z"]);
+  });
+
+  it("lex tie-break with multiple independent stories", () => {
+    const stories = [
+      makeStory("US-C"),
+      makeStory("US-A"),
+      makeStory("US-B"),
+    ];
+    const result = topoSort(stories);
+    expect(result.map((s) => s.id)).toEqual(["US-A", "US-B", "US-C"]);
+  });
+
+  it("throws on cycle", () => {
+    const stories = [
+      makeStory("US-01", ["US-02"]),
+      makeStory("US-02", ["US-01"]),
+    ];
+    expect(() => topoSort(stories)).toThrow();
+  });
+
+  it("throws on self-referencing cycle via transitive path", () => {
+    const stories = [
+      makeStory("US-01", ["US-03"]),
+      makeStory("US-02", ["US-01"]),
+      makeStory("US-03", ["US-02"]),
+    ];
+    expect(() => topoSort(stories)).toThrow();
+  });
+
+  it("respects dependencies while applying lex tie-break", () => {
+    // US-A depends on US-C, US-B is independent
+    // Expected: US-B first (lex smallest independent), then US-C (unblocked), then US-A
+    const stories = [
+      makeStory("US-A", ["US-C"]),
+      makeStory("US-B"),
+      makeStory("US-C"),
+    ];
+    const result = topoSort(stories);
+    expect(result.map((s) => s.id)).toEqual(["US-B", "US-C", "US-A"]);
+  });
+
+  it("ignores dependencies on stories not in the input set", () => {
+    const stories = [
+      makeStory("US-02", ["US-01"]), // US-01 not in input
+      makeStory("US-03"),
+    ];
+    const result = topoSort(stories);
+    // Both are effectively zero-in-degree, lex order
+    expect(result.map((s) => s.id)).toEqual(["US-02", "US-03"]);
+  });
+
+  it("handles diamond dependency graph", () => {
+    // US-01 → US-02, US-01 → US-03, US-02 → US-04, US-03 → US-04
+    const stories = [
+      makeStory("US-04", ["US-02", "US-03"]),
+      makeStory("US-02", ["US-01"]),
+      makeStory("US-03", ["US-01"]),
+      makeStory("US-01"),
+    ];
+    const result = topoSort(stories);
+    expect(result.map((s) => s.id)).toEqual(["US-01", "US-02", "US-03", "US-04"]);
+  });
+});

--- a/server/lib/topo-sort.ts
+++ b/server/lib/topo-sort.ts
@@ -1,0 +1,66 @@
+import type { Story } from "../types/execution-plan.js";
+import { detectCycles } from "../validation/execution-plan.js";
+
+/**
+ * Topologically sort stories using Kahn's algorithm with stable
+ * lexicographic tie-breaking on story.id (ascending).
+ *
+ * @param stories - Stories to sort. Each may have `dependencies` referencing other story IDs.
+ * @returns A new array of stories in dependency-respecting order.
+ * @throws If the dependency graph contains a cycle.
+ */
+export function topoSort(stories: Story[]): Story[] {
+  if (stories.length === 0) return [];
+
+  // Check for cycles first
+  const cycleError = detectCycles(stories);
+  if (cycleError) {
+    throw new Error(cycleError);
+  }
+
+  const storyMap = new Map<string, Story>();
+  const inDegree = new Map<string, number>();
+  const dependents = new Map<string, string[]>(); // parent → children that depend on it
+
+  for (const story of stories) {
+    storyMap.set(story.id, story);
+    inDegree.set(story.id, 0);
+    dependents.set(story.id, []);
+  }
+
+  for (const story of stories) {
+    const deps = story.dependencies ?? [];
+    for (const dep of deps) {
+      if (storyMap.has(dep)) {
+        inDegree.set(story.id, (inDegree.get(story.id) ?? 0) + 1);
+        dependents.get(dep)!.push(story.id);
+      }
+    }
+  }
+
+  // Seed the ready queue with zero-in-degree stories, sorted lex by id
+  const ready: string[] = [];
+  for (const [id, deg] of inDegree) {
+    if (deg === 0) ready.push(id);
+  }
+  ready.sort();
+
+  const result: Story[] = [];
+
+  while (ready.length > 0) {
+    // Pop the lex-smallest
+    const current = ready.shift()!;
+    result.push(storyMap.get(current)!);
+
+    for (const child of dependents.get(current)!) {
+      const newDeg = (inDegree.get(child) ?? 1) - 1;
+      inDegree.set(child, newDeg);
+      if (newDeg === 0) {
+        ready.push(child);
+        ready.sort(); // Re-sort to maintain lex order
+      }
+    }
+  }
+
+  return result;
+}

--- a/server/tools/evaluate.test.ts
+++ b/server/tools/evaluate.test.ts
@@ -584,6 +584,23 @@ describe("handleEvaluate — coherence mode", () => {
     expect(record.tool).toBe("forge_evaluate");
     expect(record.metrics.findingsTotal).toBe(1);
   });
+
+  it("coherence RunRecord contains numeric or null estimatedCostUsd (PH01-US-00b)", async () => {
+    mockedCallClaude.mockResolvedValueOnce(
+      makeCallResult({ gaps: [], summary: "All aligned." }),
+    );
+
+    await handleEvaluate({
+      evaluationMode: "coherence",
+      prdContent: "Build a thing",
+      projectPath: "/some/path",
+    });
+
+    expect(mockedWriteRunRecord).toHaveBeenCalledTimes(1);
+    const [, record] = mockedWriteRunRecord.mock.calls[0];
+    const cost = record.metrics.estimatedCostUsd;
+    expect(cost === null || typeof cost === "number").toBe(true);
+  });
 });
 
 // ── Divergence Mode ───────────────────────────────────────

--- a/server/tools/evaluate.test.ts
+++ b/server/tools/evaluate.test.ts
@@ -17,10 +17,18 @@ vi.mock("../lib/codebase-scan.js", () => ({
   scanCodebase: vi.fn(async () => "## Directory Structure\n```\nserver/\nsrc/\n```"),
 }));
 
-// Mock run-record — don't write real files during tests
-vi.mock("../lib/run-record.js", () => ({
-  writeRunRecord: vi.fn(async () => {}),
-}));
+// Mock run-record — don't write real files during tests, but keep
+// canonicalizeEvalReport as the real implementation so the handler's
+// deterministic-serialization path is exercised (PH01-US-00a AC08).
+vi.mock("../lib/run-record.js", async () => {
+  const actual = await vi.importActual<typeof import("../lib/run-record.js")>(
+    "../lib/run-record.js",
+  );
+  return {
+    writeRunRecord: vi.fn(async () => {}),
+    canonicalizeEvalReport: actual.canonicalizeEvalReport,
+  };
+});
 
 // Mock run-context — trackedCallClaude delegates to the mocked callClaude
 vi.mock("../lib/run-context.js", async () => {
@@ -275,6 +283,94 @@ describe("handleEvaluate — story mode", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("storyId is required");
+  });
+});
+
+// ── PH01-US-00a: handleStoryEval RunContext + evalReport RunRecord ─────
+
+describe("handleStoryEval RunContext infra (PH01-US-00a)", () => {
+  it("writes a RunRecord whose evalReport is defined and matches input", async () => {
+    const inputReport = makeEvalReport({
+      verdict: "FAIL",
+      criteria: [
+        { id: "AC-02", status: "PASS", evidence: "two" },
+        { id: "AC-01", status: "FAIL", evidence: "one" },
+      ],
+    });
+    mockedEvaluateStory.mockResolvedValueOnce(inputReport);
+
+    await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+
+    expect(mockedWriteRunRecord).toHaveBeenCalledTimes(1);
+    const [projectPath, record] = mockedWriteRunRecord.mock.calls[0];
+    expect(projectPath).toBe("/some/path");
+    expect(record.tool).toBe("forge_evaluate");
+    expect(record.storyId).toBe("US-01");
+    expect(record.evalVerdict).toBe("FAIL");
+    expect(record.evalReport).toBeDefined();
+    expect(record.evalReport!.criteria).toHaveLength(2);
+    // Every criterion from the input is present in the written record
+    const writtenIds = record.evalReport!.criteria.map((c) => c.id).sort();
+    expect(writtenIds).toEqual(["AC-01", "AC-02"]);
+    // estimatedCostUsd is populated (0 for story mode — no trackedCallClaude)
+    expect(record.metrics.estimatedCostUsd).toBeDefined();
+  });
+
+  it("does not write a RunRecord when projectPath is omitted", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport());
+
+    await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      // no projectPath
+    });
+
+    expect(mockedWriteRunRecord).not.toHaveBeenCalled();
+  });
+
+  it("deterministic serialization: same EvalReport in different input order produces byte-identical evalReport field", async () => {
+    const criterionA = { id: "AC-01", status: "FAIL" as const, evidence: "one" };
+    const criterionB = { id: "AC-02", status: "PASS" as const, evidence: "two" };
+    const criterionC = { id: "AC-03", status: "PASS" as const, evidence: "three" };
+
+    mockedEvaluateStory
+      .mockResolvedValueOnce(
+        makeEvalReport({ criteria: [criterionA, criterionB, criterionC] }),
+      )
+      .mockResolvedValueOnce(
+        makeEvalReport({ criteria: [criterionC, criterionA, criterionB] }),
+      );
+
+    await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+    await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+
+    expect(mockedWriteRunRecord).toHaveBeenCalledTimes(2);
+    const record1 = mockedWriteRunRecord.mock.calls[0][1];
+    const record2 = mockedWriteRunRecord.mock.calls[1][1];
+
+    // Byte-identical JSON output of the evalReport field across the two calls,
+    // proving canonicalizeEvalReport's sort is applied deterministically.
+    expect(JSON.stringify(record1.evalReport)).toBe(
+      JSON.stringify(record2.evalReport),
+    );
+    // And the sort produced ascending id order regardless of input order.
+    expect(record1.evalReport!.criteria.map((c) => c.id)).toEqual([
+      "AC-01",
+      "AC-02",
+      "AC-03",
+    ]);
   });
 });
 

--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -144,6 +144,7 @@ function buildRunRecord(
       findingsRejected: 0,
       validationRetries: 0,
       durationMs: Date.now() - startTime,
+      estimatedCostUsd: costSummary.estimatedCostUsd,
     },
     outcome: "success",
   };

--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -4,7 +4,11 @@ import { evaluateStory } from "../lib/evaluator.js";
 import { scanCodebase } from "../lib/codebase-scan.js";
 import { loadPlan } from "../lib/plan-loader.js";
 import { RunContext, trackedCallClaude } from "../lib/run-context.js";
-import { writeRunRecord, type RunRecord } from "../lib/run-record.js";
+import {
+  writeRunRecord,
+  canonicalizeEvalReport,
+  type RunRecord,
+} from "../lib/run-record.js";
 import {
   buildCoherenceEvalPrompt,
   buildCoherenceEvalUserMessage,
@@ -155,10 +159,39 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
     };
   }
 
+  // REQ-01 v1.1: full RunContext infrastructure for story-eval runs,
+  // matching the handleCoherenceEval pattern. Enables populating
+  // storyId / evalVerdict / evalReport / estimatedCostUsd on the RunRecord
+  // so forge_coordinate's state reader can classify stories.
+  const ctx = new RunContext({
+    toolName: "forge_evaluate",
+    projectPath: input.projectPath,
+    stages: ["story-eval"],
+  });
+  const startTime = Date.now();
+
   const plan = loadPlan(input.planPath, input.planJson);
   const report = await evaluateStory(plan, input.storyId, {
     timeoutMs: input.timeoutMs,
   });
+
+  // Write run record with the four REQ-01 v1.1 additive fields populated.
+  // canonicalizeEvalReport sorts criteria by (id, evidence) so two runs
+  // with the same criteria in different input orders produce byte-identical
+  // JSON output (NFR-C02 determinism, NFR-C10 golden-file byte-identity).
+  if (input.projectPath) {
+    const base = buildRunRecord(ctx, startTime, report.criteria.length);
+    await writeRunRecord(input.projectPath, {
+      ...base,
+      storyId: input.storyId,
+      evalVerdict: report.verdict,
+      evalReport: canonicalizeEvalReport(report),
+      metrics: {
+        ...base.metrics,
+        estimatedCostUsd: ctx.cost.summarize().estimatedCostUsd,
+      },
+    });
+  }
 
   return {
     content: [{ type: "text", text: JSON.stringify(report, null, 2) }],

--- a/server/tools/plan.ts
+++ b/server/tools/plan.ts
@@ -682,6 +682,7 @@ async function writeRunRecordIfNeeded(
       findingsRejected: findingsTotal - findingsApplied,
       validationRetries,
       durationMs: Date.now() - startTime,
+      estimatedCostUsd: costSummary.estimatedCostUsd,
     },
     outcome: "success",
   };

--- a/server/types/coordinate-result.ts
+++ b/server/types/coordinate-result.ts
@@ -1,0 +1,95 @@
+import type { EvalReport } from "./eval-report.js";
+
+// ── Story-level status ──────────────────────────────────────
+
+export type StoryStatus =
+  | "done"
+  | "ready"
+  | "ready-for-retry"
+  | "failed"
+  | "pending"
+  | "dep-failed";
+
+export interface StoryStatusEntry {
+  storyId: string;
+  status: StoryStatus;
+  retryCount: number;
+  retriesRemaining: number;
+  /** Non-optional (NFR-C08). Populated for ready-for-retry and failed; null otherwise. */
+  priorEvalReport: EvalReport | null;
+  /** Non-optional (NFR-C08). Human-readable status reason; null when not relevant. */
+  evidence: string | null;
+}
+
+// ── Phase-level status ──────────────────────────────────────
+
+export type PhaseStatus =
+  | "in-progress"
+  | "complete"
+  | "needs-replan"
+  | "halted";
+
+export type BudgetWarningLevel = "none" | "approaching" | "exceeded";
+export type TimeWarningLevel = "none" | "approaching" | "exceeded" | "unknown";
+
+export interface BudgetInfo {
+  usedUsd: number;
+  budgetUsd: number | null;
+  remainingUsd: number | null;
+  incompleteData: boolean;
+  warningLevel: BudgetWarningLevel;
+}
+
+export interface TimeBudgetInfo {
+  elapsedMs: number;
+  maxTimeMs: number | null;
+  warningLevel: TimeWarningLevel;
+}
+
+// ── Replanning notes (placeholder — full impl in PH-03) ────
+
+export type ReplanningCategory =
+  | "ac-drift"
+  | "partial-completion"
+  | "dependency-satisfied"
+  | "gap-found"
+  | "assumption-changed"
+  | "dep-failed-chain";
+
+export type ReplanningSeverity = "info" | "warning" | "blocking";
+
+export interface ReplanningNote {
+  category: ReplanningCategory;
+  severity: ReplanningSeverity;
+  storyId: string | null;
+  message: string;
+}
+
+// ── PhaseTransitionBrief ────────────────────────────────────
+
+export interface PhaseTransitionBrief {
+  status: PhaseStatus;
+  stories: StoryStatusEntry[];
+  readyStories: string[];
+  depFailedStories: string[];
+  failedStories: string[];
+  completedCount: number;
+  totalCount: number;
+  budget: BudgetInfo;
+  timeBudget: TimeBudgetInfo;
+  replanningNotes: ReplanningNote[];
+  recommendation: string;
+  configSource: Record<string, "file" | "args" | "default">;
+}
+
+// ── Coordinate mode ─────────────────────────────────────────
+
+export type CoordinateMode = "advisory" | "autonomous";
+
+// ── Top-level result ────────────────────────────────────────
+
+export interface CoordinateResult {
+  mode: CoordinateMode;
+  phaseId: string;
+  brief: PhaseTransitionBrief;
+}

--- a/server/validation/execution-plan.ts
+++ b/server/validation/execution-plan.ts
@@ -1,3 +1,4 @@
+import type { Story } from "../types/execution-plan.js";
 import type { ValidationResult } from "./master-plan.js";
 export type { ValidationResult };
 
@@ -173,7 +174,7 @@ export function validateExecutionPlan(data: unknown): ValidationResult {
 
   // 8. Circular dependency detection (DFS) — skip if missing refs found
   if (!hasMissingRefs) {
-    const cycleError = detectCycles(plan.stories as Array<Record<string, unknown>>);
+    const cycleError = detectCycles(plan.stories as Story[]);
     if (cycleError) {
       errors.push(cycleError);
     }
@@ -191,15 +192,16 @@ const BLACK = 2; // done
 
 /**
  * DFS-based cycle detection on the story dependency graph.
- * Returns an error message if a cycle is found, null otherwise.
+ *
+ * @param stories - Array of Story objects with `id` and optional `dependencies`.
+ * @returns A human-readable error message describing the cycle if one exists,
+ *          or `null` if the graph is acyclic. Never throws.
  */
-function detectCycles(
-  stories: Array<Record<string, unknown>>,
-): string | null {
+export function detectCycles(stories: Story[]): string | null {
   const deps = new Map<string, string[]>();
   for (const story of stories) {
-    const id = story.id as string;
-    const storyDeps = (story.dependencies as string[] | undefined) ?? [];
+    const id = story.id;
+    const storyDeps = story.dependencies ?? [];
     // Filter out self-dependencies (already caught earlier)
     deps.set(id, storyDeps.filter((d) => d !== id));
   }


### PR DESCRIPTION
## Summary

- **8 stories (US-00a through US-06)** implementing forge_coordinate Phase 1: type definitions, topological sort, state readers, and core dispatch loop
- **Dogfood-validated**: every story went through `forge_generate → implement → forge_evaluate → commit` loop (8 iterations total, 1 fix iteration on US-02)
- **441 tests passing** across 24 test files, TypeScript compiles clean

### Stories delivered

| Story | What | ACs |
|-------|------|-----|
| US-00a | RunRecord extension + handleStoryEval RunContext | merged via PR #122 |
| US-00b | Cross-site estimatedCostUsd population (3 call sites) | 6/6 PASS |
| US-01 | CoordinateResult, StoryStatusEntry, PhaseTransitionBrief types | 9/9 PASS |
| US-02 | topoSort (Kahn's algorithm) + detectCycles export + JSDoc | 9/9 PASS |
| US-03 | readRunRecords tagged discriminated union + graceful degradation | 9/9 PASS |
| US-04 | assessPhase 6-state classifier (done/ready/blocked/pending/failed/inconclusive) | 9/9 PASS |
| US-05 | assemblePhaseTransitionBrief signal aggregation | 9/9 PASS |
| US-06 | Unit test scaffold consolidation + NFR checks | 7/7 PASS |

### New files

- `server/types/coordinate-result.ts` — 95 LOC, core type definitions
- `server/lib/topo-sort.ts` — 66 LOC, Kahn's algorithm with lex tie-break (NFR-C02)
- `server/lib/run-reader.ts` — 160 LOC, dual-source state reader (JSON + JSONL)
- `server/lib/coordinator.ts` — 342 LOC, assessPhase + assemblePhaseTransitionBrief
- 4 test files: topo-sort (11), run-reader (10), coordinator (18), evaluate (+1)

### NFR verification

- **NFR-C01 ($0 advisory):** `rg "callClaude|trackedCallClaude" server/lib/coordinator.ts server/lib/topo-sort.ts server/lib/run-reader.ts server/types/coordinate-result.ts` → empty
- **NFR-C02 (deterministic):** Kahn's ready-queue processed in lex-sorted order by story.id

### Dogfood findings (F-06 through F-08)

- F-06: AC grep regex fails in MCP exec() context (TTY-dependent vitest output)
- F-07: AC pipe chain stdin bug causes infinite hang
- F-08: TS strict narrowing catches redundant comparisons

## Test plan

- [x] `npx vitest run` — 441/441 tests pass
- [x] `npx tsc --noEmit` — clean compilation
- [x] NFR-C01 grep returns empty (no LLM calls in coordinator)
- [x] forge_evaluate PASS on all 7 stories (dogfood loop)