### PR TITLE
feat(generator): persist GenerationBrief to .forge/runs/briefs/

### DIFF
--- a/server/lib/generator.test.ts
+++ b/server/lib/generator.test.ts
@@ -12,6 +12,7 @@ import {
   buildEscalation,
   assembleGenerateResult,
   assembleGenerateResultWithContext,
+  persistGenerateBrief,
 } from "./generator.js";
 import type { EvalReport, CriterionResult } from "../types/eval-report.js";
 import type { ExecutionPlan } from "../types/execution-plan.js";
@@ -962,5 +963,89 @@ describe("PH03-US03: lineage pass-through from plan to brief", () => {
       tier: "phase-plan",
       sourceId: "PH-01",
     });
+  });
+});
+
+// ── Brief persistence ─────────────────────────
+
+describe("persistGenerateBrief", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "brief-persist-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes brief to .forge/runs/briefs/ with storyId and iteration in filename", async () => {
+    const result: GenerateResult = {
+      action: "implement",
+      storyId: "US-01",
+      iteration: 0,
+      maxIterations: 3,
+      brief: {
+        story: {
+          id: "US-01",
+          title: "Test story",
+          acceptanceCriteria: [{ id: "AC-01", description: "check", command: "echo ok" }],
+        },
+        codebaseContext: "some context",
+        gitBranch: "feat/US-01",
+        baselineCheck: "npm test",
+      },
+    };
+
+    await persistGenerateBrief(tmpDir, result);
+
+    const briefsDir = join(tmpDir, ".forge", "runs", "briefs");
+    const files = await readdir(briefsDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^US-01-iter0-/);
+    expect(files[0]).toMatch(/\.json$/);
+
+    const content = JSON.parse(await readFile(join(briefsDir, files[0]), "utf-8"));
+    expect(content.storyId).toBe("US-01");
+    expect(content.action).toBe("implement");
+    expect(content.brief.story.id).toBe("US-01");
+  });
+
+  it("no-ops when projectPath is undefined", async () => {
+    const result: GenerateResult = {
+      action: "implement",
+      storyId: "US-01",
+      iteration: 0,
+      maxIterations: 3,
+    };
+
+    // Should not throw
+    await persistGenerateBrief(undefined, result);
+  });
+
+  it("persists fix briefs with iteration > 0", async () => {
+    const result: GenerateResult = {
+      action: "fix",
+      storyId: "US-02",
+      iteration: 2,
+      maxIterations: 3,
+      fixBrief: {
+        failedCriteria: [{ id: "AC-01", description: "check", evidence: "failed" }],
+        score: 0.5,
+        evalHint: { failFastIds: ["AC-01"] },
+        guidance: "Fix the test",
+      },
+    };
+
+    await persistGenerateBrief(tmpDir, result);
+
+    const briefsDir = join(tmpDir, ".forge", "runs", "briefs");
+    const files = await readdir(briefsDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^US-02-iter2-/);
+
+    const content = JSON.parse(await readFile(join(briefsDir, files[0]), "utf-8"));
+    expect(content.action).toBe("fix");
+    expect(content.fixBrief.guidance).toBe("Fix the test");
   });
 });

--- a/server/lib/generator.ts
+++ b/server/lib/generator.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { scanCodebase } from "./codebase-scan.js";
 import { loadPlan } from "./plan-loader.js";
@@ -454,6 +454,16 @@ export async function assembleGenerateResultWithContext(
     );
   }
 
+  // Persist full brief to .forge/runs/briefs/ (NFR-05: graceful)
+  try {
+    await persistGenerateBrief(input.projectPath, result);
+  } catch (err) {
+    console.error(
+      "forge_generate: brief persistence failed (continuing):",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
   return result;
 }
 
@@ -481,6 +491,32 @@ export async function appendGeneratorIterationRecord(
   await mkdir(runsDir, { recursive: true });
   const filePath = join(runsDir, "data.jsonl");
   await appendFile(filePath, JSON.stringify(record) + "\n", "utf-8");
+}
+
+/**
+ * Persist the full GenerateResult (brief or fix brief) to
+ * `.forge/runs/briefs/{storyId}-iter{N}.json`.
+ *
+ * This captures the complete input side of the dogfood loop so that
+ * future sessions can analyze brief quality, affected-path accuracy,
+ * and fix guidance effectiveness without re-running forge_generate.
+ *
+ * No-op when projectPath is undefined. Failures are swallowed (NFR-05).
+ */
+export async function persistGenerateBrief(
+  projectPath: string | undefined,
+  result: GenerateResult,
+): Promise<void> {
+  if (!projectPath) return;
+
+  const briefsDir = join(projectPath, ".forge", "runs", "briefs");
+  await mkdir(briefsDir, { recursive: true });
+
+  const safeDateStr = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `${result.storyId}-iter${result.iteration}-${safeDateStr}.json`;
+  const filePath = join(briefsDir, filename);
+
+  await writeFile(filePath, JSON.stringify(result, null, 2), "utf-8");
 }
 
 // ── PH-02 US03: Cost estimation ─────────────


### PR DESCRIPTION
## Summary

- Add `persistGenerateBrief()` to `server/lib/generator.ts` — writes the full `GenerateResult` (init brief, fix brief, or escalation) to `.forge/runs/briefs/{storyId}-iter{N}.json` after each `forge_generate` call
- Completes the dogfood data pipeline: `forge_generate` now persists the **input side** (briefs), paired with `forge_evaluate`'s existing RunRecords (**output side**), giving every generate→evaluate iteration full on-disk traceability
- No-op when `projectPath` is undefined; failures swallowed per NFR-05

### Why this matters

During the PH-01 dogfood redo, we discovered that forge_generate's JSONL record (`data.jsonl`) captures only `{timestamp, storyId, iteration, action, score, durationMs}` — the actual GenerationBrief content was returned in the MCP response and lost with the session. This means brief quality analysis (did it identify the right files? was the approach correct?) required re-running forge_generate, which isn't reproducible across sessions.

### Data flow after this change

```
forge_generate call
  ├─ .forge/runs/data.jsonl          (existing: minimal JSONL record)
  ├─ .forge/runs/briefs/US-01-iter0-*.json  (NEW: full GenerateResult)
  └─ MCP response to caller          (ephemeral)

forge_evaluate call (with projectPath)
  ├─ .forge/runs/forge_evaluate-*.json  (existing: RunRecord with evalReport)
  └─ MCP response to caller             (ephemeral)
```

## Test plan

- [x] `persistGenerateBrief` writes to `.forge/runs/briefs/` with correct filename pattern
- [x] No-op when `projectPath` is undefined
- [x] Fix briefs (iteration > 0) persist correctly
- [x] Full test suite: 444/444 pass
- [x] TypeScript compilation: clean