### PR TITLE
chore(plan): add AC subprocess contract to forge_plan prompt

### DIFF
--- a/.ai-workspace/plans/forge-coordinate-phase-PH-04.json
+++ b/.ai-workspace/plans/forge-coordinate-phase-PH-04.json
@@ -151,7 +151,7 @@
         {
           "id": "PH04-US-03-AC01",
           "description": "coordinate.test.ts has at least 17 passing integration tests",
-          "command": "npx vitest run server/tools/coordinate.test.ts 2>&1 | grep -qE 'Tests[[:space:]]+1[7-9]|Tests[[:space:]]+[2-9][0-9]'"
+          "command": "OUT=$(npx vitest run server/tools/coordinate.test.ts 2>&1); echo \"$OUT\" | grep -qE '1[7-9] passed|[2-9][0-9] passed'"
         },
         {
           "id": "PH04-US-03-AC02",
@@ -186,7 +186,7 @@
         {
           "id": "PH04-US-03-AC08",
           "description": "Full test suite green",
-          "command": "npx vitest run 2>&1 | grep -q 'passed' && ! grep -q 'failed'"
+          "command": "OUT=$(npx vitest run 2>&1); echo \"$OUT\" | grep -q 'passed' && ! echo \"$OUT\" | grep -qE '[0-9]+ failed'"
         }
       ],
       "affectedPaths": ["server/tools/coordinate.test.ts", ".github/workflows/"]

--- a/server/lib/prompts/planner.ts
+++ b/server/lib/prompts/planner.ts
@@ -269,6 +269,19 @@ Respond with ONLY a JSON object matching this exact schema (execution-plan v3.0.
   the command must include the build step as a prerequisite (e.g., \`npm run build && node ...\`).
   Without this, the AC fails in a clean environment where the build output doesn't exist.
 
+### AC Command Contract
+AC commands execute inside node:child_process.exec() with bash shell.
+Environment: no TTY, no stdin, stdout/stderr captured as evidence, 30s timeout.
+Exit code 0 = PASS, non-zero = FAIL. Design commands accordingly:
+- Prefer exit-code checks over stdout parsing:
+  GOOD: \`npx vitest run -t 'budget'\` (exits 0 on pass)
+  BAD:  \`npx vitest run -t 'budget' 2>&1 | grep -qE 'Tests[[:space:]]+[5-9]'\`
+- Never pipe then && to another grep (second grep has no stdin, hangs forever):
+  BAD:  \`cmd | grep -q 'x' && ! grep -q 'y'\`
+  GOOD: \`OUT=$(cmd 2>&1); echo "$OUT" | grep -q 'x' && ! echo "$OUT" | grep -q 'y'\`
+- No count-based regex on test runner summary lines (format is TTY-dependent).
+- 30s timeout — keep commands focused. Use -t filters for test suites instead of running all tests.
+
 ### Mode-Specific Rules (mode: ${mode})
 ${modeRules[mode]}
 


### PR DESCRIPTION
## Summary

- Embeds AC command authoring rules directly in forge_plan's planner prompt (`server/lib/prompts/planner.ts`)
- Prevents F-55 (TTY-dependent output parsing) and F-56 (stdin-less grep hangs) in generated AC commands
- Also fixes 2 existing broken AC commands in the PH-04 phase plan (P60: build for the consumer, not the author)

### What changed

**`server/lib/prompts/planner.ts`** — Added `### AC Command Contract` section to the planner prompt, immediately after existing AC rules. Contains:
1. Subprocess environment description (no TTY, no stdin, 30s timeout)
2. Exit-code preference over stdout parsing (with GOOD/BAD examples)
3. Captured-output pattern for multi-grep (with GOOD/BAD examples)
4. Count-based regex warning
5. Timeout awareness

**`.ai-workspace/plans/forge-coordinate-phase-PH-04.json`** — Fixed 2 AC commands:
- US-03-AC01: count-based regex → captured-output pattern
- US-03-AC08: F-56 pipe chain → captured-output pattern

## Test plan

- [x] `grep -q 'AC Command Contract' server/lib/prompts/planner.ts` — contract present
- [x] `grep -q 'no TTY' server/lib/prompts/planner.ts` — environment described
- [x] `grep -q 'hangs forever' server/lib/prompts/planner.ts` — F-56 warning present
- [x] `npx vitest run` — 444/444 tests pass