### PR TITLE
refactor: rename generator.ts RunRecord to GeneratorIterationRecord

### DIFF
--- a/server/lib/generator.ts
+++ b/server/lib/generator.ts
@@ -361,7 +361,7 @@ export async function assembleGenerateResult(
 // ── PH-02: Infrastructure wrapper ───────────
 
 /** JSONL run record written to .forge/runs/data.jsonl */
-export interface RunRecord {
+interface GeneratorIterationRecord {
   timestamp: string;
   storyId: string;
   iteration: number;
@@ -483,7 +483,7 @@ export async function assembleGenerateResultWithContext(
  */
 export async function appendGeneratorIterationRecord(
   projectPath: string | undefined,
-  record: RunRecord,
+  record: GeneratorIterationRecord,
 ): Promise<void> {
   if (!projectPath) return;
 


### PR DESCRIPTION
Closes #116

Auto-fix by /housekeep Stage 4.

Renamed the local RunRecord interface in server/lib/generator.ts to GeneratorIterationRecord and removed the export keyword, eliminating the name collision with the canonical RunRecord in run-record.ts.