### PR TITLE
refactor: remove redundant estimatedCostUsd override in handleStoryEval

### DIFF
--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -187,10 +187,6 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
       storyId: input.storyId,
       evalVerdict: report.verdict,
       evalReport: canonicalizeEvalReport(report),
-      metrics: {
-        ...base.metrics,
-        estimatedCostUsd: ctx.cost.summarize().estimatedCostUsd,
-      },
     });
   }
 


### PR DESCRIPTION
Closes #129

Auto-fix by /housekeep Stage 4.

Removed redundant estimatedCostUsd override in handleStoryEval. buildRunRecord already sets this from ctx.cost.summarize(), so the spread override was unnecessary.