### PR TITLE
refactor: deduplicate filtered deps in classifyStory/hasFailedTransitiveDep

### DIFF
--- a/server/lib/coordinator.ts
+++ b/server/lib/coordinator.ts
@@ -124,7 +124,7 @@ function classifyStory(
   }
 
   // Rule 2: dep-failed — any transitive dependency is failed
-  if (hasFailedTransitiveDep(story, statusMap, storyIds)) {
+  if (hasFailedTransitiveDep(deps, statusMap)) {
     return "dep-failed";
   }
 
@@ -161,11 +161,9 @@ function allDepsDone(deps: string[], statusMap: Map<string, StoryStatusEntry>): 
 }
 
 function hasFailedTransitiveDep(
-  story: Story,
+  deps: string[],
   statusMap: Map<string, StoryStatusEntry>,
-  storyIds: Set<string>,
 ): boolean {
-  const deps = (story.dependencies ?? []).filter((d) => storyIds.has(d));
   for (const depId of deps) {
     const entry = statusMap.get(depId);
     if (!entry) continue;


### PR DESCRIPTION
Closes #131

Auto-fix by /housekeep Stage 4.

Changed hasFailedTransitiveDep to accept pre-filtered deps as a parameter instead of recomputing the same filter internally. Updated the call site in classifyStory to pass the already-computed deps array.