### PR TITLE
test: rename misleading permission-denied test in run-reader

### DIFF
--- a/server/lib/run-reader.test.ts
+++ b/server/lib/run-reader.test.ts
@@ -164,7 +164,7 @@ describe("readRunRecords", () => {
     consoleSpy.mockRestore();
   });
 
-  it("handles permission denied on individual files gracefully", async () => {
+  it("reads a single valid primary record without crashing", async () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     // We simulate permission error by mocking readFile for one specific call


### PR DESCRIPTION
Closes #132

Auto-fix by /housekeep Stage 4.

Renamed misleading test from 'handles permission denied on individual files gracefully' to 'reads a single valid primary record without crashing' to match what the test actually does.