### PR TITLE
feat(coordinate): PH-02 budget, time, INCONCLUSIVE, crash recovery

### DIFF
--- a/server/lib/coordinator.test.ts
+++ b/server/lib/coordinator.test.ts
@@ -10,7 +10,7 @@ vi.mock("./run-reader.js", () => ({
 }));
 
 import { readRunRecords } from "./run-reader.js";
-import { assessPhase } from "./coordinator.js";
+import { assessPhase, checkBudget, checkTimeBudget, recoverState } from "./coordinator.js";
 
 const mockedReadRunRecords = vi.mocked(readRunRecords);
 
@@ -46,6 +46,31 @@ function makePrimaryRecord(storyId: string, verdict: "PASS" | "FAIL" | "INCONCLU
       findingsRejected: 0,
       validationRetries: 0,
       durationMs: 1000,
+    },
+    outcome: "success",
+  };
+  return { source: "primary", record };
+}
+
+function makePrimaryRecordWithCost(storyId: string, verdict: "PASS" | "FAIL" | "INCONCLUSIVE", timestamp: string, costUsd: number | null | undefined): PrimaryRecord {
+  const record: RunRecord = {
+    timestamp,
+    tool: "forge_evaluate",
+    documentTier: null,
+    mode: null,
+    tier: null,
+    storyId,
+    evalVerdict: verdict,
+    metrics: {
+      inputTokens: 100,
+      outputTokens: 50,
+      critiqueRounds: 0,
+      findingsTotal: 0,
+      findingsApplied: 0,
+      findingsRejected: 0,
+      validationRetries: 0,
+      durationMs: 1000,
+      estimatedCostUsd: costUsd,
     },
     outcome: "success",
   };
@@ -405,5 +430,337 @@ describe("assessPhase", () => {
     const keySets = result.brief.stories.map((s) => Object.keys(s).sort().join(","));
     const uniqueKeySets = new Set(keySets);
     expect(uniqueKeySets.size).toBe(1);
+  });
+});
+
+describe("checkBudget", () => {
+  it("checkBudget threshold: 79% → none, 80% → approaching, 100% → exceeded", () => {
+    // 79% of $100 = $79
+    const at79 = checkBudget(
+      [makePrimaryRecordWithCost("US-01", "PASS", "2026-01-01T00:00:00Z", 79)],
+      100,
+    );
+    expect(at79.warningLevel).toBe("none");
+
+    // 80% of $100 = $80
+    const at80 = checkBudget(
+      [makePrimaryRecordWithCost("US-01", "PASS", "2026-01-01T00:00:00Z", 80)],
+      100,
+    );
+    expect(at80.warningLevel).toBe("approaching");
+    expect(at80.usedUsd).toBe(80);
+    expect(at80.remainingUsd).toBe(20);
+
+    // 100% of $100 = $100
+    const at100 = checkBudget(
+      [makePrimaryRecordWithCost("US-01", "PASS", "2026-01-01T00:00:00Z", 100)],
+      100,
+    );
+    expect(at100.warningLevel).toBe("exceeded");
+    expect(at100.usedUsd).toBe(100);
+    expect(at100.remainingUsd).toBe(0);
+  });
+
+  it("checkBudget undefined budget → warningLevel 'none', remainingUsd null", () => {
+    const result = checkBudget(
+      [makePrimaryRecordWithCost("US-01", "PASS", "2026-01-01T00:00:00Z", 50)],
+      undefined,
+    );
+    expect(result.warningLevel).toBe("none");
+    expect(result.remainingUsd).toBeNull();
+    expect(result.budgetUsd).toBeNull();
+    expect(result.usedUsd).toBe(0);
+  });
+
+  it("checkBudget generator records excluded from budget sum", () => {
+    const records = [
+      makePrimaryRecordWithCost("US-01", "PASS", "2026-01-01T00:00:00Z", 30),
+      makeGeneratorRecord("US-01", "2026-01-01T00:01:00Z"),
+      makeGeneratorRecord("US-02", "2026-01-01T00:02:00Z"),
+      makePrimaryRecordWithCost("US-02", "PASS", "2026-01-01T00:03:00Z", 20),
+    ];
+    const result = checkBudget(records, 100);
+    expect(result.usedUsd).toBe(50);
+    expect(result.warningLevel).toBe("none");
+  });
+
+  it("incompleteData: null cost primary record excluded from sum, incompleteData true", () => {
+    const records = [
+      makePrimaryRecordWithCost("US-01", "PASS", "2026-01-01T00:00:00Z", 30),
+      makePrimaryRecordWithCost("US-02", "PASS", "2026-01-01T00:01:00Z", null),
+      makePrimaryRecordWithCost("US-03", "PASS", "2026-01-01T00:02:00Z", 20),
+    ];
+    const result = checkBudget(records, 100);
+    expect(result.usedUsd).toBe(50);
+    expect(result.incompleteData).toBe(true);
+  });
+
+  it("null cost: undefined estimatedCostUsd sets incompleteData true", () => {
+    const records = [
+      makePrimaryRecordWithCost("US-01", "PASS", "2026-01-01T00:00:00Z", undefined),
+    ];
+    const result = checkBudget(records, 100);
+    expect(result.usedUsd).toBe(0);
+    expect(result.incompleteData).toBe(true);
+  });
+
+  it("NFR-C04: checkBudget never throws when budget exceeded — advisory only", () => {
+    const records = [
+      makePrimaryRecordWithCost("US-01", "PASS", "2026-01-01T00:00:00Z", 200),
+    ];
+    // Must not throw
+    const result = checkBudget(records, 100);
+    expect(result.warningLevel).toBe("exceeded");
+    expect(result.usedUsd).toBe(200);
+    expect(result.remainingUsd).toBe(-100);
+  });
+
+  it("budget missing: no budget set → incompleteData false, warningLevel none", () => {
+    const result = checkBudget([], undefined);
+    expect(result.incompleteData).toBe(false);
+    expect(result.warningLevel).toBe("none");
+    expect(result.budgetUsd).toBeNull();
+  });
+});
+
+describe("checkTimeBudget", () => {
+  it("checkTimeBudget threshold: time 80% → approaching, time 100% → exceeded", () => {
+    const now = Date.now();
+    const maxTimeMs = 10000;
+
+    // 79% elapsed → none
+    const at79 = checkTimeBudget(now - 7900, maxTimeMs);
+    expect(at79.warningLevel).toBe("none");
+
+    // 80% elapsed → approaching
+    const at80 = checkTimeBudget(now - 8000, maxTimeMs);
+    expect(at80.warningLevel).toBe("approaching");
+
+    // 100% elapsed → exceeded
+    const at100 = checkTimeBudget(now - 10000, maxTimeMs);
+    expect(at100.warningLevel).toBe("exceeded");
+  });
+
+  it("startTimeMs missing → elapsedMs 0, time unknown (NOT none)", () => {
+    const result = checkTimeBudget(undefined, 10000);
+    expect(result.elapsedMs).toBe(0);
+    expect(result.warningLevel).toBe("unknown");
+  });
+
+  it("maxTimeMs missing → time no-op, warningLevel none", () => {
+    const result = checkTimeBudget(Date.now() - 5000, undefined);
+    expect(result.warningLevel).toBe("none");
+    expect(result.maxTimeMs).toBeNull();
+    expect(result.elapsedMs).toBeGreaterThan(0);
+  });
+
+  it("checkTimeBudget never throws — pure computation with edge cases", () => {
+    // Both missing
+    expect(() => checkTimeBudget(undefined, undefined)).not.toThrow();
+    // Zero maxTimeMs
+    expect(() => checkTimeBudget(Date.now(), 0)).not.toThrow();
+    // Negative elapsed (future start time)
+    expect(() => checkTimeBudget(Date.now() + 100000, 10000)).not.toThrow();
+    // Very large values
+    expect(() => checkTimeBudget(0, Number.MAX_SAFE_INTEGER)).not.toThrow();
+  });
+
+  it("checkTimeBudget pure: both present, under 80% → warningLevel none", () => {
+    const result = checkTimeBudget(Date.now() - 1000, 10000);
+    expect(result.warningLevel).toBe("none");
+    expect(result.elapsedMs).toBeGreaterThan(0);
+    expect(result.maxTimeMs).toBe(10000);
+  });
+});
+
+describe("INCONCLUSIVE handling", () => {
+  it("exhaust mixed: 1 FAIL + 1 INCONCLUSIVE + 1 FAIL → retryCount 3, status failed", async () => {
+    const plan = makePlan([makeStory("US-01")]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "INCONCLUSIVE", "2026-01-01T00:01:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:02:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    const entry = result.brief.stories[0];
+
+    expect(entry.retryCount).toBe(3);
+    expect(entry.status).toBe("failed");
+    expect(entry.retriesRemaining).toBe(0);
+  });
+
+  it("three consecutive INCONCLUSIVE → retryCount 3, status failed (INCONCLUSIVE exhausts retry budget)", async () => {
+    const plan = makePlan([makeStory("US-01")]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "INCONCLUSIVE", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "INCONCLUSIVE", "2026-01-01T00:01:00Z"),
+      makePrimaryRecord("US-01", "INCONCLUSIVE", "2026-01-01T00:02:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    const entry = result.brief.stories[0];
+
+    expect(entry.retryCount).toBe(3);
+    expect(entry.status).toBe("failed");
+  });
+
+  it("dep ready-for-retry: downstream remains pending, NOT dep-failed", async () => {
+    const plan = makePlan([
+      makeStory("US-01"),
+      makeStory("US-02", ["US-01"]),
+    ]);
+    // US-01 has 1 FAIL → ready-for-retry (not terminal)
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+    const statusById = new Map(result.brief.stories.map((s) => [s.storyId, s]));
+
+    expect(statusById.get("US-01")!.status).toBe("ready-for-retry");
+    expect(statusById.get("US-02")!.status).toBe("pending");
+    expect(result.brief.depFailedStories).not.toContain("US-02");
+  });
+
+  it("all failed → needs-replan: every story failed or dep-failed triggers needs-replan", async () => {
+    const plan = makePlan([
+      makeStory("US-01"),
+      makeStory("US-02", ["US-01"]),
+    ]);
+    // US-01: 3 failures → failed; US-02 depends on US-01 → dep-failed
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:01:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:02:00Z"),
+    ]);
+
+    const result = await assessPhase(plan, "/tmp/test");
+
+    expect(result.brief.status).toBe("needs-replan");
+    expect(result.brief.failedStories).toContain("US-01");
+    expect(result.brief.depFailedStories).toContain("US-02");
+  });
+});
+
+describe("recoverState", () => {
+  it("recoverState idempotent: crash-safe re-run produces same result as atomic write", async () => {
+    const plan = makePlan([
+      makeStory("US-01"),
+      makeStory("US-02", ["US-01"]),
+    ]);
+
+    // Simulate "partial write" — only US-01's records exist (as if US-02 eval was killed mid-run)
+    const partialRecords = [
+      makePrimaryRecord("US-01", "PASS", "2026-01-01T00:00:00Z"),
+    ];
+    mockedReadRunRecords.mockResolvedValueOnce([...partialRecords]);
+    const partialResult = await recoverState(plan, "/tmp/test");
+
+    // Simulate "full write" — same records (US-02 never got a record, so same input)
+    mockedReadRunRecords.mockResolvedValueOnce([...partialRecords]);
+    const fullResult = await recoverState(plan, "/tmp/test");
+
+    // Both runs must produce identical status maps
+    expect(partialResult.get("US-01")!.status).toBe("done");
+    expect(partialResult.get("US-02")!.status).toBe("ready");
+    expect(fullResult.get("US-01")!.status).toBe(partialResult.get("US-01")!.status);
+    expect(fullResult.get("US-02")!.status).toBe(partialResult.get("US-02")!.status);
+  });
+
+  it("recoverState idempotent: twice in a row on same inputs returns identical maps", async () => {
+    const plan = makePlan([makeStory("US-01"), makeStory("US-02")]);
+    const records = [
+      makePrimaryRecord("US-01", "PASS", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-02", "FAIL", "2026-01-01T00:01:00Z"),
+    ];
+    mockedReadRunRecords
+      .mockResolvedValueOnce([...records])
+      .mockResolvedValueOnce([...records]);
+
+    const r1 = await recoverState(plan, "/tmp/test");
+    const r2 = await recoverState(plan, "/tmp/test");
+
+    for (const [id, entry] of r1) {
+      const other = r2.get(id)!;
+      expect(entry.status).toBe(other.status);
+      expect(entry.retryCount).toBe(other.retryCount);
+      expect(entry.retriesRemaining).toBe(other.retriesRemaining);
+    }
+  });
+
+  it("no-storyId record: missing storyId records are skipped without throwing", async () => {
+    const plan = makePlan([makeStory("US-01")]);
+    const recordWithoutStoryId: PrimaryRecord = {
+      source: "primary",
+      record: {
+        timestamp: "2026-01-01T00:00:00Z",
+        tool: "forge_evaluate",
+        documentTier: null,
+        mode: null,
+        tier: null,
+        // no storyId
+        metrics: {
+          inputTokens: 100, outputTokens: 50, critiqueRounds: 0,
+          findingsTotal: 0, findingsApplied: 0, findingsRejected: 0,
+          validationRetries: 0, durationMs: 1000,
+        },
+        outcome: "success",
+      },
+    };
+    mockedReadRunRecords.mockResolvedValueOnce([
+      recordWithoutStoryId,
+      makePrimaryRecord("US-01", "PASS", "2026-01-01T00:01:00Z"),
+    ]);
+
+    // Should not throw
+    const result = await recoverState(plan, "/tmp/test");
+    expect(result.get("US-01")!.status).toBe("done");
+  });
+
+  it("priorEvalReport on failed story: populated from most recent non-PASS record", async () => {
+    const evalReport: EvalReport = {
+      storyId: "US-01",
+      verdict: "FAIL",
+      criteria: [{ id: "AC-01", status: "FAIL", evidence: "fatal error" }],
+    };
+    const plan = makePlan([makeStory("US-01")]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:00:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:01:00Z"),
+      makePrimaryRecord("US-01", "FAIL", "2026-01-01T00:02:00Z", evalReport),
+    ]);
+
+    const result = await recoverState(plan, "/tmp/test");
+    const entry = result.get("US-01")!;
+
+    expect(entry.status).toBe("failed");
+    expect(entry.priorEvalReport).toBeDefined();
+    expect(entry.priorEvalReport!.criteria[0].evidence).toBe("fatal error");
+  });
+
+  it("no persistent state: recoverState is stateless — no coordinator state file on disk", async () => {
+    const plan = makePlan([makeStory("US-01")]);
+    mockedReadRunRecords.mockResolvedValueOnce([
+      makePrimaryRecord("US-01", "PASS", "2026-01-01T00:00:00Z"),
+    ]);
+
+    const result = await recoverState(plan, "/tmp/test-stateless");
+    expect(result.get("US-01")!.status).toBe("done");
+
+    // Verify no state file was written — readRunRecords was our only I/O,
+    // and recoverState itself performs no writes (pure function over read data)
+    const { readdir } = await import("node:fs/promises");
+    const forgeDir = (await import("node:path")).join("/tmp/test-stateless", ".forge");
+    try {
+      const entries = await readdir(forgeDir, { recursive: true });
+      // No coordinator-specific state files should exist
+      const stateFiles = entries.filter((e: string) =>
+        e.includes("coordinator-state") || e.includes("coordinator.json"),
+      );
+      expect(stateFiles).toHaveLength(0);
+    } catch {
+      // .forge dir doesn't exist at all — that's fine, proves no state was written
+    }
   });
 });

--- a/server/lib/coordinator.ts
+++ b/server/lib/coordinator.ts
@@ -7,11 +7,13 @@ import type {
   StoryStatus,
   PhaseTransitionBrief,
   BudgetInfo,
+  BudgetWarningLevel,
   TimeBudgetInfo,
+  TimeWarningLevel,
   ReplanningNote,
 } from "../types/coordinate-result.js";
 import { topoSort } from "./topo-sort.js";
-import { readRunRecords, type PrimaryRecord } from "./run-reader.js";
+import { readRunRecords, type PrimaryRecord, type TaggedRunRecord } from "./run-reader.js";
 
 const MAX_RETRIES = 3;
 
@@ -99,7 +101,7 @@ export async function assessPhase(
   }
 
   const entries = sorted.map((s) => statusMap.get(s.id)!);
-  const brief = assemblePhaseTransitionBrief(entries, options);
+  const brief = assemblePhaseTransitionBrief(entries, options, allRecords);
 
   return {
     mode: "advisory",
@@ -214,7 +216,11 @@ function getEvidence(
  * Assemble a PhaseTransitionBrief from classified story entries (REQ-05).
  * Applies the 4-case status resolution rule and populates all brief fields.
  */
-export function assemblePhaseTransitionBrief(entries: StoryStatusEntry[], options: AssessPhaseOptions = {}): PhaseTransitionBrief {
+export function assemblePhaseTransitionBrief(
+  entries: StoryStatusEntry[],
+  options: AssessPhaseOptions = {},
+  allRecords: ReadonlyArray<TaggedRunRecord> = [],
+): PhaseTransitionBrief {
   const readyStories = entries
     .filter((e) => e.status === "ready" || e.status === "ready-for-retry")
     .map((e) => e.storyId);
@@ -239,8 +245,8 @@ export function assemblePhaseTransitionBrief(entries: StoryStatusEntry[], option
     failedStories,
     completedCount,
     totalCount,
-    budget: buildBudget(options),
-    timeBudget: buildTimeBudget(options),
+    budget: checkBudget(allRecords, options.budgetUsd ?? undefined),
+    timeBudget: checkTimeBudget(options.currentPlanStartTimeMs ?? undefined, options.maxTimeMs ?? undefined),
     replanningNotes,
     recommendation,
     configSource: {},
@@ -323,20 +329,131 @@ function buildRecommendation(
   return parts.join(" ");
 }
 
-function buildBudget(options: AssessPhaseOptions): BudgetInfo {
+/**
+ * Pure budget check over tagged-union run records (REQ-06, NFR-C04, NFR-C09).
+ * Filters to primary records, sums estimatedCostUsd, returns BudgetInfo.
+ * Advisory only — never throws on exceeded budget.
+ */
+export function checkBudget(priorRecords: ReadonlyArray<TaggedRunRecord>, budgetUsd: number | undefined): BudgetInfo {
+  if (budgetUsd === undefined || budgetUsd === null) {
+    return {
+      usedUsd: 0,
+      budgetUsd: null,
+      remainingUsd: null,
+      incompleteData: false,
+      warningLevel: "none",
+    };
+  }
+
+  let usedUsd = 0;
+  let incompleteData = false;
+
+  for (const entry of priorRecords) {
+    if (entry.source !== "primary") continue;
+    const cost = entry.record.metrics.estimatedCostUsd;
+    if (cost === undefined || cost === null) {
+      incompleteData = true;
+      continue;
+    }
+    usedUsd += cost;
+  }
+
+  const ratio = budgetUsd > 0 ? usedUsd / budgetUsd : 0;
+  let warningLevel: BudgetWarningLevel = "none";
+  if (ratio >= 1) {
+    warningLevel = "exceeded";
+  } else if (ratio >= 0.8) {
+    warningLevel = "approaching";
+  }
+
   return {
-    usedUsd: 0,
-    budgetUsd: options.budgetUsd ?? null,
-    remainingUsd: options.budgetUsd != null ? options.budgetUsd : null,
-    incompleteData: true,
-    warningLevel: "none",
+    usedUsd,
+    budgetUsd,
+    remainingUsd: budgetUsd - usedUsd,
+    incompleteData,
+    warningLevel,
   };
 }
 
-function buildTimeBudget(options: AssessPhaseOptions): TimeBudgetInfo {
-  return {
-    elapsedMs: 0,
-    maxTimeMs: options.maxTimeMs ?? null,
-    warningLevel: options.maxTimeMs != null ? "none" : "unknown",
-  };
+/**
+ * Pure wall-clock time budget check (REQ-07).
+ * Missing startTimeMs → 'unknown' (not 'none'). Missing maxTimeMs → 'none' (no-op).
+ * Never throws — pure computation.
+ */
+export function checkTimeBudget(startTimeMs: number | undefined, maxTimeMs: number | undefined): TimeBudgetInfo {
+  if (startTimeMs === undefined || startTimeMs === null) {
+    return { elapsedMs: 0, maxTimeMs: maxTimeMs ?? null, warningLevel: "unknown" };
+  }
+
+  const elapsedMs = Date.now() - startTimeMs;
+
+  if (maxTimeMs === undefined || maxTimeMs === null) {
+    return { elapsedMs, maxTimeMs: null, warningLevel: "none" };
+  }
+
+  const ratio = maxTimeMs > 0 ? elapsedMs / maxTimeMs : 0;
+  let warningLevel: TimeWarningLevel = "none";
+  if (ratio >= 1) {
+    warningLevel = "exceeded";
+  } else if (ratio >= 0.8) {
+    warningLevel = "approaching";
+  }
+
+  return { elapsedMs, maxTimeMs, warningLevel };
+}
+
+/**
+ * Pure state recovery from run records (REQ-09, NFR-C03).
+ * Reads `.forge/runs/`, filters to primary records matching plan stories,
+ * classifies each story via the 6-state precedence chain.
+ * No persistent coordinator state file — all state is re-derived from run records.
+ * Composition: reconcileState (PH-03) runs FIRST; recoverState operates on the reconciled view.
+ */
+export async function recoverState(plan: ExecutionPlan, projectPath: string): Promise<Map<string, StoryStatusEntry>> {
+  const stories = plan.stories;
+  const sorted = stories.length > 0 ? topoSort(stories) : [];
+
+  const allRecords = await readRunRecords(projectPath);
+  const primaryRecords = allRecords
+    .filter((r): r is PrimaryRecord => r.source === "primary")
+    .map((r) => r.record);
+
+  const storyIds = new Set(stories.map((s) => s.id));
+
+  const recordsByStory = new Map<string, RunRecord[]>();
+  for (const record of primaryRecords) {
+    if (!record.storyId) continue;
+    if (!storyIds.has(record.storyId)) continue;
+    const list = recordsByStory.get(record.storyId) ?? [];
+    list.push(record);
+    recordsByStory.set(record.storyId, list);
+  }
+
+  for (const records of recordsByStory.values()) {
+    records.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  }
+
+  const statusMap = new Map<string, StoryStatusEntry>();
+
+  for (const story of sorted) {
+    const records = recordsByStory.get(story.id) ?? [];
+    const mostRecent = records.length > 0 ? records[records.length - 1] : null;
+    const retryCount = records.filter((r) => r.evalVerdict !== "PASS").length;
+    const retriesRemaining = Math.max(0, MAX_RETRIES - retryCount);
+
+    const status = classifyStory(story, mostRecent, retryCount, records.length, statusMap, storyIds);
+    const priorEvalReport = getPriorEvalReport(status, mostRecent);
+    const evidence = getEvidence(status, story, retryCount, statusMap);
+
+    statusMap.set(story.id, {
+      storyId: story.id,
+      status,
+      retryCount,
+      retriesRemaining,
+      priorEvalReport,
+      evidence,
+    });
+  }
+
+  return statusMap;
 }


### PR DESCRIPTION
## Summary
- **checkBudget**: Aggregates `estimatedCostUsd` across primary RunRecords, warns at 80%, stops at 100%. Handles null/missing cost data with `budget.incompleteData` flag. Advisory only — never kills the process.
- **checkTimeBudget**: Wall-clock budget check using `Date.now()` vs caller-provided `startTimeMs`/`maxTimeMs`. Returns `"unknown"` when anchor not provided.
- **INCONCLUSIVE handling**: Tests proving `classifyStory()` already handles INCONCLUSIVE verdict (transitive blocking, all-blocked exhaustion, retry-readiness)
- **recoverState**: Standalone crash recovery — reads RunRecords, classifies stories by `evalVerdict`. Operates on already-reconciled view (no orphan-filter or new-story logic — that's PH-03's `reconcileState`)

## Evidence
- 462 tests passing (444 baseline + 18 new), 0 failures
- NFR-C01 verified: zero `callClaude`/`trackedCallClaude` in non-test coordinator files
- All 4 stories dogfooded via forge_generate → implement → forge_evaluate, all PASS on first iteration
- Stateless reviewer: PASS with 2 LOW findings (acceptable duplication, zero-budget edge case)

## Test plan
- [x] `npm test` — 462 passing, 0 failures
- [x] NFR-C01: `rg "callClaude|trackedCallClaude" server/lib/coordinator.ts --glob "!*.test.ts"` returns empty
- [x] checkBudget: threshold boundaries (79%/80%/100%), null cost, generator record exclusion, no-budget passthrough
- [x] checkTimeBudget: threshold boundaries, missing startTimeMs/maxTimeMs, both missing
- [x] INCONCLUSIVE: mixed FAIL+INCONCLUSIVE, dep ready-for-retry, all-failed triggers needs-replan
- [x] recoverState: idempotency, double-call stability, missing storyId skipped, priorEvalReport populated