### PR TITLE
fix(reconcile): L4 pre-flight — audit log accuracy + status failure disambiguation

### DIFF
--- a/server/tools/reconcile.test.ts
+++ b/server/tools/reconcile.test.ts
@@ -171,7 +171,7 @@ describe("handleReconcile — atomic halt", () => {
     expect(result.isError).toBe(true);
     const output = JSON.parse(result.content[0].text);
     expect(output.status).toBe("halted");
-    expect(output.haltedOnNoteId).toBe(1);
+    expect(output.haltedOnNoteIndex).toBe(1);
     expect(output.rewriteCount).toBe(0);
     expect(output.operations).toHaveLength(0);
 
@@ -437,7 +437,7 @@ describe("handleReconcile — gap-found bypasses precedence", () => {
 
 // ── Adversarial 3: handlePlan returns non-enveloped payload ──
 describe("handleReconcile — parseHandlePlanOutput failure path", () => {
-  it("master route: non-enveloped handlePlan response yields error + partial status", async () => {
+  it("master route: non-enveloped handlePlan response yields error + failed status (sole op)", async () => {
     await writePlanFiles();
     const base = makeBase();
 
@@ -458,11 +458,160 @@ describe("handleReconcile — parseHandlePlanOutput failure path", () => {
     });
 
     const output = JSON.parse(result.content[0].text);
-    expect(output.status).toBe("partial");
+    // Only op failed and no deferredNotes → "failed", not "partial"
+    expect(output.status).toBe("failed");
     expect(output.errors?.length ?? 0).toBeGreaterThan(0);
     expect(output.operations).toHaveLength(1);
     expect(output.operations[0].planPathWritten).toBe("");
     expect(result.isError).toBe(true);
+  });
+});
+
+// ── MAJOR-1: 3-way overlap stale winningCategory rewrite ──
+describe("handleReconcile — 3-way overlap conflict audit rewrite", () => {
+  it("rewrites stale winningCategory when pairwise winner is later suppressed", async () => {
+    await writePlanFiles();
+    const base = makeBase();
+
+    // Note 0: ac-drift       — wins pairwise vs note 1, later suppressed by note 2
+    // Note 1: partial-completion — loses to note 0 (stale winner)
+    // Note 2: assumption-changed — highest precedence, suppresses note 0
+    // All three touch US-01.
+    const result = await handleReconcile({
+      ...base,
+      replanningNotes: [
+        {
+          category: "ac-drift",
+          severity: "should-address",
+          description: "drift",
+          affectedStories: ["US-01"],
+        },
+        {
+          category: "partial-completion",
+          severity: "should-address",
+          description: "partial",
+          affectedStories: ["US-01"],
+          affectedPhases: ["PH-01"],
+        },
+        {
+          category: "assumption-changed",
+          severity: "should-address",
+          description: "assumption flipped",
+          affectedStories: ["US-01"],
+        },
+      ],
+    });
+
+    const output = JSON.parse(result.content[0].text);
+    // conflicts must exist and note 1's winning category must be rewritten
+    // to the surviving highest-precedence note (assumption-changed), not "ac-drift"
+    const losersByIdx = new Map<number, string>();
+    for (const c of output.conflicts) {
+      losersByIdx.set(c.noteIndex, c.winningCategory);
+    }
+    expect(losersByIdx.get(1)).toBe("assumption-changed");
+    expect(losersByIdx.get(1)).not.toBe("ac-drift");
+    // Note 0 also a loser, correctly recorded
+    expect(losersByIdx.get(0)).toBe("assumption-changed");
+  });
+});
+
+// ── MAJOR-3: half-failed mixed status ──
+describe("handleReconcile — mixed success/failure status", () => {
+  it("half-failed: first op succeeds, second op fails → status=partial", async () => {
+    await writePlanFiles();
+    const base = makeBase();
+
+    // First handlePlan call (master route): valid envelope (default mock)
+    // Second handlePlan call (phase route PH-01): garbage
+    mockedHandlePlan.mockImplementationOnce(async () => ({
+      content: [
+        {
+          type: "text" as const,
+          text:
+            "=== UPDATED PLAN ===\n\n" +
+            JSON.stringify({ schemaVersion: "3.0.0", stories: [] }, null, 2) +
+            "\n\n=== USAGE ===\nTotal tokens: 0 input / 0 output",
+        },
+      ],
+    }));
+    mockedHandlePlan.mockImplementationOnce(async () => ({
+      content: [{ type: "text" as const, text: "garbage no envelope" }],
+    }));
+
+    const result = await handleReconcile({
+      ...base,
+      replanningNotes: [
+        {
+          category: "ac-drift",
+          severity: "should-address",
+          description: "drift",
+        },
+        {
+          category: "partial-completion",
+          severity: "should-address",
+          description: "partial",
+          affectedPhases: ["PH-01"],
+        },
+      ],
+    });
+
+    const output = JSON.parse(result.content[0].text);
+    expect(output.status).toBe("partial");
+    const successful = output.operations.filter(
+      (op: { planPathWritten: string }) => op.planPathWritten !== "",
+    );
+    const failed = output.operations.filter(
+      (op: { planPathWritten: string }) => op.planPathWritten === "",
+    );
+    expect(successful).toHaveLength(1);
+    expect(failed).toHaveLength(1);
+    expect(output.errors?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("all-failed multi-op: 2 ac-drift routes all fail → status=failed", async () => {
+    await writePlanFiles();
+    const base = makeBase();
+
+    // Both handlePlan calls return garbage. ac-drift collapses into a single
+    // master-update op (batched), so we only need one garbage response to cause
+    // total failure with operations.length > 0.
+    mockedHandlePlan.mockImplementationOnce(async () => ({
+      content: [{ type: "text" as const, text: "garbage 1" }],
+    }));
+
+    const result = await handleReconcile({
+      ...base,
+      replanningNotes: [
+        {
+          category: "ac-drift",
+          severity: "should-address",
+          description: "drift 1",
+        },
+        {
+          category: "ac-drift",
+          severity: "should-address",
+          description: "drift 2",
+        },
+      ],
+    });
+
+    const output = JSON.parse(result.content[0].text);
+    expect(output.status).toBe("failed");
+    expect(output.operations.length).toBeGreaterThan(0);
+    for (const op of output.operations) {
+      expect(op.planPathWritten).toBe("");
+    }
+    expect(output.errors?.length ?? 0).toBeGreaterThan(0);
+    expect(output.rewriteCount).toBe(0);
+    // No plan files should have been written
+    const masterPath = join(TEST_DIR, "master.json");
+    const hashAfter = await sha256File(masterPath);
+    // master.json had seed content; if it was overwritten it would change
+    const seedHash = createHash("sha256")
+      .update(JSON.stringify({ seed: "master" }))
+      .digest("hex");
+    expect(hashAfter).toBe(seedHash);
   });
 });
 

--- a/server/tools/reconcile.ts
+++ b/server/tools/reconcile.ts
@@ -176,7 +176,7 @@ export async function handleReconcile(input: ReconcileInput): Promise<McpRespons
       operations: [],
       deferredNotes: [],
       conflicts: [],
-      haltedOnNoteId: haltIdx,
+      haltedOnNoteIndex: haltIdx,
       rewriteCount: 0,
       timestamp: new Date().toISOString(),
     };
@@ -265,6 +265,35 @@ export async function handleReconcile(input: ReconcileInput): Promise<McpRespons
         break; // i is gone; stop comparing
       }
     }
+  }
+
+  // ── Pass 2b: rewrite stale conflict winningCategory entries ──
+  // In a 3-way overlap, a pairwise winner recorded during Pass 2 may itself
+  // be suppressed by a later, higher-precedence note. The audit-log entry in
+  // conflicts[] would then claim a loser lost to a note that is also gone.
+  // Rewrite each conflict's winningCategory to the highest-precedence
+  // surviving note whose affectedStories overlap with the loser's stories.
+  for (const conflict of conflicts) {
+    const loserNote = replanningNotes[conflict.noteIndex];
+    const loserStories = new Set(loserNote.affectedStories ?? []);
+    let bestSurvivor: { category: ReplanningCategory; rank: number } | null = null;
+    for (let k = 0; k < replanningNotes.length; k++) {
+      if (suppressed.has(k)) continue;
+      if (gapFoundHandled.has(k)) continue;
+      const candidate = replanningNotes[k];
+      if (candidate.category === "gap-found") continue;
+      const candidateStories = candidate.affectedStories ?? [];
+      const overlap = candidateStories.some((s) => loserStories.has(s));
+      if (!overlap) continue;
+      const rank = precedenceRank(candidate.category);
+      if (bestSurvivor === null || rank < bestSurvivor.rank) {
+        bestSurvivor = { category: candidate.category, rank };
+      }
+    }
+    if (bestSurvivor) {
+      conflict.winningCategory = bestSurvivor.category;
+    }
+    // else: leave original winningCategory (all overlappers also suppressed)
   }
 
   // ── Pass 3: route surviving non-gap-found notes ──
@@ -433,16 +462,19 @@ export async function handleReconcile(input: ReconcileInput): Promise<McpRespons
   const rewriteCount = operations.filter((op) => op.planPathWritten !== "").length;
 
   let status: ReconcileStatus;
+  const successfulOps = operations.filter((op) => op.planPathWritten !== "").length;
   if (operations.length === 0 && deferredNotes.length === 0 && errors.length === 0) {
     status = "no-op";
-  } else if (errors.length > 0 && (operations.length > 0 || deferredNotes.length > 0)) {
-    // Nit 11 — some work succeeded, some failed.
-    status = "partial";
-  } else if (errors.length > 0) {
-    // Nothing succeeded at all.
-    status = "partial";
-  } else {
+  } else if (errors.length === 0) {
     status = "success";
+  } else if (successfulOps === 0 && deferredNotes.length === 0) {
+    // Nothing actually landed — distinguish total failure from partial success
+    // so downstream retry logic doesn't loop forever on a silent all-fail.
+    status = "failed";
+  } else {
+    // Mixed: some operations wrote plan files (or gap-found notes deferred)
+    // while others errored.
+    status = "partial";
   }
 
   const output: ReconcileOutput = {

--- a/server/types/reconcile-output.ts
+++ b/server/types/reconcile-output.ts
@@ -1,6 +1,6 @@
 import type { ReplanningNote } from "./coordinate-result.js";
 
-export type ReconcileStatus = "success" | "halted" | "no-op" | "partial";
+export type ReconcileStatus = "success" | "halted" | "no-op" | "partial" | "failed";
 
 export interface ReconcileOperation {
   route: "master-update" | "phase-update";
@@ -20,7 +20,7 @@ export interface ReconcileOutput {
   operations: ReconcileOperation[];
   deferredNotes: ReplanningNote[]; // gap-found notes
   conflicts: ReconcileConflict[];
-  haltedOnNoteId?: number; // note index (deterministic order); only set when status=halted
+  haltedOnNoteIndex?: number; // note index (deterministic order); only set when status=halted
   rewriteCount: number; // total plan files written (0 when halted or no-op)
   timestamp: string; // ISO-8601
   errors?: string[];


### PR DESCRIPTION
## Summary

L4 pre-flight fix PR addressing 3 findings from forge-plan's independent cold review on merge commit `a89d779` (mailbox `2026-04-13T1205-forge-plan-to-swift-henry-cold-review-findings.md`). All 3 are L4 pre-flight requirements — must land before Q0/L4 code builds on reconcile's audit output and status-driven retry logic.

### MAJOR-1 — `conflicts[].winningCategory` stale in 3-way overlap

The pairwise Pass 2 loop records `winningCategory = note[i].category` when suppressing `note[j]`, but `note[i]` may later be suppressed by a yet-higher-precedence `note[k]` where `k > j`. Routing remains correct (suppression is monotonic), but the `conflicts[]` audit log lies about which category actually survived — downstream observability would be misled.

**Fix**: Pass 2b sweep rewrites each conflict's `winningCategory` to the highest-precedence **non-suppressed** note whose `affectedStories` overlap the original loser's. Edge case (all overlappers also suppressed) preserves the original value.

**Test**: 3-note fixture where `ac-drift` initially wins pairwise against `partial-completion` but is later suppressed by `assumption-changed`. Asserts the `partial-completion` loser's conflict entry has `winningCategory === "assumption-changed"`, NOT `"ac-drift"`.

### MAJOR-3 — `ReconcileStatus "partial"` conflated all-failed and half-success

Both "some succeeded, some failed" and "everything failed, nothing written" mapped to `"partial"` — indistinguishable. L4+ retry logic branching on reconcile status could silently loop on total failures classified as recoverable partials.

**Fix**: Add `"failed"` to `ReconcileStatus` enum (additive, P50-compliant). Status computation now distinguishes:
- no ops, no errors         → `"no-op"`
- ops, no errors            → `"success"`
- errors, no successful ops → `"failed"` *(new branch)*
- errors, some successful   → `"partial"`

**Tests**:
- **All-failed**: 2 `ac-drift` notes, `handlePlan` mock returns garbage on every call → `status === "failed"`, sha256 assertion proves master plan never touched.
- **Half-failed**: first `handlePlan` call succeeds, second fails → `status === "partial"`, exactly 1 successful op + 1 error.

### MINOR-7 — `haltedOnNoteId` → `haltedOnNoteIndex` rename

Field name said "ID" but semantic is "index" (deterministic input-order position, not a content-derived identifier). Zero-cost rename now while the field has zero live consumers post-v0.21.0; breaking later.

## Test plan

- [x] `npm run build` — exit 0
- [x] `npm test` — **576 tests pass across 28 files** (up from 573 post-L2: +3 new MAJOR-1/MAJOR-3 tests)
- [x] `npx vitest run server/tools/reconcile.test.ts` — 17 tests pass (up from 14)
- [x] `git diff master..HEAD -- server/tools/plan.ts` — empty (negative AC holds)
- [x] `grep -r haltedOnNoteId server/` — no matches after rename
- [x] Schema additivity: old serialized records without `"failed"` remain valid

## Stateless review plan

This PR is small and focused (~60 LOC production code + 3 new tests + 2 edits). The findings it addresses came from forge-plan's cold review, so the content is already cold-reviewer-audited. Forge-plan to spawn their own independent cold review in parallel per their T1205 autonomous-authority guidance. I'll mail them this PR URL immediately.

---
plan-refresh: no-op

Refs: forge-plan cold review mailbox `2026-04-13T1205-forge-plan-to-swift-henry-cold-review-findings.md`, PR #159 merge `a89d779`