### PR TITLE
test(plan): envelope contract for handleUpdatePlan output (Q0/L5 pre-flight)

### DIFF
--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -943,6 +943,50 @@ describe("documentTier: update", () => {
     const [, record] = mockedWriteRunRecord.mock.calls[0];
     expect(record.documentTier).toBe("update");
   });
+
+  // Q0/L5 pre-flight: envelope contract test (plan.ts:920-934).
+  // Locks the text-blob format that server/tools/reconcile.ts parses in
+  // parseHandlePlanOutput. If this test fails, reconcile's brace-counting
+  // extractor breaks silently. L5 proper will replace the text scraping
+  // with a structured return (option b+ per forge-plan T1240), but until
+  // then this contract is load-bearing. See Q0/L5 pre-flight PR.
+  it("envelope contract: output matches '=== UPDATED PLAN ===\\n\\n<JSON>\\n\\n[=== CRITIQUE SUMMARY ===\\n\\n...\\n\\n]=== USAGE ===...'", async () => {
+    const plan = makeValidPlan();
+    mockedCallClaude.mockResolvedValueOnce(makeCallResult(plan));
+
+    const result = await handlePlan({
+      intent: "update plan",
+      documentTier: "update",
+      currentPlan: JSON.stringify(makeValidPlan()),
+      implementationNotes: "Envelope contract test",
+      tier: "quick",
+    });
+
+    const text = result.content[0].text;
+
+    // 1. Exact marker strings present in order
+    const updatedIdx = text.indexOf("=== UPDATED PLAN ===");
+    const usageIdx = text.indexOf("=== USAGE ===");
+    expect(updatedIdx).toBe(0); // first section starts at offset 0
+    expect(usageIdx).toBeGreaterThan(updatedIdx);
+
+    // 2. Sections joined by exactly "\n\n"
+    expect(text).toMatch(/^=== UPDATED PLAN ===\n\n\{/);
+    expect(text).toMatch(/\n\n=== USAGE ===\n/);
+
+    // 3. JSON block after UPDATED PLAN parses cleanly
+    const afterMarker = text.slice("=== UPDATED PLAN ===\n\n".length);
+    // Find the end of the JSON by locating the next "\n\n===" marker
+    const nextSectionIdx = afterMarker.indexOf("\n\n===");
+    expect(nextSectionIdx).toBeGreaterThan(0);
+    const jsonBlob = afterMarker.slice(0, nextSectionIdx);
+    const parsed = JSON.parse(jsonBlob);
+    expect(parsed.schemaVersion).toBe("3.0.0");
+
+    // 4. USAGE section contains the exact "Total tokens:" literal
+    const usageSection = text.slice(usageIdx);
+    expect(usageSection).toMatch(/^=== USAGE ===\nTotal tokens: \d+ input \/ \d+ output/);
+  });
 });
 
 describe("backward compatibility (no documentTier)", () => {


### PR DESCRIPTION
## Summary

Q0/L5 pre-flight per forge-plan's Caveat C adjudication (mailbox `2026-04-13T1155`). Locks the text-blob envelope format that `server/tools/reconcile.ts` depends on via `parseHandlePlanOutput` (brace-counting JSON extractor). If any future change to `plan.ts` reorders sections, renames markers, or changes the join separator, reconcile would break **silently** — there's no type-level link between the two files. This contract test is the guardrail until L5 proper lands option (b+).

## External consumer check

`grep -rn "=== UPDATED PLAN" server/` returns only:
- `server/tools/plan.ts:922` (the emitter)
- `server/tools/reconcile.ts:97,99` (the consumer + its parseHandlePlanOutput)

**No outside consumers.** Per forge-plan T1340 release-batching directive, L5 proper can ship as a minor bump (v0.22.0) — no major bump required since the envelope-shape breaking change is contained to this repo.

## The contract asserted

`handleUpdatePlan` output text:
```
=== UPDATED PLAN ===

<JSON plan>

[=== CRITIQUE SUMMARY ===

<critique text>

]=== USAGE ===
Total tokens: <N> input / <N> output
<cost summary>
```
Sections joined by exactly `"\n\n"` (per `plan.ts:920-934`).

4 binary assertions:
1. `"=== UPDATED PLAN ==="` is at offset 0 (first section)
2. `"=== USAGE ==="` appears after `"=== UPDATED PLAN ==="` with `"\n\n"` separator
3. The JSON block between markers parses cleanly via `JSON.parse` with `schemaVersion === "3.0.0"`
4. USAGE section matches `/^=== USAGE ===\nTotal tokens: \d+ input \/ \d+ output/`

## Test plan

- [x] `npx vitest run server/tools/plan.test.ts -t "envelope contract"` → 1 pass
- [x] `npm test` — **591 passed / 4 skipped** (591 total), up from 590 post-#162
- [x] `git diff master..HEAD -- server/tools/plan.ts` — empty (negative AC holds — plan.ts unlock window is L5 proper, NOT this PR)
- [x] Cold review skipped per forge-plan T1240 directive ("skip cold review — trivial fixture test")

## Hard constraints

- [x] `server/tools/plan.ts` unmodified (assertion target, not edit target)
- [x] No M-track files touched
- [x] No Q0.5 files touched
- [x] Only `server/tools/plan.test.ts` modified, +44 −0 lines

---
plan-refresh: no-op

Refs: forge-plan mailbox `2026-04-13T1155` Caveat C, `2026-04-13T1340` release batching