### PR TITLE
feat(plan,reconcile): structured updatedPlan/critiqueRounds sidecar (Q0/L5 proper)

### DIFF
--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -657,6 +657,9 @@ describe("documentTier: master", () => {
     expect(result.content[0].text).toContain('"schemaVersion": "1.0.0"');
     expect(result.content[0].text).toContain("PH-01");
     expect(result.content[0].text).toContain("PH-02");
+    // Q0/L5: structured updatedPlan sidecar is exclusive to handleUpdatePlan.
+    // Non-update branches (master/phase/default) must NOT set the field.
+    expect((result as { updatedPlan?: unknown }).updatedPlan).toBeUndefined();
   });
 
   it("returns error when visionDoc is missing", async () => {
@@ -944,12 +947,12 @@ describe("documentTier: update", () => {
     expect(record.documentTier).toBe("update");
   });
 
-  // Q0/L5 pre-flight: envelope contract test (plan.ts:920-934).
-  // Locks the text-blob format that server/tools/reconcile.ts parses in
-  // parseHandlePlanOutput. If this test fails, reconcile's brace-counting
-  // extractor breaks silently. L5 proper will replace the text scraping
-  // with a structured return (option b+ per forge-plan T1240), but until
-  // then this contract is load-bearing. See Q0/L5 pre-flight PR.
+  // Envelope contract test (plan.ts:~920-934). Originally added in Q0/L5
+  // pre-flight (PR #163) to lock the text blob format that reconcile.ts
+  // was parsing via brace-counting. Q0/L5 proper moved reconcile to read
+  // the structured updatedPlan sidecar (see the structured-return test
+  // below), but the text blob MUST still match this contract for backward
+  // compat with external MCP consumers.
   it("envelope contract: output matches '=== UPDATED PLAN ===\\n\\n<JSON>\\n\\n[=== CRITIQUE SUMMARY ===\\n\\n...\\n\\n]=== USAGE ===...'", async () => {
     const plan = makeValidPlan();
     mockedCallClaude.mockResolvedValueOnce(makeCallResult(plan));
@@ -986,6 +989,63 @@ describe("documentTier: update", () => {
     // 4. USAGE section contains the exact "Total tokens:" literal
     const usageSection = text.slice(usageIdx);
     expect(usageSection).toMatch(/^=== USAGE ===\nTotal tokens: \d+ input \/ \d+ output/);
+  });
+
+  // Q0/L5 proper: structured sidecar fields on the handlePlan("update") response.
+  // reconcile.ts reads `resp.updatedPlan` directly instead of scraping the
+  // text envelope. This test locks the additive contract. The text blob
+  // (envelope contract test above) must ALSO still be present for backward
+  // compat with external MCP consumers.
+  it("returns structured updatedPlan + critiqueRounds fields on the response (Q0/L5)", async () => {
+    const plan = makeValidPlan();
+    mockedCallClaude.mockResolvedValueOnce(makeCallResult(plan));
+
+    const result = await handlePlan({
+      intent: "update plan",
+      documentTier: "update",
+      currentPlan: JSON.stringify(makeValidPlan()),
+      implementationNotes: "Structured return test",
+      tier: "quick",
+    });
+
+    // Structured fields present (additive on handlePlan return shape)
+    const resp = result as typeof result & {
+      updatedPlan?: unknown;
+      critiqueRounds?: unknown;
+    };
+    expect(resp.updatedPlan).toBeDefined();
+    expect((resp.updatedPlan as { schemaVersion?: string }).schemaVersion).toBe("3.0.0");
+
+    // critiqueRounds is present as either an array (rounds) or null (no rounds).
+    // Quick tier runs zero critique rounds, so expect null here.
+    expect("critiqueRounds" in resp).toBe(true);
+    expect(resp.critiqueRounds).toBeNull();
+
+    // Text blob unchanged (backward compat with envelope contract)
+    expect(result.content[0].text).toMatch(/^=== UPDATED PLAN ===\n\n\{/);
+    expect(result.content[0].text).toContain("=== USAGE ===");
+  });
+
+  // N3: non-null critiqueRounds path — when the critic actually runs, the
+  // sidecar field must carry the raw rounds array, not null.
+  it("returns non-null critiqueRounds when critic actually runs (Q0/L5)", async () => {
+    const plan = makeValidPlan();
+    mockedCallClaude
+      .mockResolvedValueOnce(makeCallResult(plan)) // update planner
+      .mockResolvedValueOnce(makeCriticResult()); // critic-1 (standard tier, zero findings)
+
+    const result = await handlePlan({
+      intent: "update plan",
+      documentTier: "update",
+      currentPlan: JSON.stringify(makeValidPlan()),
+      implementationNotes: "Non-null critique test",
+      tier: "standard",
+    });
+
+    const resp = result as typeof result & { critiqueRounds?: unknown };
+    expect(resp.critiqueRounds).not.toBeNull();
+    expect(Array.isArray(resp.critiqueRounds)).toBe(true);
+    expect((resp.critiqueRounds as unknown[]).length).toBeGreaterThan(0);
   });
 });
 

--- a/server/tools/plan.ts
+++ b/server/tools/plan.ts
@@ -931,7 +931,28 @@ async function handleUpdatePlan(options: HandlePlanOptions) {
     projectPath, startTime, "update", null, effectiveTier, critiqueRounds, validationRetries, ctx,
   );
 
-  return { content: [{ type: "text" as const, text: sections.join("\n\n") }] };
+  // Additive top-level fields on the MCP response (P50 additive extension).
+  // Consumed in-process by server/tools/reconcile.ts to avoid text-scraping
+  // the content[0].text envelope (Q0/L5 closes the forge_plan(update) orphan).
+  //
+  // WIRE BEHAVIOR: forge_plan is registered without an outputSchema, so the
+  // MCP SDK does NOT filter these fields from the JSON-RPC response. They
+  // ship over stdio to external callers. Default SDK clients ignore unknown
+  // keys (CallToolResultSchema is non-strict zod), so this is harmless in
+  // practice — but strict-schema clients may reject. A follow-up (Q0/L5b)
+  // should migrate these fields to the MCP-canonical `structuredContent`
+  // slot, which requires declaring an outputSchema and opting into strict
+  // validation. Tracked as a follow-up issue.
+  //
+  // Backward compat: the text blob in content[0].text is unchanged, so
+  // existing external consumers (none known in this repo — grep confirms
+  // only server/tools/reconcile.ts depends on the envelope shape) continue
+  // to work without modification.
+  return {
+    content: [{ type: "text" as const, text: sections.join("\n\n") }],
+    updatedPlan: plan,
+    critiqueRounds: critiqueRounds.length > 0 ? critiqueRounds : null,
+  };
 }
 
 /**

--- a/server/tools/reconcile.test.ts
+++ b/server/tools/reconcile.test.ts
@@ -5,8 +5,10 @@ import { tmpdir } from "node:os";
 import { createHash } from "node:crypto";
 import { execSync } from "node:child_process";
 
-// Mock handlePlan — stub returns a fixed updated plan as a text blob in the
-// same shape evaluate/plan produces in real runs.
+// Mock handlePlan — Q0/L5: returns structured updatedPlan + critiqueRounds
+// sidecar fields alongside a text blob. reconcile.ts reads the structured
+// field directly and no longer parses the text envelope, so the text body
+// here is purely cosmetic (kept realistic for readability).
 vi.mock("./plan.js", () => ({
   handlePlan: vi.fn(async () => ({
     content: [
@@ -18,6 +20,8 @@ vi.mock("./plan.js", () => ({
           "\n\n=== USAGE ===\nTotal tokens: 0 input / 0 output",
       },
     ],
+    updatedPlan: { schemaVersion: "3.0.0", stories: [] },
+    critiqueRounds: null,
   })),
 }));
 
@@ -435,15 +439,20 @@ describe("handleReconcile — gap-found bypasses precedence", () => {
   });
 });
 
-// ── Adversarial 3: handlePlan returns non-enveloped payload ──
-describe("handleReconcile — parseHandlePlanOutput failure path", () => {
-  it("master route: non-enveloped handlePlan response yields error + failed status (sole op)", async () => {
+// ── Adversarial 3: handlePlan response missing structured updatedPlan field ──
+// Q0/L5: reconcile reads resp.updatedPlan directly. If handlePlan ever drops
+// the field (regression or bug), reconcile must fail loudly instead of
+// writing garbage to the plan file.
+describe("handleReconcile — missing structured updatedPlan field failure path", () => {
+  it("master route: handlePlan response without updatedPlan yields error + failed status (sole op)", async () => {
     await writePlanFiles();
     const base = makeBase();
 
-    // Override mock: return raw garbage (no === UPDATED PLAN === marker, no valid JSON)
+    // Override mock: text content is irrelevant now — the load-bearing
+    // signal is the absence of the structured updatedPlan sidecar field.
     mockedHandlePlan.mockImplementationOnce(async () => ({
-      content: [{ type: "text" as const, text: "this is not a plan, not json, no envelope" }],
+      content: [{ type: "text" as const, text: "anything" }],
+      // updatedPlan intentionally absent
     }));
 
     const result = await handleReconcile({
@@ -522,8 +531,8 @@ describe("handleReconcile — mixed success/failure status", () => {
     await writePlanFiles();
     const base = makeBase();
 
-    // First handlePlan call (master route): valid envelope (default mock)
-    // Second handlePlan call (phase route PH-01): garbage
+    // First handlePlan call (master route): valid structured response
+    // Second handlePlan call (phase route PH-01): missing updatedPlan sidecar
     mockedHandlePlan.mockImplementationOnce(async () => ({
       content: [
         {
@@ -534,9 +543,12 @@ describe("handleReconcile — mixed success/failure status", () => {
             "\n\n=== USAGE ===\nTotal tokens: 0 input / 0 output",
         },
       ],
+      updatedPlan: { schemaVersion: "3.0.0", stories: [] },
+      critiqueRounds: null,
     }));
     mockedHandlePlan.mockImplementationOnce(async () => ({
-      content: [{ type: "text" as const, text: "garbage no envelope" }],
+      content: [{ type: "text" as const, text: "missing sidecar" }],
+      // updatedPlan intentionally absent
     }));
 
     const result = await handleReconcile({
@@ -573,11 +585,12 @@ describe("handleReconcile — mixed success/failure status", () => {
     await writePlanFiles();
     const base = makeBase();
 
-    // Both handlePlan calls return garbage. ac-drift collapses into a single
-    // master-update op (batched), so we only need one garbage response to cause
-    // total failure with operations.length > 0.
+    // Both handlePlan calls return responses without the updatedPlan sidecar.
+    // ac-drift collapses into a single master-update op (batched), so we only
+    // need one bad response to cause total failure with operations.length > 0.
     mockedHandlePlan.mockImplementationOnce(async () => ({
-      content: [{ type: "text" as const, text: "garbage 1" }],
+      content: [{ type: "text" as const, text: "missing sidecar 1" }],
+      // updatedPlan intentionally absent
     }));
 
     const result = await handleReconcile({

--- a/server/tools/reconcile.ts
+++ b/server/tools/reconcile.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { mkdir, writeFile, appendFile } from "node:fs/promises";
 import { dirname, join, isAbsolute } from "node:path";
 import { handlePlan } from "./plan.js";
+import type { ExecutionPlan } from "../types/execution-plan.js";
 import type { ReplanningNote, ReplanningCategory } from "../types/coordinate-result.js";
 import type {
   ReconcileOutput,
@@ -93,55 +94,25 @@ function formatNotesAsMarkdown(notes: ReplanningNote[]): string {
     .join("\n");
 }
 
-function parseHandlePlanOutput(text: string): unknown | null {
-  // handlePlan update returns "=== UPDATED PLAN ===\n\n<JSON>\n\n=== CRITIQUE..."
-  // We need to extract the JSON object between the header and next section.
-  const marker = "=== UPDATED PLAN ===";
-  const idx = text.indexOf(marker);
-  if (idx === -1) {
-    // Try direct JSON parse
-    try {
-      return JSON.parse(text);
-    } catch {
-      return null;
-    }
-  }
-  const after = text.slice(idx + marker.length);
-  // Find the first `{` and the matching end `}` using brace counting.
-  const start = after.indexOf("{");
-  if (start === -1) return null;
-  let depth = 0;
-  let inString = false;
-  let escape = false;
-  for (let i = start; i < after.length; i++) {
-    const ch = after[i];
-    if (escape) {
-      escape = false;
-      continue;
-    }
-    if (ch === "\\") {
-      escape = true;
-      continue;
-    }
-    if (ch === '"') {
-      inString = !inString;
-      continue;
-    }
-    if (inString) continue;
-    if (ch === "{") depth++;
-    else if (ch === "}") {
-      depth--;
-      if (depth === 0) {
-        const jsonStr = after.slice(start, i + 1);
-        try {
-          return JSON.parse(jsonStr);
-        } catch {
-          return null;
-        }
-      }
-    }
-  }
-  return null;
+/**
+ * Q0/L5: read the structured `updatedPlan` field off a handlePlan("update")
+ * response. handleUpdatePlan emits this field alongside the text blob
+ * (additive top-level response field — see server/tools/plan.ts:~934).
+ * Returns `undefined` if the response is an error, or if the sidecar field
+ * is absent or not an object, so the caller can record an error instead of
+ * writing garbage to disk.
+ *
+ * Defense-in-depth: all call sites already gate on `resp.isError` before
+ * invoking this reader, but we re-check here so a reorder can't silently
+ * leak a partial/garbage plan through.
+ */
+function readStructuredUpdatedPlan(
+  resp: { content?: unknown; isError?: boolean; updatedPlan?: unknown },
+): ExecutionPlan | undefined {
+  if (resp.isError) return undefined;
+  const field = resp.updatedPlan;
+  if (!field || typeof field !== "object") return undefined;
+  return field as ExecutionPlan;
 }
 
 /**
@@ -348,12 +319,12 @@ export async function handleReconcile(input: ReconcileInput): Promise<McpRespons
     let planPathWritten = "";
     if ((resp as { isError?: boolean }).isError) {
       errors.push(
-        `handlePlan (master-update) returned error: ${resp.content[0]?.text ?? "unknown"}`,
+        `handlePlan (master-update) returned isError; cannot extract updatedPlan: ${resp.content[0]?.text ?? "unknown"}`,
       );
     } else {
-      const parsed = parseHandlePlanOutput(resp.content[0]?.text ?? "");
-      if (parsed === null) {
-        errors.push("handlePlan (master-update): failed to parse updated plan JSON");
+      const parsed = readStructuredUpdatedPlan(resp);
+      if (parsed === undefined) {
+        errors.push("handlePlan (master-update) response missing structured updatedPlan field");
       } else {
         const target = resolvePath(projectPath, masterPlanPath);
         try {
@@ -420,13 +391,13 @@ export async function handleReconcile(input: ReconcileInput): Promise<McpRespons
     let planPathWritten = "";
     if ((resp as { isError?: boolean }).isError) {
       errors.push(
-        `handlePlan (phase-update ${phaseId}) returned error: ${resp.content[0]?.text ?? "unknown"}`,
+        `handlePlan (phase-update ${phaseId}) returned isError; cannot extract updatedPlan: ${resp.content[0]?.text ?? "unknown"}`,
       );
     } else {
-      const parsed = parseHandlePlanOutput(resp.content[0]?.text ?? "");
-      if (parsed === null) {
+      const parsed = readStructuredUpdatedPlan(resp);
+      if (parsed === undefined) {
         errors.push(
-          `handlePlan (phase-update ${phaseId}): failed to parse updated plan JSON`,
+          `handlePlan (phase-update ${phaseId}) response missing structured updatedPlan field`,
         );
       } else {
         const rel = phasePlanPaths[phaseId];


### PR DESCRIPTION
## Summary

Closes the `forge_plan(documentTier: "update")` orphan by switching `server/tools/reconcile.ts` from brittle envelope text-scraping to reading structured sidecar fields off the in-process `handlePlan` response. Implements **option b+** per forge-plan mailbox `2026-04-13T1240` Caveat C.

**This is the only Q0 layer where `server/tools/plan.ts` may be modified** — the negative AC is lifted specifically for this layer's scope (the `handleUpdatePlan` return shape). Non-update branches (`handleMasterPlan`, `handlePhasePlan`, `handleDefaultPlan`) are untouched.

## Changes

### `plan.ts` — `handleUpdatePlan` return shape

```typescript
return {
  content: [{ type: "text", text: sections.join("\n\n") }],  // unchanged (backward compat)
  updatedPlan: plan,                                          // new, ExecutionPlan type preserved
  critiqueRounds: critiqueRounds.length > 0 ? critiqueRounds : null,
};
```

The text envelope (`=== UPDATED PLAN ===\n\n{JSON}\n\n=== USAGE ===...`) is **unchanged** — existing external MCP consumers continue to work without modification.

### Wire-protocol note (documented accurately in the inline comment)

An initial draft of the inline comment claimed the sidecar fields were "not part of the MCP wire protocol — only present on in-process tool calls." Cold review caught this as **factually false**:

- `forge_plan` is registered in `server/index.ts` without an `outputSchema`, so MCP SDK's `validateToolOutput` is a no-op
- `shared/protocol.js` JSON.stringifies the full response object over stdio without filtering unknown keys
- Default SDK clients use `CallToolResultSchema` (non-strict zod) — unknown keys silently dropped → harmless in practice
- Strict-schema clients may reject

**Follow-up tracked**: Q0/L5b should migrate these fields to the MCP-canonical `structuredContent` slot, which requires declaring an `outputSchema` and opting into strict validation. Out of scope for this PR.

### `reconcile.ts` — structured read

- **Deleted** `parseHandlePlanOutput` (brace-counting text extractor, ~50 LOC)
- **Added** `readStructuredUpdatedPlan(resp): ExecutionPlan | undefined`
  - Asserts `!resp.isError` as defense-in-depth (belt-and-suspenders beyond the existing callsite isError check)
  - Type-guards the `updatedPlan` field before returning
- Both master-update and phase-update branches call the structured reader
- Error messages distinguish "returned isError" vs "response missing structured updatedPlan field"

### Tests

- **New**: `"returns structured updatedPlan + critiqueRounds fields on the response"` (tier: quick, critiqueRounds: null path)
- **New**: `"returns non-null critiqueRounds when critic actually runs"` (tier: standard, mocks planner + critic-1, asserts non-empty array)
- **Augmented**: master branch test asserts `updatedPlan === undefined` (P50 additivity — non-update branches don't leak sidecar fields)
- **Updated**: `reconcile.test.ts` mocks emit the sidecar; adversarial test now verifies missing-sidecar failure path instead of non-enveloped text

## Cold review iterations

**Round 1**: Fresh cold reviewer (zero implementation context). Verdict: PASS-WITH-NITS + 1 comment blocker.

- **B1** (blocker): comment on plan.ts:934-939 lied about wire-protocol behavior. Fixed — comment now states the truth, including the `structuredContent` migration as a Q0/L5b follow-up.
- **N1**: tightened `readStructuredUpdatedPlan` with `!resp.isError` assertion (defense-in-depth)
- **N2**: preserved `ExecutionPlan` type on the sidecar field (no `as unknown` cast)
- **N3**: added a test exercising the non-null `critiqueRounds` path (tier: standard)
- **N5**: renamed `critiqueSummary` → `critiqueRounds` to match the local variable name (the raw rounds data, not a human-readable summary)

**Skipped** (out of scope, filed as follow-ups):
- N4 (wire-protocol integration test via StdioServerTransport round-trip)
- `structuredContent` migration with `outputSchema` declaration

## Test plan

- [x] `npm run build` — exit 0
- [x] `npm test` — **589 passed + 4 skipped** (up from 588 post-#163, +1 for N3 non-null critique test)
- [x] `npx vitest run server/tools/plan.test.ts server/tools/reconcile.test.ts` — all pass
- [x] `grep -rn "parseHandlePlanOutput" server/` — empty (dead code deleted)
- [x] `grep -rn "critiqueSummary" server/` — 8 hits, all local variables receiving `formatCritiqueSummary()` output; no sidecar field references remain
- [x] `grep "=== UPDATED PLAN" server/tools/plan.ts` — still present at emitter line (backward compat)
- [x] `grep "=== UPDATED PLAN" server/tools/reconcile.ts` — empty (envelope parsing gone)

## Hard constraints

- [x] Plan.ts negative AC **LIFTED** this layer (34 lines of diff, scope confined to `handleUpdatePlan`)
- [x] Backward compat: text blob unchanged
- [x] P50 additivity: sidecar fields are optional
- [x] No `callClaude` / Anthropic SDK in reconcile.ts
- [x] `parseHandlePlanOutput` fully deleted
- [x] No M-track files touched
- [x] No Q0.5 files touched

## External consumer check

`grep -rn "=== UPDATED PLAN" server/` pre-L5 returned only:
- `server/tools/plan.ts:922` (emitter — still present)
- `server/tools/reconcile.ts:97,99` (consumer — removed in this PR)

No outside consumers. Per forge-plan T1340 release batching: stays on **minor** bump (v0.22.0), no major bump required since the envelope-shape change is contained to this repo.

---
plan-refresh: no-op

Refs: forge-plan mailbox `2026-04-13T1205` MAJOR-2, `2026-04-13T1240` Caveat C option b+, `2026-04-13T1340` release batching