### PR TITLE
chore(q0-l4): set q0L4ProvenBy to L6 merge SHA 05ff764

### DIFF
--- a/.ai-workspace/q0-l4-anchor.json
+++ b/.ai-workspace/q0-l4-anchor.json
@@ -4,5 +4,5 @@
   "q0PrNumber": 159,
   "q0FillMode": "bootstrap",
   "q0AnchorCreatedAt": "2026-04-13T12:45:00+08:00",
-  "q0L4ProvenBy": null
+  "q0L4ProvenBy": "05ff764de9b58e1620032077014668eb33066abe"
 }


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #165 (Q0/L6 merge). Sets `q0L4ProvenBy` in `.ai-workspace/q0-l4-anchor.json` from `null` to `"05ff764de9b58e1620032077014668eb33066abe"` — the L6 merge SHA that proved the Q0 plan-writeback loop end-to-end.

Couldn't ship this as part of PR #165 because the merge SHA isn't known pre-merge. This is a standalone 1-line change per forge-plan mailbox `2026-04-13T1240` Caveat A ("q0L4ProvenBy natural proven-by marker").

## Effect

The 14-day deadline watchdog (`.github/workflows/q0-l4-deadline.yml`) reads `q0L4ProvenBy` from `origin/master:.ai-workspace/q0-l4-anchor.json` and returns `status: "proven"` when the field is a valid SHA regex (`/^[a-f0-9]{7,40}$/`). With this commit, the watchdog will stop firing the `q0-l4-unproven` tracking issue when the 14-day deadline hits on 2026-04-27T01:22:51+08:00. The loop is now structurally proven.

## Test plan

- [x] 1 line change, JSON still parses
- [x] SHA matches PR #165's merge commit
- [x] SHA matches the regex `/^[a-f0-9]{7,40}$/` (40-char full SHA)
- [x] `server/lib/q0-l4-deadline.ts` unit test "proven" case continues to pass

---
plan-refresh: no-op

Refs: PR #165 (L6 merge `05ff764`), forge-plan mailbox `2026-04-13T1240` Caveat A