### PR TITLE
feat(q0.5-a1): ac-lint module + shared subprocess rules + primitive wiring

### DIFF
--- a/.github/workflows/ac-lint.yml
+++ b/.github/workflows/ac-lint.yml
@@ -1,0 +1,40 @@
+name: ac-lint
+# Q0.5/A1c — advisory-only ac-lint sweep across every plan file in
+# `.ai-workspace/plans/*.json`. The binding merge gate for plan-file lint
+# violations is Q0.5/C1's retroactive-critique workflow; this workflow is
+# observability-only (continue-on-error + non-blocking).
+#
+# Gate ordering (R2/C2 minor 3 enforcement): the preflight step below fails
+# this workflow if retroactive-critique.yml is absent from both master and
+# the PR diff. Per the plan, A1c cannot land without C1 (or alongside it).
+on:
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Preflight — retroactive-critique ordering gate
+        run: |
+          if ! test -f .github/workflows/retroactive-critique.yml && \
+             ! git diff --name-only origin/master...HEAD | grep -qx '.github/workflows/retroactive-critique.yml'; then
+            echo "ac-lint.yml requires retroactive-critique.yml to be on master or added in this PR. See Q0.5/A1c gate-ordering enforcement."
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Run ac-lint across all plans (advisory)
+        run: node scripts/run-ac-lint.mjs
+        continue-on-error: true

--- a/.github/workflows/retroactive-critique.yml
+++ b/.github/workflows/retroactive-critique.yml
@@ -1,0 +1,18 @@
+name: retroactive-critique
+# Q0.5/C1 stub — not yet implemented.
+#
+# This file exists ONLY to satisfy the gate-ordering preflight in
+# `.github/workflows/ac-lint.yml` (Q0.5/A1c), which refuses to run unless
+# a retroactive-critique.yml file is present on master or in the PR diff.
+#
+# The full retroactive-critique workflow (prompt-file change detection,
+# critic sweep across every `.ai-workspace/plans/*.json`, drift report
+# artifact, rule-exemptions.json binding gate, C1c auto-cleanup PR) lands
+# in a separate PR tracked as Q0.5/C1. Until then, this workflow is a
+# no-op triggered only by manual dispatch so it never consumes CI minutes.
+on: workflow_dispatch
+jobs:
+  stub:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Q0.5/C1 stub — full implementation lands in a follow-up PR."

--- a/scripts/run-ac-lint.mjs
+++ b/scripts/run-ac-lint.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Q0.5/A1c — advisory ac-lint driver for the `.github/workflows/ac-lint.yml`
+ * CI workflow.
+ *
+ * Globs every `.ai-workspace/plans/*.json`, runs `lintPlan` against each,
+ * prints a markdown summary to stdout, and always exits 0 (advisory mode).
+ *
+ * The binding merge gate for plan-file lint violations is Q0.5/C1's
+ * retroactive-critique workflow; this script is observability-only.
+ *
+ * Usage:
+ *   npm run build              # produces dist/
+ *   node scripts/run-ac-lint.mjs
+ */
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+
+// Import the built module from dist/ so we don't need tsx at runtime.
+const lintModulePath = join(repoRoot, "dist", "validation", "ac-lint.js");
+if (!existsSync(lintModulePath)) {
+  console.error(
+    `ac-lint: cannot find ${lintModulePath}. Run \`npm run build\` first.`,
+  );
+  // Advisory mode: exit 0 so CI doesn't fail.
+  process.exit(0);
+}
+const { lintPlan } = await import(pathToFileURL(lintModulePath).href);
+
+const plansDir = join(repoRoot, ".ai-workspace", "plans");
+if (!existsSync(plansDir)) {
+  console.log("# ac-lint advisory report");
+  console.log("");
+  console.log("No `.ai-workspace/plans/` directory found. Nothing to lint.");
+  process.exit(0);
+}
+
+const jsonFiles = readdirSync(plansDir)
+  .filter((f) => f.endsWith(".json"))
+  .sort();
+
+const lines = [];
+lines.push("# ac-lint advisory report");
+lines.push("");
+lines.push(
+  "Advisory-only (Q0.5/A1c). The binding merge gate is Q0.5/C1's retroactive-critique workflow.",
+);
+lines.push("");
+
+let totalFindings = 0;
+let totalSuspectAcs = 0;
+let totalGovViolations = 0;
+let filesScanned = 0;
+let filesWithFindings = 0;
+
+for (const file of jsonFiles) {
+  const fullPath = join(plansDir, file);
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(fullPath, "utf8"));
+  } catch {
+    // Not a valid JSON plan file — skip silently (e.g. config files).
+    continue;
+  }
+  if (!raw || !Array.isArray(raw.stories)) continue;
+  filesScanned += 1;
+
+  const report = lintPlan(raw);
+  if (report.findings.length === 0 && !report.governanceViolation) continue;
+
+  filesWithFindings += 1;
+  totalFindings += report.findings.length;
+  totalSuspectAcs += report.suspectAcIds.length;
+  if (report.governanceViolation) totalGovViolations += 1;
+
+  lines.push(`## \`${file}\``);
+  lines.push("");
+  lines.push(
+    `- Suspect ACs: **${report.suspectAcIds.length}** (${report.suspectAcIds.join(", ") || "none"})`,
+  );
+  lines.push(
+    `- lintExempt entries: ${report.lintExemptCount}${
+      report.governanceViolation ? " — **governance cap exceeded (>3)**" : ""
+    }`,
+  );
+  lines.push("");
+  lines.push("| Story | AC | Rule | Exempt |");
+  lines.push("|---|---|---|---|");
+  for (const f of report.findings) {
+    lines.push(
+      `| ${f.storyId} | ${f.acId} | \`${f.ruleId}\` | ${f.exempt ? "yes" : "no"} |`,
+    );
+  }
+  lines.push("");
+}
+
+const header = [
+  "# ac-lint advisory report",
+  "",
+  `**Summary:** ${filesScanned} plan file(s) scanned, ${filesWithFindings} with findings, ${totalFindings} total findings, ${totalSuspectAcs} suspect AC(s), ${totalGovViolations} governance violation(s).`,
+  "",
+];
+// Drop the old duplicated header prefix at the top of `lines`.
+const body = lines.slice(4);
+console.log(header.concat(body).join("\n"));
+// Always exit 0 — advisory mode.
+process.exit(0);

--- a/server/lib/evaluator.test.ts
+++ b/server/lib/evaluator.test.ts
@@ -149,6 +149,80 @@ describe("evaluateStory", () => {
     expect(report.warnings).toBeUndefined();
   });
 
+  // Q0.5/A1b — ac-lint short-circuit in story mode.
+  describe("ac-lint short-circuit", () => {
+    it("suspect AC is SKIPPED with reliability=suspect; no subprocess spawned", async () => {
+      const plan: ExecutionPlan = {
+        schemaVersion: "3.0.0",
+        stories: [
+          {
+            id: "US-01",
+            title: "Suspect",
+            acceptanceCriteria: [
+              {
+                id: "AC-01",
+                description: "bad vitest count grep",
+                command:
+                  "npx vitest run foo.test.ts 2>&1 | grep -qE 'Tests[[:space:]]+[5-9]'",
+              },
+            ],
+          },
+        ],
+      };
+      const report = await evaluateStory(plan, "US-01");
+      expect(mockedExecute).not.toHaveBeenCalled();
+      expect(report.criteria[0].status).toBe("SKIPPED");
+      expect(report.criteria[0].reliability).toBe("suspect");
+      expect(report.criteria[0].evidence).toContain("ac-lint: suspect");
+      expect(report.criteria[0].evidence).toContain("F55-vitest-count-grep");
+    });
+
+    it("clean AC runs normally with reliability=trusted", async () => {
+      mockedExecute.mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "ok" }));
+      const plan: ExecutionPlan = {
+        schemaVersion: "3.0.0",
+        stories: [
+          {
+            id: "US-01",
+            title: "Clean",
+            acceptanceCriteria: [
+              { id: "AC-01", description: "clean", command: "npx tsc --noEmit" },
+            ],
+          },
+        ],
+      };
+      const report = await evaluateStory(plan, "US-01");
+      expect(mockedExecute).toHaveBeenCalledTimes(1);
+      expect(report.criteria[0].status).toBe("PASS");
+      expect(report.criteria[0].reliability).toBe("trusted");
+    });
+
+    it("exempt AC runs normally even though pattern matches", async () => {
+      mockedExecute.mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "ok" }));
+      const plan: ExecutionPlan = {
+        schemaVersion: "3.0.0",
+        stories: [
+          {
+            id: "US-01",
+            title: "Exempt",
+            acceptanceCriteria: [
+              {
+                id: "AC-01",
+                description: "exempt lone passed-grep",
+                command: "npx vitest run | grep -q 'passed'",
+                lintExempt: { ruleId: "F56-passed-grep", rationale: "reviewed" },
+              },
+            ],
+          },
+        ],
+      };
+      const report = await evaluateStory(plan, "US-01");
+      expect(mockedExecute).toHaveBeenCalledTimes(1);
+      expect(report.criteria[0].status).toBe("PASS");
+      expect(report.criteria[0].reliability).toBe("trusted");
+    });
+  });
+
   it("runs ACs sequentially", async () => {
     const callOrder: number[] = [];
     mockedExecute

--- a/server/lib/evaluator.ts
+++ b/server/lib/evaluator.ts
@@ -1,6 +1,7 @@
 import type { ExecutionPlan } from "../types/execution-plan.js";
 import type { EvalReport, CriterionResult } from "../types/eval-report.js";
 import { executeCommand, type ExecuteOptions } from "./executor.js";
+import { lintAcCommand } from "../validation/ac-lint.js";
 
 export interface EvaluateOptions {
   timeoutMs?: number;
@@ -11,6 +12,14 @@ export interface EvaluateOptions {
  * Evaluate a single story from an execution plan by running all its ACs.
  *
  * Stateless: receives plan + storyId, runs shell commands, returns results.
+ *
+ * Q0.5/A1b — before executing each AC, run `lintAcCommand` against the
+ * command string. If any non-exempt deny-list rule matches, short-circuit
+ * the AC to `{status: "SKIPPED", reliability: "suspect"}` WITHOUT spawning
+ * a subprocess. Zero cost, zero hung-process risk, and a clear signal that
+ * the AC itself (not the code under test) is the broken thing.
+ *
+ * Exempt ACs execute normally regardless of pattern match.
  */
 export async function evaluateStory(
   plan: ExecutionPlan,
@@ -44,11 +53,28 @@ export async function evaluateStory(
   const criteria: CriterionResult[] = [];
 
   for (const ac of story.acceptanceCriteria) {
+    // Q0.5/A1b — ac-lint short-circuit (non-exempt suspect ACs never execute).
+    const lint = lintAcCommand(ac.command, { lintExempt: ac.lintExempt });
+    if (lint.suspect) {
+      const ruleIds = lint.findings
+        .filter((f) => !f.exempt)
+        .map((f) => f.ruleId)
+        .join(",");
+      criteria.push({
+        id: ac.id,
+        status: "SKIPPED",
+        evidence: `ac-lint: suspect (rules: ${ruleIds}); command NOT executed`,
+        reliability: "suspect",
+      });
+      continue;
+    }
+
     const result = await executeCommand(ac.command, execOptions);
     criteria.push({
       id: ac.id,
       status: result.status,
       evidence: result.evidence,
+      reliability: "trusted",
     });
   }
 

--- a/server/lib/prompts/planner.ts
+++ b/server/lib/prompts/planner.ts
@@ -1,3 +1,5 @@
+import { AC_SUBPROCESS_RULES_PROMPT } from "./shared/ac-subprocess-rules.js";
+
 /**
  * Build the system prompt for the master plan planner agent.
  * Master plans decompose a PRD/vision into phases with dependencies and I/O chains.
@@ -269,18 +271,7 @@ Respond with ONLY a JSON object matching this exact schema (execution-plan v3.0.
   the command must include the build step as a prerequisite (e.g., \`npm run build && node ...\`).
   Without this, the AC fails in a clean environment where the build output doesn't exist.
 
-### AC Command Contract
-AC commands execute inside node:child_process.exec() with bash shell.
-Environment: no TTY, no stdin, stdout/stderr captured as evidence, 30s timeout.
-Exit code 0 = PASS, non-zero = FAIL. Design commands accordingly:
-- Prefer exit-code checks over stdout parsing:
-  GOOD: \`npx vitest run -t 'budget'\` (exits 0 on pass)
-  BAD:  \`npx vitest run -t 'budget' 2>&1 | grep -qE 'Tests[[:space:]]+[5-9]'\`
-- Never pipe then && to another grep (second grep has no stdin, hangs forever):
-  BAD:  \`cmd | grep -q 'x' && ! grep -q 'y'\`
-  GOOD: \`OUT=$(cmd 2>&1); echo "$OUT" | grep -q 'x' && ! echo "$OUT" | grep -q 'y'\`
-- No count-based regex on test runner summary lines (format is TTY-dependent).
-- 30s timeout — keep commands focused. Use -t filters for test suites instead of running all tests.
+${AC_SUBPROCESS_RULES_PROMPT}
 
 ### Mode-Specific Rules (mode: ${mode})
 ${modeRules[mode]}

--- a/server/lib/prompts/shared/ac-subprocess-rules.ts
+++ b/server/lib/prompts/shared/ac-subprocess-rules.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared source of truth for AC subprocess-safety rules (Q0.5/A2).
+ *
+ * Both `planner.ts` (generation-time embedding in the LLM prompt) and
+ * `server/validation/ac-lint.ts` (mechanical lint at the primitive boundary)
+ * import from this file. This prevents the rule-parity gap that let
+ * PH01-US-06 ship with TTY-dependent greps — there is now exactly one place
+ * where the rules live.
+ *
+ * `critic.ts` will also import from this file when Q0.5/A2 (critic-prompt
+ * update) ships. That's a separate PR.
+ *
+ * Do NOT duplicate these patterns elsewhere — import from here.
+ */
+
+/**
+ * Human-readable prompt block embedded into planner/critic system prompts.
+ * This is the BYTE-IDENTICAL extraction of planner.ts:272-283's
+ * "AC Command Contract" section. Any future edit to the rule text must
+ * happen here and here only.
+ */
+export const AC_SUBPROCESS_RULES_PROMPT = `### AC Command Contract
+AC commands execute inside node:child_process.exec() with bash shell.
+Environment: no TTY, no stdin, stdout/stderr captured as evidence, 30s timeout.
+Exit code 0 = PASS, non-zero = FAIL. Design commands accordingly:
+- Prefer exit-code checks over stdout parsing:
+  GOOD: \`npx vitest run -t 'budget'\` (exits 0 on pass)
+  BAD:  \`npx vitest run -t 'budget' 2>&1 | grep -qE 'Tests[[:space:]]+[5-9]'\`
+- Never pipe then && to another grep (second grep has no stdin, hangs forever):
+  BAD:  \`cmd | grep -q 'x' && ! grep -q 'y'\`
+  GOOD: \`OUT=$(cmd 2>&1); echo "$OUT" | grep -q 'x' && ! echo "$OUT" | grep -q 'y'\`
+- No count-based regex on test runner summary lines (format is TTY-dependent).
+- 30s timeout — keep commands focused. Use -t filters for test suites instead of running all tests.`;
+
+/**
+ * Structured deny-list rules, consumed by `lintAcCommand`.
+ *
+ * Each rule's `pattern` is anchored conservatively so it does NOT false-positive
+ * on benign commands like `echo 'passed'` or `jq '.passed'`. The anchoring
+ * strategy is: match only when the offending construct appears as a shell
+ * token (word-boundary `grep`/`rg`) with the specific flag/argument shape
+ * that produces the failure mode.
+ */
+export interface AcLintRule {
+  /** Stable identifier, e.g. "F55-vitest-count-grep". */
+  id: string;
+  /** One-line human explanation. */
+  description: string;
+  /** Regex applied to the full AC command string. */
+  pattern: RegExp;
+  /** Severity — only "suspect" for now (scope of A1). */
+  severity: "suspect";
+}
+
+export const AC_LINT_RULES: AcLintRule[] = [
+  /**
+   * F55 — count-based vitest summary grep.
+   *
+   * Wrong: `npx vitest run foo.test.ts 2>&1 | grep -qE 'Tests[[:space:]]+[5-9]'`
+   * Right: `npx vitest run -t 'budget'` (relies on exit code, no stdout parsing)
+   *
+   * The vitest summary line "Tests  5 passed" is TTY-dependent; in
+   * child_process.exec() (no TTY) the formatting or even the line itself
+   * may be absent, so the grep silently returns "no match" (exit 1) and
+   * the AC spuriously fails. We match the characteristic
+   * `Tests[[:space:]]+<digit-range>` regex that F55 uses.
+   */
+  {
+    id: "F55-vitest-count-grep",
+    description:
+      "count-based vitest summary grep (TTY-dependent; use exit-code -t filter instead)",
+    pattern:
+      /grep\s+-[a-zA-Z]*E[a-zA-Z]*\s+['"][^'"]*Tests\s*(?:\[\[:space:\]\]|\\s|\s)\+[^'"]*[0-9][^'"]*['"]/,
+    severity: "suspect",
+  },
+
+  /**
+   * F56 — multi-grep pipeline with `&&`.
+   *
+   * Wrong: `cmd | grep -q 'x' && ! grep -q 'y'`
+   * Wrong: `cmd | grep -q 'x' && grep -q 'y'`
+   * Right: `OUT=$(cmd 2>&1); echo "$OUT" | grep -q 'x' && ! echo "$OUT" | grep -q 'y'`
+   *
+   * The second grep in the `&&` chain has no stdin (the pipeline ended at
+   * the first grep), so on a system with no TTY it blocks waiting for
+   * stdin → hung process or spurious match depending on buffering.
+   *
+   * We require a pipe `|` before the first grep (so this is not a
+   * standalone grep on a file argument) and a `&& ` then optional `!` then
+   * another `grep -q` without an intervening `echo` / input source.
+   */
+  {
+    id: "F56-multigrep-pipe",
+    description:
+      "multi-grep `&&` pipeline where the second grep has no stdin (hangs or false-passes)",
+    pattern:
+      /\|\s*grep\s+-[a-zA-Z]*q[a-zA-Z]*\s+['"][^'"]*['"]\s*&&\s*!?\s*grep\s+-[a-zA-Z]*q/,
+    severity: "suspect",
+  },
+
+  /**
+   * F56 variant — lone `grep -q 'passed'` / `grep -q 'failed'` on runner output.
+   *
+   * Wrong: `npx vitest run 2>&1 | grep -q 'passed'`
+   * Wrong: `cmd | grep -q 'failed'`
+   * Right: `npx vitest run -t 'foo'` (exit-code check)
+   *
+   * Matches a pipe-into-grep-q on the literal tokens `passed` or `failed`.
+   * The benign case `echo 'passed'` is NOT matched because there's no
+   * preceding pipe into the grep. `jq '.passed'` is NOT matched because
+   * the tool name is `jq`, not `grep`.
+   */
+  {
+    id: "F56-passed-grep",
+    description:
+      "lone `grep -q 'passed'/'failed'` on runner output (TTY-dependent summary line)",
+    pattern:
+      /\|\s*grep\s+-[a-zA-Z]*q[a-zA-Z]*\s+['"](?:passed|failed)['"]/,
+    severity: "suspect",
+  },
+
+  /**
+   * F36 — source-tree grep (recursive).
+   *
+   * Wrong: `grep -rn 'Redis' src/`
+   * Wrong: `grep -n 'foo' server/lib/bar.ts server/lib/baz.ts`
+   * Right: `curl localhost:3000/api | jq '.cache'` (observable behavior)
+   *
+   * ACs must not inspect source code — they verify observable behavior.
+   * This matches both recursive `grep -rn` on a directory path AND the
+   * PH01-US-06-AC04 pattern of enumerating individual files under
+   * `src/` / `server/` / `lib/`.
+   */
+  {
+    id: "F36-source-tree-grep",
+    description:
+      "grep inspecting source tree (src/, server/, lib/) instead of verifying observable behavior",
+    pattern:
+      /\bgrep\b[^\n;]*?(?:\s|["'])(?:src|server|lib)\/[A-Za-z0-9_\-./]*/,
+    severity: "suspect",
+  },
+
+  /**
+   * F36 — raw `rg` (ripgrep) invocation.
+   *
+   * Wrong: `rg 'class UserCache' server/`
+   * Right: Use `grep` only for evidence-checking output, not source inspection.
+   *
+   * ripgrep is not guaranteed to be installed on the machine running the
+   * AC (especially in lean CI containers). Plus — same source-inspection
+   * anti-pattern as F36-source-tree-grep.
+   *
+   * Match `rg` as a standalone command token (start of line, after `|`,
+   * after `;`, or after `&&`) followed by a flag or quoted pattern. We
+   * reject leading-word matches like `rg` inside an identifier or path.
+   */
+  {
+    id: "F36-raw-rg",
+    description:
+      "raw `rg` (ripgrep) invocation — portability risk; rg may not be installed",
+    pattern: /(?:^|[|;&]\s*)rg\s+(?:-[a-zA-Z]|['"])/,
+    severity: "suspect",
+  },
+];

--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -207,6 +207,56 @@ describe("handlePlan", () => {
     });
   });
 
+  describe("ac-lint gate (Q0.5/A1a)", () => {
+    function planWithSuspectAc() {
+      return {
+        schemaVersion: "3.0.0",
+        stories: [
+          {
+            id: "US-01",
+            title: "Suspect",
+            dependencies: [],
+            acceptanceCriteria: [
+              {
+                id: "AC-01",
+                description: "bad",
+                command:
+                  "npx vitest run 2>&1 | grep -qE 'Tests[[:space:]]+[5-9]'",
+              },
+            ],
+            affectedPaths: ["src/"],
+          },
+        ],
+      };
+    }
+
+    it("strictLint=true + suspect AC → throws", async () => {
+      const plan = planWithSuspectAc();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan))
+        .mockResolvedValueOnce(makeCriticResult())
+        .mockResolvedValueOnce(makeCriticResult());
+
+      await expect(
+        handlePlan({ intent: "add feature", strictLint: true }),
+      ).rejects.toThrow(/ac-lint found/);
+    });
+
+    it("default (advisory) + suspect AC → attaches lintReport, does not throw", async () => {
+      const plan = planWithSuspectAc();
+      mockedCallClaude
+        .mockResolvedValueOnce(makeCallResult(plan))
+        .mockResolvedValueOnce(makeCriticResult())
+        .mockResolvedValueOnce(makeCriticResult());
+
+      const result = await handlePlan({ intent: "add feature" });
+      expect((result as any).lintReport).toBeDefined();
+      expect((result as any).lintReport.suspectAcIds).toEqual(["AC-01"]);
+      expect((result as any).lintReport.findings.length).toBeGreaterThan(0);
+      expect(result.content[0].text).toContain("AC-LINT WARNINGS");
+    });
+  });
+
   describe("mode auto-detection", () => {
     it('detects "fix" keyword as bugfix', async () => {
       const plan = makeValidPlan();

--- a/server/tools/plan.ts
+++ b/server/tools/plan.ts
@@ -15,6 +15,7 @@ import {
 import { buildCriticPrompt, buildCriticUserMessage, buildMasterCriticPrompt, buildMasterCriticUserMessage } from "../lib/prompts/critic.js";
 import { buildCorrectorPrompt, buildCorrectorUserMessage, buildMasterCorrectorPrompt, buildMasterCorrectorUserMessage } from "../lib/prompts/corrector.js";
 import { validateExecutionPlan } from "../validation/execution-plan.js";
+import { lintPlan, type LintPlanReport } from "../validation/ac-lint.js";
 import { validateMasterPlan } from "../validation/master-plan.js";
 import { writeRunRecord, type RunRecord } from "../lib/run-record.js";
 import { RunContext, trackedCallClaude } from "../lib/run-context.js";
@@ -138,6 +139,15 @@ export const planInputSchema = {
     .describe(
       "Maximum character budget for injected context. Default: 50000. " +
       "Entries are dropped whole (last first) to stay within budget.",
+    ),
+  strictLint: z
+    .boolean()
+    .optional()
+    .describe(
+      "Q0.5/A1a: when true, ac-lint suspect findings or governance-cap violations " +
+      "(more than 3 lintExempt entries) cause forge_plan to throw. When false/omitted, " +
+      "lint findings are attached as a non-blocking `lintReport` sidecar field on the " +
+      "response for observability (advisory mode).",
     ),
 };
 
@@ -780,7 +790,7 @@ async function handleMasterPlan(options: HandlePlanOptions) {
  * Handle phase plan generation: expand one master plan phase into stories with ACs.
  */
 async function handlePhasePlan(options: HandlePlanOptions) {
-  const { visionDoc, masterPlan, phaseId, projectPath, mode, tier, context, maxContextChars } = options;
+  const { visionDoc, masterPlan, phaseId, projectPath, mode, tier, context, maxContextChars, strictLint } = options;
   if (!visionDoc || !masterPlan || !phaseId) {
     return {
       content: [{ type: "text" as const, text: "Error: visionDoc, masterPlan, and phaseId are required for documentTier 'phase'." }],
@@ -838,6 +848,14 @@ async function handlePhasePlan(options: HandlePlanOptions) {
     );
   }
 
+  // Q0.5/A1a — ac-lint gate (strict throws, advisory attaches).
+  const lintReport = runAcLintGate(plan, strictLint);
+  if (lintReport.suspectAcIds.length > 0) {
+    console.error(
+      `forge_plan: ac-lint flagged ${lintReport.suspectAcIds.length} suspect AC(s): ${lintReport.suspectAcIds.join(", ")}`,
+    );
+  }
+
   // Build output
   const sections: string[] = [
     `=== PHASE PLAN (${phaseId}) ===`,
@@ -853,6 +871,17 @@ async function handlePhasePlan(options: HandlePlanOptions) {
     ].join("\n"));
   }
 
+  if (lintReport.suspectAcIds.length > 0 || lintReport.governanceViolation) {
+    sections.push([
+      `=== AC-LINT WARNINGS (${lintReport.findings.length}) ===`,
+      `Suspect ACs: ${lintReport.suspectAcIds.join(", ") || "(none)"}`,
+      `lintExempt entries: ${lintReport.lintExemptCount} (governance cap: 3${lintReport.governanceViolation ? " — VIOLATED" : ""})`,
+      ...lintReport.findings.map(
+        (f) => `${f.storyId}/${f.acId} [${f.ruleId}${f.exempt ? " — EXEMPT" : ""}]: ${f.description}`,
+      ),
+    ].join("\n"));
+  }
+
   const critiqueSummary = formatCritiqueSummary(critiqueRounds);
   if (critiqueSummary) sections.push(critiqueSummary);
   sections.push(buildUsageSection(ctx));
@@ -861,14 +890,17 @@ async function handlePhasePlan(options: HandlePlanOptions) {
     projectPath, startTime, "phase", effectiveMode, effectiveTier, critiqueRounds, validationRetries, ctx,
   );
 
-  return { content: [{ type: "text" as const, text: sections.join("\n\n") }] };
+  return {
+    content: [{ type: "text" as const, text: sections.join("\n\n") }],
+    lintReport,
+  };
 }
 
 /**
  * Handle update mode: revise an existing plan based on implementation notes.
  */
 async function handleUpdatePlan(options: HandlePlanOptions) {
-  const { currentPlan, implementationNotes, projectPath, tier, context, maxContextChars } = options;
+  const { currentPlan, implementationNotes, projectPath, tier, context, maxContextChars, strictLint } = options;
   if (!currentPlan || !implementationNotes) {
     return {
       content: [{ type: "text" as const, text: "Error: currentPlan and implementationNotes are required for documentTier 'update'." }],
@@ -917,11 +949,30 @@ async function handleUpdatePlan(options: HandlePlanOptions) {
     }
   }
 
+  // Q0.5/A1a — ac-lint gate on the revised plan too.
+  const lintReport = runAcLintGate(plan, strictLint);
+  if (lintReport.suspectAcIds.length > 0) {
+    console.error(
+      `forge_plan (update): ac-lint flagged ${lintReport.suspectAcIds.length} suspect AC(s): ${lintReport.suspectAcIds.join(", ")}`,
+    );
+  }
+
   // Build output
   const sections: string[] = [
     "=== UPDATED PLAN ===",
     JSON.stringify(plan, null, 2),
   ];
+
+  if (lintReport.suspectAcIds.length > 0 || lintReport.governanceViolation) {
+    sections.push([
+      `=== AC-LINT WARNINGS (${lintReport.findings.length}) ===`,
+      `Suspect ACs: ${lintReport.suspectAcIds.join(", ") || "(none)"}`,
+      `lintExempt entries: ${lintReport.lintExemptCount} (governance cap: 3${lintReport.governanceViolation ? " — VIOLATED" : ""})`,
+      ...lintReport.findings.map(
+        (f) => `${f.storyId}/${f.acId} [${f.ruleId}${f.exempt ? " — EXEMPT" : ""}]: ${f.description}`,
+      ),
+    ].join("\n"));
+  }
 
   const critiqueSummary = formatCritiqueSummary(critiqueRounds);
   if (critiqueSummary) sections.push(critiqueSummary);
@@ -952,6 +1003,7 @@ async function handleUpdatePlan(options: HandlePlanOptions) {
     content: [{ type: "text" as const, text: sections.join("\n\n") }],
     updatedPlan: plan,
     critiqueRounds: critiqueRounds.length > 0 ? critiqueRounds : null,
+    lintReport,
   };
 }
 
@@ -959,7 +1011,7 @@ async function handleUpdatePlan(options: HandlePlanOptions) {
  * Handle default (no documentTier) — original execution plan pipeline, fully backward compatible.
  */
 async function handleDefaultPlan(options: HandlePlanOptions) {
-  const { intent, projectPath, mode, tier, context, maxContextChars } = options;
+  const { intent, projectPath, mode, tier, context, maxContextChars, strictLint } = options;
   const startTime = Date.now();
   const effectiveMode = mode ?? detectMode(intent);
   const effectiveTier = tier ?? "thorough";
@@ -1009,6 +1061,14 @@ async function handleDefaultPlan(options: HandlePlanOptions) {
     );
   }
 
+  // Q0.5/A1a — mechanical ac-lint gate. Strict mode throws; advisory mode attaches.
+  const lintReport = runAcLintGate(plan, strictLint);
+  if (lintReport.suspectAcIds.length > 0) {
+    console.error(
+      `forge_plan: ac-lint flagged ${lintReport.suspectAcIds.length} suspect AC(s): ${lintReport.suspectAcIds.join(", ")}`,
+    );
+  }
+
   // Build output
   const sections: string[] = [
     "=== EXECUTION PLAN ===",
@@ -1024,6 +1084,17 @@ async function handleDefaultPlan(options: HandlePlanOptions) {
     ].join("\n"));
   }
 
+  if (lintReport.suspectAcIds.length > 0 || lintReport.governanceViolation) {
+    sections.push([
+      `=== AC-LINT WARNINGS (${lintReport.findings.length}) ===`,
+      `Suspect ACs: ${lintReport.suspectAcIds.join(", ") || "(none)"}`,
+      `lintExempt entries: ${lintReport.lintExemptCount} (governance cap: 3${lintReport.governanceViolation ? " — VIOLATED" : ""})`,
+      ...lintReport.findings.map(
+        (f) => `${f.storyId}/${f.acId} [${f.ruleId}${f.exempt ? " — EXEMPT" : ""}]: ${f.description}`,
+      ),
+    ].join("\n"));
+  }
+
   const critiqueSummary = formatCritiqueSummary(critiqueRounds);
   if (critiqueSummary) sections.push(critiqueSummary);
   sections.push(buildUsageSection(ctx));
@@ -1032,7 +1103,10 @@ async function handleDefaultPlan(options: HandlePlanOptions) {
     projectPath, startTime, null, effectiveMode, effectiveTier, critiqueRounds, validationRetries, ctx,
   );
 
-  return { content: [{ type: "text" as const, text: sections.join("\n\n") }] };
+  return {
+    content: [{ type: "text" as const, text: sections.join("\n\n") }],
+    lintReport,
+  };
 }
 
 // ── Main handler ──
@@ -1050,6 +1124,41 @@ interface HandlePlanOptions {
   currentPlan?: string;
   context?: Array<{ label: string; content: string }>;
   maxContextChars?: number;
+  strictLint?: boolean;
+}
+
+/**
+ * Q0.5/A1a — run ac-lint on a generated plan. In strict mode, any non-exempt
+ * suspect finding or a governance-cap violation throws. In advisory mode,
+ * the report is returned for attachment as a sidecar.
+ */
+function runAcLintGate(
+  plan: ExecutionPlan,
+  strictLint: boolean | undefined,
+): LintPlanReport {
+  const report = lintPlan(plan);
+  if (strictLint) {
+    if (report.governanceViolation) {
+      throw new Error(
+        `forge_plan: ac-lint governance cap exceeded — ${report.lintExemptCount} lintExempt entries (max 3). Add a 'lint-exempt-governance-override: <reason>' line to the PR body or reduce exemptions.`,
+      );
+    }
+    if (report.suspectAcIds.length > 0) {
+      const detail = report.suspectAcIds
+        .map((id) => {
+          const rules = report.findings
+            .filter((f) => f.acId === id && !f.exempt)
+            .map((f) => f.ruleId)
+            .join(",");
+          return `${id} [${rules}]`;
+        })
+        .join("; ");
+      throw new Error(
+        `forge_plan: ac-lint found ${report.suspectAcIds.length} suspect AC(s) in strictLint mode: ${detail}`,
+      );
+    }
+  }
+  return report;
 }
 
 /**

--- a/server/types/eval-report.ts
+++ b/server/types/eval-report.ts
@@ -9,4 +9,22 @@ export interface CriterionResult {
   id: string;
   status: "PASS" | "FAIL" | "SKIPPED" | "INCONCLUSIVE";
   evidence: string;
+  /**
+   * Reliability of this result (Q0.5/A3 minimum slice).
+   *
+   * - Absent (undefined): treat as "trusted" for backward compatibility.
+   *   Existing consumers that don't know about this field see the same shape
+   *   as before A3 shipped.
+   * - "trusted": result is mechanically verifiable — the AC command passed
+   *   ac-lint clean and executed.
+   * - "suspect": ac-lint flagged this AC's command as matching a subprocess-
+   *   safety deny-list rule (F55/F56/F36). The command was NOT executed;
+   *   `status` is set to "SKIPPED" and `evidence` carries the matched rule
+   *   ids. Downstream readers should treat this as "we don't know the real
+   *   answer, the AC itself is broken".
+   *
+   * Note: the full A3 PR will add a third "unverified" value (for the
+   * `lintExempt` override path). A1 ships only the trusted/suspect split.
+   */
+  reliability?: "trusted" | "suspect";
 }

--- a/server/types/execution-plan.ts
+++ b/server/types/execution-plan.ts
@@ -23,4 +23,16 @@ export interface AcceptanceCriterion {
   description: string;
   command: string;
   flaky?: boolean; // Not populated by the planner in Phase 1. Exists for future manual annotation.
+  /**
+   * Per-rule ac-lint exemptions (Q0.5/A1). When an AC's command matches a
+   * deny-list pattern but the author has a justified reason (e.g. an
+   * intentional-looking pattern that is not actually subprocess-unsafe in
+   * this context), they can attach a `lintExempt` entry naming the specific
+   * `ruleId`. The lint module honors the exemption: matching findings are
+   * still reported, but `exempt: true` downgrades the overall `suspect`
+   * verdict for that rule. Other rules still fire normally. See
+   * `server/validation/ac-lint.ts`. Governance cap: plans with >3 total
+   * lintExempt entries across all ACs are flagged for review.
+   */
+  lintExempt?: { ruleId: string; rationale: string } | Array<{ ruleId: string; rationale: string }>;
 }

--- a/server/validation/ac-lint.test.ts
+++ b/server/validation/ac-lint.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from "vitest";
+import { lintAcCommand, lintPlan } from "./ac-lint.js";
+
+describe("lintAcCommand — WRONG patterns (must flag)", () => {
+  it("F55: vitest count-based grep with [5-9]", () => {
+    const cmd =
+      "npx vitest run server/lib/topo-sort.test.ts 2>&1 | grep -qE 'Tests[[:space:]]+[5-9]|Tests[[:space:]]+[0-9]{2,}'";
+    const r = lintAcCommand(cmd);
+    expect(r.suspect).toBe(true);
+    expect(r.findings.some((f) => f.ruleId === "F55-vitest-count-grep")).toBe(true);
+  });
+
+  it("F55: vitest count-based grep with [8-9] (single-digit variant)", () => {
+    const cmd =
+      "npx vitest run foo.test.ts 2>&1 | grep -qE 'Tests[[:space:]]+[8-9]'";
+    expect(lintAcCommand(cmd).suspect).toBe(true);
+  });
+
+  it("F55: vitest count with {2,} double-digit count", () => {
+    const cmd =
+      "npx vitest run foo.test.ts | grep -qE 'Tests[[:space:]]+[0-9]{2,}'";
+    expect(lintAcCommand(cmd).suspect).toBe(true);
+  });
+
+  it("F56: multi-grep && pipeline", () => {
+    const cmd = "npx vitest run 2>&1 | grep -q 'passed' && ! grep -q 'failed'";
+    const r = lintAcCommand(cmd);
+    expect(r.suspect).toBe(true);
+    expect(r.findings.some((f) => f.ruleId === "F56-multigrep-pipe")).toBe(true);
+  });
+
+  it("F56 multigrep: no-space `&&! grep` variant", () => {
+    const cmd = "cmd | grep -q 'x' &&! grep -q 'y'";
+    // Our regex tolerates optional whitespace around the !.
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F56-multigrep-pipe")).toBe(true);
+  });
+
+  it("F56: lone `grep -q 'passed'` on runner output", () => {
+    const cmd = "npx vitest run -t 'foo' 2>&1 | grep -q 'passed'";
+    const r = lintAcCommand(cmd);
+    expect(r.suspect).toBe(true);
+    expect(r.findings.some((f) => f.ruleId === "F56-passed-grep")).toBe(true);
+  });
+
+  it("F56: lone `grep -q 'failed'` on runner output", () => {
+    const cmd = "npx vitest run | grep -q 'failed'";
+    expect(lintAcCommand(cmd).suspect).toBe(true);
+  });
+
+  it("F36: grep -n on server/ file enumeration (PH01-US-06-AC04 shape)", () => {
+    const cmd =
+      "test -z \"$(grep -n 'callClaude\\|trackedCallClaude' server/lib/coordinator.ts server/lib/topo-sort.ts)\" && echo EMPTY-OK | grep -q EMPTY-OK";
+    const r = lintAcCommand(cmd);
+    expect(r.suspect).toBe(true);
+    expect(r.findings.some((f) => f.ruleId === "F36-source-tree-grep")).toBe(true);
+  });
+
+  it("F36: grep -rn on src/", () => {
+    const cmd = "grep -rn 'Redis' src/";
+    expect(lintAcCommand(cmd).suspect).toBe(true);
+  });
+
+  it("F36: raw rg invocation on a directory", () => {
+    const cmd = "rg 'class UserCache' server/";
+    const r = lintAcCommand(cmd);
+    expect(r.suspect).toBe(true);
+    expect(r.findings.some((f) => f.ruleId === "F36-raw-rg")).toBe(true);
+  });
+
+  it("F36: rg with a flag", () => {
+    const cmd = "rg -l 'foo' lib/";
+    expect(lintAcCommand(cmd).findings.some((f) => f.ruleId === "F36-raw-rg")).toBe(
+      true,
+    );
+  });
+});
+
+describe("lintAcCommand — RIGHT patterns (must NOT flag)", () => {
+  it("exit-code vitest -t filter", () => {
+    const r = lintAcCommand("npx vitest run -t 'budget'");
+    expect(r.suspect).toBe(false);
+    expect(r.findings).toHaveLength(0);
+  });
+
+  it("tsc --noEmit", () => {
+    expect(lintAcCommand("npx tsc --noEmit").suspect).toBe(false);
+  });
+
+  it("node -e inline script", () => {
+    expect(
+      lintAcCommand("node -e \"process.exit(require('./dist/foo').bar?0:1)\"")
+        .suspect,
+    ).toBe(false);
+  });
+
+  it("curl | jq check does not false-positive", () => {
+    expect(
+      lintAcCommand("curl -s localhost:3000/api/users | jq '.users | length'")
+        .suspect,
+    ).toBe(false);
+  });
+
+  it("echo 'passed' benign string is not flagged", () => {
+    // No preceding pipe-into-grep, so F56-passed-grep should not match.
+    expect(lintAcCommand("echo 'passed'").suspect).toBe(false);
+  });
+
+  it("jq '.passed' does not false-positive F56-passed-grep", () => {
+    expect(lintAcCommand("curl -s localhost | jq '.passed'").suspect).toBe(false);
+  });
+
+  it("embedded 'rg' inside a word is not flagged as raw rg", () => {
+    // "merge" contains "rg" — make sure our word-boundary anchor holds.
+    expect(lintAcCommand("git merge --no-ff foo").suspect).toBe(false);
+  });
+});
+
+describe("lintAcCommand — lintExempt precedence", () => {
+  it("exempt AC with matching pattern → finding is exempt, suspect=false", () => {
+    const cmd = "npx vitest run | grep -q 'passed'";
+    const r = lintAcCommand(cmd, {
+      lintExempt: { ruleId: "F56-passed-grep", rationale: "legacy: reviewed" },
+    });
+    expect(r.suspect).toBe(false);
+    const finding = r.findings.find((f) => f.ruleId === "F56-passed-grep");
+    expect(finding?.exempt).toBe(true);
+    expect(finding?.exemptRationale).toBe("legacy: reviewed");
+  });
+
+  it("exempt rule X + match rule Y → still suspect on Y", () => {
+    // Matches F55 (count-grep) but exempt only covers F56-passed-grep.
+    const cmd = "npx vitest run | grep -qE 'Tests[[:space:]]+[5-9]'";
+    const r = lintAcCommand(cmd, {
+      lintExempt: { ruleId: "F56-passed-grep", rationale: "n/a" },
+    });
+    expect(r.suspect).toBe(true);
+    expect(r.findings.some((f) => f.ruleId === "F55-vitest-count-grep" && !f.exempt)).toBe(
+      true,
+    );
+  });
+
+  it("array of exemptions is honored", () => {
+    const cmd = "npx vitest run | grep -q 'passed' && ! grep -q 'failed'";
+    const r = lintAcCommand(cmd, {
+      lintExempt: [
+        { ruleId: "F56-passed-grep", rationale: "a" },
+        { ruleId: "F56-multigrep-pipe", rationale: "b" },
+      ],
+    });
+    expect(r.suspect).toBe(false);
+  });
+});
+
+describe("lintPlan — governance cap and plan-level aggregation", () => {
+  function mkPlan(acs: Array<{ id: string; command: string; lintExempt?: any }>) {
+    return {
+      stories: [
+        {
+          id: "US-01",
+          acceptanceCriteria: acs.map((a) => ({
+            id: a.id,
+            description: a.id,
+            command: a.command,
+            lintExempt: a.lintExempt,
+          })),
+        },
+      ],
+    };
+  }
+
+  it("3 exemptions → governanceViolation=false", () => {
+    const plan = mkPlan([
+      {
+        id: "AC-01",
+        command: "cmd | grep -q 'passed'",
+        lintExempt: { ruleId: "F56-passed-grep", rationale: "ok" },
+      },
+      {
+        id: "AC-02",
+        command: "cmd | grep -q 'passed'",
+        lintExempt: { ruleId: "F56-passed-grep", rationale: "ok" },
+      },
+      {
+        id: "AC-03",
+        command: "cmd | grep -q 'passed'",
+        lintExempt: { ruleId: "F56-passed-grep", rationale: "ok" },
+      },
+    ]);
+    const report = lintPlan(plan);
+    expect(report.lintExemptCount).toBe(3);
+    expect(report.governanceViolation).toBe(false);
+  });
+
+  it("4 exemptions → governanceViolation=true", () => {
+    const plan = mkPlan([
+      { id: "AC-01", command: "echo ok", lintExempt: { ruleId: "X", rationale: "a" } },
+      { id: "AC-02", command: "echo ok", lintExempt: { ruleId: "X", rationale: "a" } },
+      { id: "AC-03", command: "echo ok", lintExempt: { ruleId: "X", rationale: "a" } },
+      { id: "AC-04", command: "echo ok", lintExempt: { ruleId: "X", rationale: "a" } },
+    ]);
+    const report = lintPlan(plan);
+    expect(report.lintExemptCount).toBe(4);
+    expect(report.governanceViolation).toBe(true);
+  });
+
+  it("empty stories → no crash, empty report", () => {
+    const report = lintPlan({ stories: [] });
+    expect(report.findings).toHaveLength(0);
+    expect(report.suspectAcIds).toHaveLength(0);
+    expect(report.lintExemptCount).toBe(0);
+    expect(report.governanceViolation).toBe(false);
+  });
+
+  it("story with zero ACs → no crash", () => {
+    const plan = { stories: [{ id: "US-01", acceptanceCriteria: [] }] };
+    expect(() => lintPlan(plan)).not.toThrow();
+  });
+
+  it("surfaces suspect ACs at plan level", () => {
+    const plan = mkPlan([
+      { id: "AC-01", command: "echo PASS" },
+      { id: "AC-02", command: "npx vitest run | grep -q 'passed'" },
+    ]);
+    const report = lintPlan(plan);
+    expect(report.suspectAcIds).toEqual(["AC-02"]);
+  });
+});

--- a/server/validation/ac-lint.ts
+++ b/server/validation/ac-lint.ts
@@ -1,0 +1,176 @@
+/**
+ * Q0.5/A1 — mechanical lint for AC shell commands.
+ *
+ * Imports the structured deny-list from
+ * `server/lib/prompts/shared/ac-subprocess-rules.ts` (single source of truth,
+ * shared with the planner prompt). Runs each rule's regex against a single AC
+ * command, or across every AC in an execution plan.
+ *
+ * Integration points (permanent consumers):
+ *   - `server/tools/plan.ts` — called after planner output, before write.
+ *   - `server/tools/evaluate.ts` (via `server/lib/evaluator.ts`) — called
+ *     before each AC's shell command is executed; non-exempt suspect ACs
+ *     short-circuit to `reliability=suspect` without spawning a subprocess.
+ *   - `scripts/run-ac-lint.mjs` — advisory CI driver (see
+ *     `.github/workflows/ac-lint.yml`).
+ *
+ * Scope deliberately excluded from A1 (deferred to full A3 / A2 PRs):
+ *   - No "unverified" reliability state (that's full A3).
+ *   - No critic prompt wiring (that's A2).
+ */
+
+import { AC_LINT_RULES, type AcLintRule } from "../lib/prompts/shared/ac-subprocess-rules.js";
+
+export interface LintExempt {
+  ruleId: string;
+  rationale: string;
+}
+
+export interface LintFinding {
+  ruleId: string;
+  description: string;
+  severity: "suspect";
+  /** The substring of the command that matched. */
+  snippet: string;
+  /** True iff the AC had a `lintExempt` entry for this rule. */
+  exempt: boolean;
+  /** Present only when `exempt === true`. */
+  exemptRationale?: string;
+}
+
+export interface LintAcCommandOptions {
+  lintExempt?: LintExempt | LintExempt[];
+}
+
+export interface LintAcCommandResult {
+  /** All rule matches (exempt AND non-exempt). */
+  findings: LintFinding[];
+  /** True iff at least one finding is non-exempt. */
+  suspect: boolean;
+}
+
+function normalizeExempt(
+  exempt?: LintExempt | LintExempt[],
+): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!exempt) return out;
+  const arr = Array.isArray(exempt) ? exempt : [exempt];
+  for (const e of arr) {
+    if (e && typeof e.ruleId === "string") {
+      out.set(e.ruleId, e.rationale ?? "");
+    }
+  }
+  return out;
+}
+
+/**
+ * Run every AC_LINT_RULES regex against a single command string.
+ *
+ * Returns ALL matches (exempt ones flagged with `exempt: true`). `suspect`
+ * is true iff at least one finding has `exempt: false`.
+ */
+export function lintAcCommand(
+  command: string,
+  opts?: LintAcCommandOptions,
+): LintAcCommandResult {
+  const exemptMap = normalizeExempt(opts?.lintExempt);
+  const findings: LintFinding[] = [];
+
+  for (const rule of AC_LINT_RULES) {
+    const match = rule.pattern.exec(command);
+    if (!match) continue;
+    const isExempt = exemptMap.has(rule.id);
+    const finding: LintFinding = {
+      ruleId: rule.id,
+      description: rule.description,
+      severity: rule.severity,
+      snippet: match[0],
+      exempt: isExempt,
+    };
+    if (isExempt) {
+      finding.exemptRationale = exemptMap.get(rule.id);
+    }
+    findings.push(finding);
+  }
+
+  const suspect = findings.some((f) => !f.exempt);
+  return { findings, suspect };
+}
+
+// ── Plan-level API ────────────────────────────────────────
+
+/**
+ * Minimal duck-typed plan shape. Uses a subset of the real `ExecutionPlan`
+ * so this module can accept partial plans (e.g. in tests) and hand-built
+ * objects without forcing the full schemaVersion envelope.
+ */
+export interface LintablePlan {
+  stories: Array<{
+    id: string;
+    acceptanceCriteria?: Array<{
+      id: string;
+      command: string;
+      lintExempt?: LintExempt | LintExempt[];
+    }>;
+    // Legacy / alias — some older internal shapes use `acs`.
+    acs?: Array<{
+      id: string;
+      command: string;
+      lintExempt?: LintExempt | LintExempt[];
+    }>;
+  }>;
+}
+
+export interface LintPlanFinding extends LintFinding {
+  storyId: string;
+  acId: string;
+}
+
+export interface LintPlanReport {
+  /** Every finding across every AC, flat. */
+  findings: LintPlanFinding[];
+  /** AC ids that have at least one NON-exempt finding. */
+  suspectAcIds: string[];
+  /** Total `lintExempt` entries across all ACs (for the governance cap). */
+  lintExemptCount: number;
+  /** True iff `lintExemptCount > 3` (plan-governance cap per Q0.5/A1). */
+  governanceViolation: boolean;
+}
+
+const GOVERNANCE_CAP = 3;
+
+export function lintPlan(plan: LintablePlan): LintPlanReport {
+  const findings: LintPlanFinding[] = [];
+  const suspectAcIds = new Set<string>();
+  let lintExemptCount = 0;
+
+  for (const story of plan.stories ?? []) {
+    const acs = story.acceptanceCriteria ?? story.acs ?? [];
+    for (const ac of acs) {
+      // Count exemption entries for governance.
+      if (ac.lintExempt) {
+        const arr = Array.isArray(ac.lintExempt) ? ac.lintExempt : [ac.lintExempt];
+        lintExemptCount += arr.length;
+      }
+
+      const result = lintAcCommand(ac.command, { lintExempt: ac.lintExempt });
+      for (const f of result.findings) {
+        findings.push({ ...f, storyId: story.id, acId: ac.id });
+      }
+      if (result.suspect) {
+        suspectAcIds.add(ac.id);
+      }
+    }
+  }
+
+  return {
+    findings,
+    suspectAcIds: Array.from(suspectAcIds),
+    lintExemptCount,
+    governanceViolation: lintExemptCount > GOVERNANCE_CAP,
+  };
+}
+
+// Re-export for consumers that want to inspect the rule list.
+export { AC_LINT_RULES };
+export type { AcLintRule };


### PR DESCRIPTION
## Summary
- New `server/lib/prompts/shared/ac-subprocess-rules.ts` is the single source of truth for the AC subprocess-safety rules (F55/F56/F36). `planner.ts` now imports from it instead of carrying the rule text inline. Future A2 will add `critic.ts` as the second importer.
- New `server/validation/ac-lint.ts` implements the deny-list with 5 rules, per-rule `lintExempt` override, and a governance cap of 3 exemptions per plan. Returns structured `LintPlanReport` with `suspectAcIds`, `lintExemptCount`, `governanceViolation`.
- Wired into `forge_plan` (advisory by default; new `strictLint: true` input throws on any suspect finding or governance violation) and `forge_evaluate` at the shared `evaluateStory` loop so both story mode and divergence mode inherit the short-circuit — suspect ACs route to `SKIPPED` with `reliability: "suspect"` and zero subprocess cost.
- Minimum A3 slice: `CriterionResult.reliability?: "trusted" | "suspect"` optional field. Full A3 (unverified value, `suspectFailures` split, K=10 cap, `a3-carry-forward.json`) is a follow-up.
- `.github/workflows/ac-lint.yml` ships as advisory-only per A1c with a preflight ordering gate that requires `retroactive-critique.yml` on master or in the PR diff. A stub `retroactive-critique.yml` (workflow_dispatch only) lands in the same PR to satisfy the gate mechanically; Q0.5/C1 replaces the stub with the full retroactive-critique body.

## Test plan
- [x] `npm run build` — clean, 0 TS errors
- [x] `npm test` — 622 passing + 4 skipped (up from 591; +31 new tests: 26 ac-lint + 3 evaluator + 2 plan)
- [x] `node scripts/run-ac-lint.mjs` against current corpus — runs cleanly, emits markdown summary
- [x] PH01-US-06 lint verification — exactly 6 suspect findings (5 subprocess AC01/02/03/05/06 + 1 source-tree AC04), matches Appendix A
- [x] Stateless cold review round 1 — PASS, 0 blockers
- [x] Planner prompt byte-identity verified — `\${AC_SUBPROCESS_RULES_PROMPT}` embed preserves all 11 lines of the AC Command Contract block verbatim

## Scope
Refs: Q0.5/A1 in `.ai-workspace/plans/2026-04-12-next-execution-plan.md`. Explicit negatives: does NOT modify `critic.ts` (A2), does NOT add smoke-test mode (B1), does NOT implement full retroactive critique (C1 — stub only), does NOT reactivate the `flaky` field (C2), does NOT rewrite PH-01 suspect ACs (absorbed into normal plan-refresh loop via Q0's forge_reconcile).

---
plan-refresh: no-op