### PR TITLE
feat(q0.5-a2): critic parity + structured AC_LINT_RULES + regex hardening

### DIFF
--- a/server/lib/prompts/critic.test.ts
+++ b/server/lib/prompts/critic.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCriticPrompt,
+  renderAcLintRulesForCritic,
+} from "./critic.js";
+import { AC_LINT_RULES } from "./shared/ac-subprocess-rules.js";
+
+describe("buildCriticPrompt — Q0.5/A2 subprocess-safety parity", () => {
+  it("embeds the full AC Command Contract prompt block", () => {
+    const prompt = buildCriticPrompt(1);
+    expect(prompt).toContain("AC Command Contract");
+    expect(prompt).toContain("node:child_process.exec()");
+    expect(prompt).toContain("30s timeout");
+  });
+
+  it("cites every AC_LINT_RULES id as a structured bullet", () => {
+    const prompt = buildCriticPrompt(1);
+    for (const rule of AC_LINT_RULES) {
+      expect(prompt, `rule ${rule.id} must appear`).toContain(rule.id);
+      expect(prompt, `${rule.id} wrongExample`).toContain(rule.wrongExample);
+      expect(prompt, `${rule.id} rightExample`).toContain(rule.rightExample);
+    }
+  });
+
+  it("includes a Subprocess Safety category (#9) in the What to Check list", () => {
+    const prompt = buildCriticPrompt(1);
+    expect(prompt).toMatch(/9\.\s+\*\*Subprocess Safety/);
+  });
+
+  it("round-2 regression check survives the rule injection", () => {
+    const round2 = buildCriticPrompt(2);
+    expect(round2).toContain("Regression Check (Round 2 Only)");
+    expect(round2).toContain("F55-vitest-count-grep");
+  });
+});
+
+describe("renderAcLintRulesForCritic", () => {
+  it("renders exactly 5 bullets, one per rule", () => {
+    const rendered = renderAcLintRulesForCritic();
+    const bulletCount = rendered.split(/^- \*\*/gm).length - 1;
+    expect(bulletCount).toBe(AC_LINT_RULES.length);
+  });
+
+  it("each bullet has Wrong and Right lines", () => {
+    const rendered = renderAcLintRulesForCritic();
+    const wrongCount = (rendered.match(/Wrong:/g) ?? []).length;
+    const rightCount = (rendered.match(/Right:/g) ?? []).length;
+    expect(wrongCount).toBe(AC_LINT_RULES.length);
+    expect(rightCount).toBe(AC_LINT_RULES.length);
+  });
+});

--- a/server/lib/prompts/critic.ts
+++ b/server/lib/prompts/critic.ts
@@ -1,3 +1,20 @@
+import {
+  AC_SUBPROCESS_RULES_PROMPT,
+  AC_LINT_RULES,
+} from "./shared/ac-subprocess-rules.js";
+
+/**
+ * Render the structured rule list as a markdown block the critic can cite.
+ * Exposed so tests can assert exact rule-id coverage.
+ */
+export function renderAcLintRulesForCritic(): string {
+  const lines = AC_LINT_RULES.map(
+    (r) =>
+      `- **${r.id}**: ${r.description}\n  - Wrong: \`${r.wrongExample}\`\n  - Right: \`${r.rightExample}\``,
+  );
+  return lines.join("\n");
+}
+
 /**
  * Build the system prompt for a master plan critic agent.
  * Reviews a master plan for vision coverage and phase sequencing quality.
@@ -101,6 +118,15 @@ You see ONLY the execution plan JSON. Review it for quality and correctness.
 8. **Evidence-Gating:** If the plan references specific files, functions, or patterns in the codebase,
    are those references grounded in the codebase context? Flag any claim about the codebase that
    appears to be assumed rather than cited from provided context.
+9. **Subprocess Safety (AC Command Contract):** Every AC command runs inside
+   \`node:child_process.exec()\` — no TTY, no stdin, 30s timeout. Flag any AC
+   command that violates the rules below. When flagging, cite the specific
+   rule id (e.g. "F55-vitest-count-grep") in your \`description\`.
+
+${AC_SUBPROCESS_RULES_PROMPT}
+
+**Subprocess-safety rules (cite the id in findings):**
+${renderAcLintRulesForCritic()}
 
 ## Output Format
 

--- a/server/lib/prompts/shared/ac-subprocess-rules.ts
+++ b/server/lib/prompts/shared/ac-subprocess-rules.ts
@@ -1,23 +1,19 @@
 /**
- * Shared source of truth for AC subprocess-safety rules (Q0.5/A2).
+ * Shared source of truth for AC subprocess-safety rules (Q0.5/A1 + A2).
  *
- * Both `planner.ts` (generation-time embedding in the LLM prompt) and
- * `server/validation/ac-lint.ts` (mechanical lint at the primitive boundary)
- * import from this file. This prevents the rule-parity gap that let
- * PH01-US-06 ship with TTY-dependent greps — there is now exactly one place
- * where the rules live.
- *
- * `critic.ts` will also import from this file when Q0.5/A2 (critic-prompt
- * update) ships. That's a separate PR.
+ * Consumers:
+ *   - `server/lib/prompts/planner.ts` — embeds AC_SUBPROCESS_RULES_PROMPT.
+ *   - `server/lib/prompts/critic.ts` — embeds AC_SUBPROCESS_RULES_PROMPT +
+ *     cites AC_LINT_RULES by id in findings (Q0.5/A2).
+ *   - `server/validation/ac-lint.ts` — mechanical lint at the primitive boundary.
  *
  * Do NOT duplicate these patterns elsewhere — import from here.
  */
 
 /**
  * Human-readable prompt block embedded into planner/critic system prompts.
- * This is the BYTE-IDENTICAL extraction of planner.ts:272-283's
- * "AC Command Contract" section. Any future edit to the rule text must
- * happen here and here only.
+ * Byte-identical extraction of the original planner "AC Command Contract"
+ * section. Any future edit to the rule text must happen here only.
  */
 export const AC_SUBPROCESS_RULES_PROMPT = `### AC Command Contract
 AC commands execute inside node:child_process.exec() with bash shell.
@@ -33,13 +29,10 @@ Exit code 0 = PASS, non-zero = FAIL. Design commands accordingly:
 - 30s timeout — keep commands focused. Use -t filters for test suites instead of running all tests.`;
 
 /**
- * Structured deny-list rules, consumed by `lintAcCommand`.
+ * Structured deny-list rules, consumed by `lintAcCommand` and cited by critic.
  *
- * Each rule's `pattern` is anchored conservatively so it does NOT false-positive
- * on benign commands like `echo 'passed'` or `jq '.passed'`. The anchoring
- * strategy is: match only when the offending construct appears as a shell
- * token (word-boundary `grep`/`rg`) with the specific flag/argument shape
- * that produces the failure mode.
+ * Each rule carries `wrongExample` + `rightExample` so the critic can surface
+ * concrete examples in its findings (Q0.5/A2 richer-scope payoff).
  */
 export interface AcLintRule {
   /** Stable identifier, e.g. "F55-vitest-count-grep". */
@@ -48,117 +41,87 @@ export interface AcLintRule {
   description: string;
   /** Regex applied to the full AC command string. */
   pattern: RegExp;
-  /** Severity — only "suspect" for now (scope of A1). */
+  /** Severity — only "suspect" for now (scope of A1/A2). */
   severity: "suspect";
+  /** Concrete WRONG example that this rule flags. */
+  wrongExample: string;
+  /** Concrete RIGHT example that demonstrates the safe alternative. */
+  rightExample: string;
 }
 
 export const AC_LINT_RULES: AcLintRule[] = [
-  /**
-   * F55 — count-based vitest summary grep.
-   *
-   * Wrong: `npx vitest run foo.test.ts 2>&1 | grep -qE 'Tests[[:space:]]+[5-9]'`
-   * Right: `npx vitest run -t 'budget'` (relies on exit code, no stdout parsing)
-   *
-   * The vitest summary line "Tests  5 passed" is TTY-dependent; in
-   * child_process.exec() (no TTY) the formatting or even the line itself
-   * may be absent, so the grep silently returns "no match" (exit 1) and
-   * the AC spuriously fails. We match the characteristic
-   * `Tests[[:space:]]+<digit-range>` regex that F55 uses.
-   */
   {
     id: "F55-vitest-count-grep",
     description:
       "count-based vitest summary grep (TTY-dependent; use exit-code -t filter instead)",
+    // Matches `grep -qE 'Tests[[:space:]]+[5-9]'` and digit-count variants.
     pattern:
       /grep\s+-[a-zA-Z]*E[a-zA-Z]*\s+['"][^'"]*Tests\s*(?:\[\[:space:\]\]|\\s|\s)\+[^'"]*[0-9][^'"]*['"]/,
     severity: "suspect",
+    wrongExample:
+      "npx vitest run foo.test.ts 2>&1 | grep -qE 'Tests[[:space:]]+[5-9]'",
+    rightExample: "npx vitest run -t 'budget'",
   },
 
-  /**
-   * F56 — multi-grep pipeline with `&&`.
-   *
-   * Wrong: `cmd | grep -q 'x' && ! grep -q 'y'`
-   * Wrong: `cmd | grep -q 'x' && grep -q 'y'`
-   * Right: `OUT=$(cmd 2>&1); echo "$OUT" | grep -q 'x' && ! echo "$OUT" | grep -q 'y'`
-   *
-   * The second grep in the `&&` chain has no stdin (the pipeline ended at
-   * the first grep), so on a system with no TTY it blocks waiting for
-   * stdin → hung process or spurious match depending on buffering.
-   *
-   * We require a pipe `|` before the first grep (so this is not a
-   * standalone grep on a file argument) and a `&& ` then optional `!` then
-   * another `grep -q` without an intervening `echo` / input source.
-   */
   {
     id: "F56-multigrep-pipe",
     description:
-      "multi-grep `&&` pipeline where the second grep has no stdin (hangs or false-passes)",
+      "multi-grep pipeline chained with `&&`/`||`/`;` where the second grep has no stdin (hangs or false-passes)",
+    // Q0.5/A2 MINOR-4 fix: accept && | || | ; as the chain operator.
     pattern:
-      /\|\s*grep\s+-[a-zA-Z]*q[a-zA-Z]*\s+['"][^'"]*['"]\s*&&\s*!?\s*grep\s+-[a-zA-Z]*q/,
+      /\|\s*grep\s+-[a-zA-Z]*q[a-zA-Z]*\s+['"][^'"]*['"]\s*(?:&&|\|\||;)\s*!?\s*grep\s+-[a-zA-Z]*q/,
     severity: "suspect",
+    wrongExample: "cmd | grep -q 'x' && ! grep -q 'y'",
+    rightExample:
+      "OUT=$(cmd 2>&1); echo \"$OUT\" | grep -q 'x' && ! echo \"$OUT\" | grep -q 'y'",
   },
 
-  /**
-   * F56 variant — lone `grep -q 'passed'` / `grep -q 'failed'` on runner output.
-   *
-   * Wrong: `npx vitest run 2>&1 | grep -q 'passed'`
-   * Wrong: `cmd | grep -q 'failed'`
-   * Right: `npx vitest run -t 'foo'` (exit-code check)
-   *
-   * Matches a pipe-into-grep-q on the literal tokens `passed` or `failed`.
-   * The benign case `echo 'passed'` is NOT matched because there's no
-   * preceding pipe into the grep. `jq '.passed'` is NOT matched because
-   * the tool name is `jq`, not `grep`.
-   */
   {
     id: "F56-passed-grep",
     description:
-      "lone `grep -q 'passed'/'failed'` on runner output (TTY-dependent summary line)",
+      "lone `grep -q 'passed'/'failed'` on runner output (TTY-dependent summary line; includes unquoted + regex-alt forms)",
+    // Q0.5/A2 MINOR-5 fix: also match `grep -qE 'passed|failed'`, unquoted
+    // `grep -q passed`, and any quoted arg containing the bare word `passed`
+    // or `failed`.
     pattern:
-      /\|\s*grep\s+-[a-zA-Z]*q[a-zA-Z]*\s+['"](?:passed|failed)['"]/,
+      /\|\s*grep\s+-[a-zA-Z]*q[a-zA-Z]*\s+(?:['"][^'"]*\b(?:passed|failed)\b[^'"]*['"]|(?:passed|failed)\b)/,
     severity: "suspect",
+    wrongExample: "npx vitest run 2>&1 | grep -q 'passed'",
+    rightExample: "npx vitest run -t 'foo'",
   },
 
-  /**
-   * F36 — source-tree grep (recursive).
-   *
-   * Wrong: `grep -rn 'Redis' src/`
-   * Wrong: `grep -n 'foo' server/lib/bar.ts server/lib/baz.ts`
-   * Right: `curl localhost:3000/api | jq '.cache'` (observable behavior)
-   *
-   * ACs must not inspect source code — they verify observable behavior.
-   * This matches both recursive `grep -rn` on a directory path AND the
-   * PH01-US-06-AC04 pattern of enumerating individual files under
-   * `src/` / `server/` / `lib/`.
-   */
   {
     id: "F36-source-tree-grep",
     description:
       "grep inspecting source tree (src/, server/, lib/) instead of verifying observable behavior",
+    // Q0.5/A2 MAJOR-2 fix: structural anchoring. Require the path token to
+    // appear as a DIRECT grep argument — flags, optional quoted pattern,
+    // then (src|server|lib)/path — NOT as trailing text anywhere after grep.
+    // This rejects benign chains like
+    //   `grep -q 'ok' out.log && curl localhost/src/main.js`
+    // (where `src/` is inside a URL, not a grep arg), while still matching
+    //   `grep -n 'callClaude\|trackedCallClaude' server/lib/coordinator.ts`
+    // (where `\|` appears inside a quoted grep pattern — the OLD lazy
+    //  `[^\n;]*?` span was too permissive and couldn't reject the &&/|| case).
     pattern:
-      /\bgrep\b[^\n;]*?(?:\s|["'])(?:src|server|lib)\/[A-Za-z0-9_\-./]*/,
+      /\bgrep\b(?:\s+-[A-Za-z]+)*\s+(?:['"][^'"]*['"]\s+)?(?:src|server|lib)\/[A-Za-z0-9_\-./]*/,
     severity: "suspect",
+    wrongExample: "grep -rn 'Redis' src/",
+    rightExample: "curl localhost:3000/api | jq '.cache'",
   },
 
-  /**
-   * F36 — raw `rg` (ripgrep) invocation.
-   *
-   * Wrong: `rg 'class UserCache' server/`
-   * Right: Use `grep` only for evidence-checking output, not source inspection.
-   *
-   * ripgrep is not guaranteed to be installed on the machine running the
-   * AC (especially in lean CI containers). Plus — same source-inspection
-   * anti-pattern as F36-source-tree-grep.
-   *
-   * Match `rg` as a standalone command token (start of line, after `|`,
-   * after `;`, or after `&&`) followed by a flag or quoted pattern. We
-   * reject leading-word matches like `rg` inside an identifier or path.
-   */
   {
     id: "F36-raw-rg",
     description:
-      "raw `rg` (ripgrep) invocation — portability risk; rg may not be installed",
-    pattern: /(?:^|[|;&]\s*)rg\s+(?:-[a-zA-Z]|['"])/,
+      "raw `rg` (ripgrep) invocation — portability risk and source-inspection anti-pattern",
+    // Q0.5/A2 MINOR-3 fix: also match bare-word arguments
+    // (`rg pattern server/`), not just quoted-or-flag forms. Negative
+    // lookahead allows `rg --help` / `rg --version` through (those are
+    // ergonomic probes, not source inspection). `rg` must be a standalone
+    // command token (start-of-line, or after `|`/`;`/`&`).
+    pattern: /(?:^|[|;&]\s*)rg\s+(?!--(?:help|version)\b)\S+/,
     severity: "suspect",
+    wrongExample: "rg 'class UserCache' server/",
+    rightExample: "curl localhost:3000/api/classes | jq '.UserCache'",
   },
 ];

--- a/server/validation/ac-lint.test.ts
+++ b/server/validation/ac-lint.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { lintAcCommand, lintPlan } from "./ac-lint.js";
+import { AC_LINT_RULES } from "../lib/prompts/shared/ac-subprocess-rules.js";
 
 describe("lintAcCommand — WRONG patterns (must flag)", () => {
   it("F55: vitest count-based grep with [5-9]", () => {
@@ -73,6 +74,88 @@ describe("lintAcCommand — WRONG patterns (must flag)", () => {
     expect(lintAcCommand(cmd).findings.some((f) => f.ruleId === "F36-raw-rg")).toBe(
       true,
     );
+  });
+});
+
+describe("lintAcCommand — Q0.5/A2 MAJOR-2/MINOR-3/4/5 additions", () => {
+  // MAJOR-2 false-positive regressions — each was falsely SKIPPED by A1's regex.
+  it("MAJOR-2 FP-a: grep + && + url containing 'src' must NOT flag F36", () => {
+    const cmd = "grep -q 'ok' out.log && curl localhost:3000/src/main.js";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F36-source-tree-grep")).toBe(false);
+  });
+
+  it("MAJOR-2 FP-b: grep + || + echo containing 'server/' must NOT flag F36", () => {
+    const cmd = "grep -q 'x' out.log || echo 'server/up'";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F36-source-tree-grep")).toBe(false);
+  });
+
+  it("MAJOR-2 FP-c: grep + ; + ls lib/*.ts must NOT flag F36", () => {
+    const cmd = "grep -q 'foo' out.log ; ls lib/*.ts";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F36-source-tree-grep")).toBe(false);
+  });
+
+  // MINOR-3: bare-word rg arg.
+  it("MINOR-3: `rg pattern server/` (unquoted single-word) flags F36-raw-rg", () => {
+    const cmd = "rg pattern server/";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F36-raw-rg")).toBe(true);
+  });
+
+  it("MINOR-3: `rg --help` does NOT flag (flag-only probe is allowed)", () => {
+    expect(lintAcCommand("rg --help").suspect).toBe(false);
+  });
+
+  it("MINOR-3: `rg --version` does NOT flag", () => {
+    expect(lintAcCommand("rg --version").suspect).toBe(false);
+  });
+
+  // MINOR-4: `||` and `;` variants of multi-grep.
+  it("MINOR-4: `cmd | grep -q 'x' || grep -q 'y'` flags F56-multigrep-pipe", () => {
+    const cmd = "cmd | grep -q 'x' || grep -q 'y'";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F56-multigrep-pipe")).toBe(true);
+  });
+
+  it("MINOR-4: `cmd | grep -q 'x' ; grep -q 'y'` flags F56-multigrep-pipe", () => {
+    const cmd = "cmd | grep -q 'x' ; grep -q 'y'";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F56-multigrep-pipe")).toBe(true);
+  });
+
+  // MINOR-5: regex-alt and unquoted passed/failed.
+  it("MINOR-5: `grep -qE 'passed|failed'` flags F56-passed-grep", () => {
+    const cmd = "npx vitest run | grep -qE 'passed|failed'";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F56-passed-grep")).toBe(true);
+  });
+
+  it("MINOR-5: `grep -q passed` (unquoted) flags F56-passed-grep", () => {
+    const cmd = "npx vitest run | grep -q passed";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F56-passed-grep")).toBe(true);
+  });
+});
+
+describe("AC_LINT_RULES structure (Q0.5/A2 typed-export contract)", () => {
+  it("every rule has a non-empty wrongExample and rightExample", () => {
+    for (const rule of AC_LINT_RULES) {
+      expect(rule.wrongExample, `${rule.id}.wrongExample`).toBeTruthy();
+      expect(rule.rightExample, `${rule.id}.rightExample`).toBeTruthy();
+    }
+  });
+
+  it("exports exactly the 5 rules A1 shipped (no accidental drops)", () => {
+    const ids = AC_LINT_RULES.map((r) => r.id).sort();
+    expect(ids).toEqual([
+      "F36-raw-rg",
+      "F36-source-tree-grep",
+      "F55-vitest-count-grep",
+      "F56-multigrep-pipe",
+      "F56-passed-grep",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Q0.5/A2 — critic parity with planner via shared `AC_SUBPROCESS_RULES_PROMPT`, structured `AC_LINT_RULES` export with `wrongExample`/`rightExample` fields so critic can cite rule ids in findings, and the 2 MAJOR + 3 MINOR regex fixes forge-plan's round-2 cold review flagged against PR #167.

- **A2 core:** Critic imports `AC_SUBPROCESS_RULES_PROMPT` + `AC_LINT_RULES` from `server/lib/prompts/shared/ac-subprocess-rules.ts`. New check category #9 "Subprocess Safety" in `buildCriticPrompt`. New `renderAcLintRulesForCritic()` emits structured markdown bullets letting critic findings cite rule ids with wrong/right examples.
- **MAJOR-2 hotfix:** F36-source-tree-grep false positive on `&&`/`||`/`;` chains. Fixed via **structural anchoring** (require path as direct grep argument) rather than operator exclusion — exclusion would have broken the existing PH01-US-06-AC04 test where `\|` appears inside a quoted grep pattern.
- **MINOR-3:** F36-raw-rg now matches bare-word args (`rg pattern server/`) with negative lookahead allowing `rg --help`/`--version`.
- **MINOR-4:** F56-multigrep now matches `||` and `;` chain operators, not just `&&`.
- **MINOR-5:** F56-passed-grep now matches `grep -qE 'passed|failed'` and `grep -q passed` (unquoted).

Single-source-of-truth architecture from A1 paid off — planner.ts pulls the same constant, zero risk of rule drift.

## Test plan

- [x] `npm run build` clean (0 TS errors)
- [x] `npx vitest run` → **640 passing, 4 skipped** (baseline 622 → +18 new: 10 ac-lint + 2 structure + 6 critic prompt). Zero regressions.
- [x] Existing PH01-US-06-AC04 test (`grep -n 'callClaude\|trackedCallClaude' server/lib/coordinator.ts`) still flags F36-source-tree-grep after MAJOR-2 anchoring fix.
- [x] 3 new FP test cases assert clean ACs with `&&`/`||`/`;` chains do NOT flag.
- [x] Critic prompt embeds full AC Command Contract + every rule id + wrong/right examples.
- [x] Round-2 regression check (round === 2) still emits `[REGRESSION]` tag section after rule injection.

Implements Q0.5/A2 per forge-plan mailbox 2026-04-13T2000 PASS-WITH-NOTES verdict. Does NOT touch A3 schema, B1 smoke-test, C1 retroactive-critique.yml body, or C2 flaky field — those are parallel PRs per forge-plan's sequencing recommendation.

---
plan-refresh: no-op