### PR TITLE
fix(evaluator): Q0.5/C2 reactivate flaky field with retry-on-failure

### DIFF
--- a/server/lib/evaluator.test.ts
+++ b/server/lib/evaluator.test.ts
@@ -325,6 +325,110 @@ describe("evaluateStory", () => {
     });
   });
 
+  // Q0.5/C2 — flaky field retry semantics.
+  describe("flaky retry (C2)", () => {
+    function flakyPlan(flaky: boolean, command = "echo ok"): ExecutionPlan {
+      return {
+        schemaVersion: "3.0.0",
+        stories: [
+          {
+            id: "US-01",
+            title: "Flaky",
+            acceptanceCriteria: [
+              { id: "AC-01", description: "maybe flaky", command, flaky },
+            ],
+          },
+        ],
+      };
+    }
+
+    it("flaky AC: run-1 FAIL + run-2 PASS → PASS with reliability=suspect", async () => {
+      mockedExecute
+        .mockResolvedValueOnce(mockResult({ status: "FAIL", evidence: "first fail" }))
+        .mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "retry ok" }));
+
+      const report = await evaluateStory(flakyPlan(true), "US-01", {
+        flakyRetryGapMs: 1,
+      });
+      expect(mockedExecute).toHaveBeenCalledTimes(2);
+      expect(report.verdict).toBe("PASS");
+      expect(report.criteria[0].status).toBe("PASS");
+      expect(report.criteria[0].reliability).toBe("suspect");
+      expect(report.criteria[0].evidence).toContain("flaky-retry");
+      expect(report.criteria[0].evidence).toContain("retry ok");
+    });
+
+    it("flaky AC: both runs FAIL → FAIL, reliability=trusted", async () => {
+      mockedExecute
+        .mockResolvedValueOnce(mockResult({ status: "FAIL", evidence: "first fail" }))
+        .mockResolvedValueOnce(mockResult({ status: "FAIL", evidence: "second fail" }));
+
+      const report = await evaluateStory(flakyPlan(true), "US-01", {
+        flakyRetryGapMs: 1,
+      });
+      expect(mockedExecute).toHaveBeenCalledTimes(2);
+      expect(report.verdict).toBe("FAIL");
+      expect(report.criteria[0].status).toBe("FAIL");
+      expect(report.criteria[0].reliability).toBe("trusted");
+      expect(report.criteria[0].evidence).toContain("both runs FAIL");
+      expect(report.criteria[0].evidence).toContain("first fail");
+    });
+
+    it("flaky AC: run-1 PASS → no retry spawned", async () => {
+      mockedExecute.mockResolvedValueOnce(
+        mockResult({ status: "PASS", evidence: "clean ok" }),
+      );
+
+      const report = await evaluateStory(flakyPlan(true), "US-01", {
+        flakyRetryGapMs: 1,
+      });
+      expect(mockedExecute).toHaveBeenCalledTimes(1);
+      expect(report.verdict).toBe("PASS");
+      expect(report.criteria[0].reliability).toBe("trusted");
+      expect(report.criteria[0].evidence).toBe("clean ok");
+    });
+
+    it("lint-flagged AC with flaky:true → A1b short-circuit wins, no retry", async () => {
+      const plan: ExecutionPlan = {
+        schemaVersion: "3.0.0",
+        stories: [
+          {
+            id: "US-01",
+            title: "Lint-flagged + flaky",
+            acceptanceCriteria: [
+              {
+                id: "AC-01",
+                description: "bad count grep marked flaky",
+                command: "npx vitest run foo.test.ts | grep -qE 'Tests[[:space:]]+[5-9]'",
+                flaky: true,
+              },
+            ],
+          },
+        ],
+      };
+      const report = await evaluateStory(plan, "US-01", { flakyRetryGapMs: 1 });
+      expect(mockedExecute).not.toHaveBeenCalled();
+      expect(report.criteria[0].status).toBe("SKIPPED");
+      expect(report.criteria[0].reliability).toBe("suspect");
+      expect(report.verdict).toBe("INCONCLUSIVE");
+    });
+
+    it("non-flaky AC: run-1 FAIL → FAIL, no retry (regression guard)", async () => {
+      mockedExecute.mockResolvedValueOnce(
+        mockResult({ status: "FAIL", evidence: "real fail" }),
+      );
+
+      const report = await evaluateStory(flakyPlan(false), "US-01", {
+        flakyRetryGapMs: 1,
+      });
+      expect(mockedExecute).toHaveBeenCalledTimes(1);
+      expect(report.verdict).toBe("FAIL");
+      expect(report.criteria[0].status).toBe("FAIL");
+      expect(report.criteria[0].evidence).toBe("real fail");
+      expect(report.criteria[0].evidence).not.toContain("flaky-retry");
+    });
+  });
+
   it("runs ACs sequentially", async () => {
     const callOrder: number[] = [];
     mockedExecute

--- a/server/lib/evaluator.test.ts
+++ b/server/lib/evaluator.test.ts
@@ -413,6 +413,38 @@ describe("evaluateStory", () => {
       expect(report.verdict).toBe("INCONCLUSIVE");
     });
 
+    it("flaky AC: run-1 INCONCLUSIVE → passes through, no retry spawned", async () => {
+      mockedExecute.mockResolvedValueOnce(
+        mockResult({ status: "INCONCLUSIVE", evidence: "spawn ENOENT" }),
+      );
+
+      const report = await evaluateStory(flakyPlan(true), "US-01", {
+        flakyRetryGapMs: 1,
+      });
+      expect(mockedExecute).toHaveBeenCalledTimes(1);
+      expect(report.verdict).toBe("INCONCLUSIVE");
+      expect(report.criteria[0].status).toBe("INCONCLUSIVE");
+      expect(report.criteria[0].reliability).toBe("trusted");
+      expect(report.criteria[0].evidence).toBe("spawn ENOENT");
+      expect(report.criteria[0].evidence).not.toContain("flaky-retry");
+    });
+
+    it("flaky AC: run-1 FAIL + run-2 INCONCLUSIVE → INCONCLUSIVE with accurate evidence prefix", async () => {
+      mockedExecute
+        .mockResolvedValueOnce(mockResult({ status: "FAIL", evidence: "first fail" }))
+        .mockResolvedValueOnce(
+          mockResult({ status: "INCONCLUSIVE", evidence: "retry ENOENT" }),
+        );
+
+      const report = await evaluateStory(flakyPlan(true), "US-01", {
+        flakyRetryGapMs: 1,
+      });
+      expect(mockedExecute).toHaveBeenCalledTimes(2);
+      expect(report.criteria[0].status).toBe("INCONCLUSIVE");
+      expect(report.criteria[0].evidence).toContain("run-1 FAIL, run-2 INCONCLUSIVE");
+      expect(report.criteria[0].evidence).not.toContain("both runs FAIL");
+    });
+
     it("non-flaky AC: run-1 FAIL → FAIL, no retry (regression guard)", async () => {
       mockedExecute.mockResolvedValueOnce(
         mockResult({ status: "FAIL", evidence: "real fail" }),

--- a/server/lib/evaluator.ts
+++ b/server/lib/evaluator.ts
@@ -90,7 +90,12 @@ export async function evaluateStory(
     // means the subprocess machinery itself failed (ENOENT, etc.) — retrying
     // won't fix a missing binary.
     if (ac.flaky === true && firstRun.status === "FAIL") {
-      const gapMs = options?.flakyRetryGapMs ?? DEFAULT_FLAKY_RETRY_GAP_MS;
+      // Clamp negative/NaN to zero so a malformed option can never become a
+      // long delay via setTimeout coercion (setTimeout itself already
+      // clamps, but an explicit Math.max documents intent and survives
+      // future refactors of `sleep`).
+      const rawGap = options?.flakyRetryGapMs ?? DEFAULT_FLAKY_RETRY_GAP_MS;
+      const gapMs = Number.isFinite(rawGap) ? Math.max(0, rawGap) : DEFAULT_FLAKY_RETRY_GAP_MS;
       await sleep(gapMs);
       const secondRun = await executeCommand(ac.command, execOptions);
 
@@ -109,13 +114,20 @@ export async function evaluateStory(
         continue;
       }
 
-      // Both runs failed — real failure. Keep the first run's evidence as
-      // the primary signal; a flaky AC failing twice in a row is the
-      // strongest "this is actually broken" signal we can get.
+      // Retry did not pass. Emit an evidence prefix that accurately reflects
+      // run-2's actual status — FAIL means "both runs failed" (strongest
+      // real-failure signal), INCONCLUSIVE means "run-2 subprocess machinery
+      // broke" (e.g. ENOENT on retry; treat as flaky-then-infra rather than
+      // real failure). Forward secondRun.status either way so downstream
+      // aggregation behaves correctly.
+      const prefix =
+        secondRun.status === "FAIL"
+          ? "flaky-retry: both runs FAIL"
+          : `flaky-retry: run-1 FAIL, run-2 ${secondRun.status}`;
       criteria.push({
         id: ac.id,
         status: secondRun.status,
-        evidence: `flaky-retry: both runs FAIL — ${firstRun.evidence}`,
+        evidence: `${prefix} — ${firstRun.evidence}`,
         reliability: "trusted",
       });
       continue;

--- a/server/lib/evaluator.ts
+++ b/server/lib/evaluator.ts
@@ -6,6 +6,18 @@ import { lintAcCommand } from "../validation/ac-lint.js";
 export interface EvaluateOptions {
   timeoutMs?: number;
   cwd?: string;
+  /**
+   * Q0.5/C2 — gap in ms between run-1 and run-2 when an AC marked `flaky: true`
+   * returns FAIL on its first run. Default 500ms. Ignored for non-flaky ACs
+   * and for ACs short-circuited by ac-lint.
+   */
+  flakyRetryGapMs?: number;
+}
+
+const DEFAULT_FLAKY_RETRY_GAP_MS = 500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
@@ -69,11 +81,50 @@ export async function evaluateStory(
       continue;
     }
 
-    const result = await executeCommand(ac.command, execOptions);
+    const firstRun = await executeCommand(ac.command, execOptions);
+
+    // Q0.5/C2 — flaky retry gate. Only fires when (a) the AC author opted in
+    // via `flaky: true`, (b) ac-lint passed clean (we're past the A1b
+    // short-circuit), and (c) run-1 actually returned FAIL. PASS and
+    // INCONCLUSIVE are NOT retried: PASS needs no retry, and INCONCLUSIVE
+    // means the subprocess machinery itself failed (ENOENT, etc.) — retrying
+    // won't fix a missing binary.
+    if (ac.flaky === true && firstRun.status === "FAIL") {
+      const gapMs = options?.flakyRetryGapMs ?? DEFAULT_FLAKY_RETRY_GAP_MS;
+      await sleep(gapMs);
+      const secondRun = await executeCommand(ac.command, execOptions);
+
+      if (secondRun.status === "PASS") {
+        // Flake detected — the retry passed but we can't fully trust the
+        // result because the same command failed moments ago. Report PASS
+        // so the AC doesn't block the verdict, but surface the soft signal
+        // via reliability="suspect" and an evidence prefix so callers can
+        // audit the flake rate downstream.
+        criteria.push({
+          id: ac.id,
+          status: "PASS",
+          evidence: `flaky-retry: first-run FAIL, retry PASS — ${secondRun.evidence}`,
+          reliability: "suspect",
+        });
+        continue;
+      }
+
+      // Both runs failed — real failure. Keep the first run's evidence as
+      // the primary signal; a flaky AC failing twice in a row is the
+      // strongest "this is actually broken" signal we can get.
+      criteria.push({
+        id: ac.id,
+        status: secondRun.status,
+        evidence: `flaky-retry: both runs FAIL — ${firstRun.evidence}`,
+        reliability: "trusted",
+      });
+      continue;
+    }
+
     criteria.push({
       id: ac.id,
-      status: result.status,
-      evidence: result.evidence,
+      status: firstRun.status,
+      evidence: firstRun.evidence,
       reliability: "trusted",
     });
   }

--- a/server/lib/prompts/planner.ts
+++ b/server/lib/prompts/planner.ts
@@ -278,7 +278,15 @@ ${modeRules[mode]}
 
 ### Fields NOT to Populate
 - Do NOT include "prdPath" in the output (reserved for future use).
-- Do NOT include "flaky" in any AC (reserved for future use).
+
+### Optional: the "flaky" AC field
+- Add "flaky": true to an AC only when the command is known to be timing-sensitive or
+  non-deterministic (e.g. hits a network endpoint, depends on wall-clock, exercises a
+  race-condition-prone path). The evaluator retries a flaky AC once on first-run FAIL;
+  if the retry passes, the result is reported as PASS with reliability="suspect".
+- Default is to omit the field. Do NOT mark an AC flaky just to silence a real failure —
+  that is laundering the signal. Only mark it when the command's output genuinely
+  varies across runs for reasons outside the code under test.
 
 ### Quality Checks
 - Ensure every story's ACs actually verify the story's title/goal.

--- a/server/types/execution-plan.ts
+++ b/server/types/execution-plan.ts
@@ -22,7 +22,24 @@ export interface AcceptanceCriterion {
   id: string;
   description: string;
   command: string;
-  flaky?: boolean; // Not populated by the planner in Phase 1. Exists for future manual annotation.
+  /**
+   * Q0.5/C2 — runtime-flaky marker. When `true`, the evaluator retries the AC
+   * once if the first run returns `status: FAIL`, waiting `flakyRetryGapMs`
+   * between runs (default 500ms). Retry semantics:
+   *   - run-1 PASS → PASS (no retry spawned)
+   *   - run-1 FAIL + run-2 PASS → PASS with `reliability: "suspect"` (flake
+   *     detected; the run passed but the trust level is degraded so callers
+   *     can surface the soft signal)
+   *   - run-1 FAIL + run-2 FAIL → FAIL (real failure, two signals)
+   *
+   * Lint-flagged suspect ACs (A1b short-circuit) do NOT enter this retry
+   * path — they are skipped before the retry gate because the command shape
+   * itself is broken and retrying would just burn CPU for the same wrong
+   * answer. The `flaky` field should only be set on ACs whose commands pass
+   * ac-lint clean but are known to vary across runs for reasons outside the
+   * code under test (network, wall-clock, race conditions).
+   */
+  flaky?: boolean;
   /**
    * Per-rule ac-lint exemptions (Q0.5/A1). When an AC's command matches a
    * deny-list pattern but the author has a justified reason (e.g. an


### PR DESCRIPTION
## Summary
- Wires up the long-dead `flaky?: boolean` field on `AcceptanceCriterion` (was marked "reserved for future use" since Phase 1 — closes **F59**)
- Evaluator runs `flaky: true` ACs up to twice: if run-1 FAILs, waits `flakyRetryGapMs` (default 500ms) and retries once. Run-1 PASS skips retry entirely
- Outcome matrix: PASS→PASS/trusted; FAIL+PASS→PASS/**suspect**+`flaky-retry:` evidence prefix; FAIL+FAIL→FAIL/trusted
- Lint-flagged ACs (A1b short-circuit) bypass the retry gate — structurally broken commands don't benefit from retrying
- Planner prompt: removed "Do NOT include flaky" directive, replaced with guidance on when annotation is appropriate vs. when it's laundering a real failure

## Design decisions (locked with user 2026-04-13)
- **Retry-on-failure**, not always-two-runs. Spec wording "run twice with a short gap" read as *up to twice*. 50% subprocess cost savings on clean runs. Binary exit criterion only demands "retry logic tested + bypass tested"
- **PASS+suspect does NOT poison `computeVerdict`.** Only SKIPPED+suspect poisons (per #168) because that's the zero-signal case. Flake-retry-PASS has *some* signal — the AC did work once — so verdict stays PASS and the trust flag surfaces per-AC via `reliability: "suspect"` and the evidence-string prefix
- **Lint short-circuit runs structurally before retry gate.** Spec-required: ac-lint-flagged ACs hit SKIPPED+suspect via A1b and never reach the retry branch in the loop. The bypass property is composition-by-placement, not a separate guard

## Q0.5 closure queue status
- #168 ✓ merged (v0.24.1)
- **C2 → this PR** (first of three parallel-unblocker tracks)
- B1 queued (forge_evaluate smoke-test mode)
- C1 queued (retroactive-critique.yml)
- A3 starts after first of {B1, C1, C2} lands — this unblocks A3

## Test plan
- [x] `server/lib/evaluator.test.ts` +5 new cases under `describe("flaky retry (C2)")`
  - flaky + run-1 FAIL + run-2 PASS → PASS/suspect/flaky-retry evidence
  - flaky + both runs FAIL → FAIL/trusted/both-runs-FAIL evidence
  - flaky + run-1 PASS → `executeCommand` called exactly once
  - lint-flagged + flaky:true → `executeCommand` never called, verdict INCONCLUSIVE
  - non-flaky + FAIL → no retry spawned (regression guard)
- [x] Full suite: 649 pass / 4 skip (baseline 644 → +5; zero regressions)
- [x] `npm run build` exits 0
- [x] All 23 evaluator-module tests green

---
plan-refresh: no-op