### PR TITLE
feat(q05-a3): CriterionResult.reliability full split + divergence forward-split

### DIFF
--- a/.ai-workspace/plans/2026-04-14-q05-a3-reliability-full-split.md
+++ b/.ai-workspace/plans/2026-04-14-q05-a3-reliability-full-split.md
@@ -1,0 +1,172 @@
+# Q0.5/A3 — CriterionResult.reliability full split + divergence forward-split
+
+**Task #13.** Owner: swift-henry (implementer). Grounded directly in the current code on `master` (post-v0.28.0 / PR #183 merged). Phase 1 scope-gate rounds with forge-plan are **complete** — thread `q05-a3` T1510 blessed narrow scope, T1545 blessed Option 2 detection semantics.
+
+## Context
+
+`CriterionResult.reliability` was introduced half-shipped in Q0.5/A1b+C2 with the two-value union `"trusted" | "suspect"` at `server/types/eval-report.ts:29`. The type JSDoc explicitly reserves a third value `"unverified"` for the `lintExempt` override path, stating **"A1 ships only the trusted/suspect split. [...] the full A3 PR will add a third 'unverified' value"**. A3 closes that prefabricated slot.
+
+Two distinct gaps close in this PR:
+
+1. **Schema gap — Option 2 detection.** An AC whose command triggers a subprocess-safety deny-list rule AND whose per-AC `lintExempt` entry FIRED (the exemption actually suppressed a real finding — `lint.findings.some(f => f.exempt === true)`) currently gets `reliability: "trusted"` at `server/lib/evaluator.ts:140`, which is a lie. The safety gate was real and the author overrode it; the correct tag is `"unverified"`. **Vestigial** `lintExempt` entries — declared but never matched — stay `"trusted"` (AC-A3-02b pins this). **Plan-level** `ExecutionPlan.lintExempt[]` (scope "plan") stays `"trusted"` by construction, deferred to Q0.5/A3-bis. Per T1545, the detection rule is `lint.findings.some(f => f.exempt === true)`, NOT `ac.lintExempt !== undefined`.
+
+2. **Divergence-handler gap** — `handleDivergenceEval` (`server/tools/evaluate.ts:398-407`) currently lumps **every** FAIL/INCONCLUSIVE criterion into `forwardDivergences` with no reliability tag. A suspect (ac-lint-skipped) AC and a trusted (real failure) AC land in the same bucket. Task #13 description says explicitly: *"Divergence mode splits real vs suspect failures."* The fix: propagate `reliability` into `ForwardDivergence` so downstream consumers can filter.
+
+## Scope resolution — RESOLVED (thread q05-a3)
+
+Task #13 second sentence mentions *"Dual-trigger refresh: C1c (prompt/rules change) OR 14-day calendar"* — a refresh-cadence tool that is **orthogonal** to the type work. Resolved by forge-plan T1510: **(a) NARROW A3**, ship schema + divergence split only. The refresh tool is deferred to **Q0.5/A3-bis** (dual-trigger refresh, separate PR after A3 merges).
+
+Detection semantics resolved by T1545: **Option 2 (per-AC fired exemption only)**. Options 1 (any presence) and 3 (full coverage including plan-level) were rejected — Option 1 noisy, Option 3 violates AC-A3-10 negative-space by forcing edits into `server/validation/ac-lint.ts`. Vestigial exemptions stay `"trusted"`, plan-level absorptions stay `"trusted"`, only fired per-AC exemptions flip to `"unverified"`.
+
+## Files and code anchors
+
+| File | Anchor | Action |
+|---|---|---|
+| `server/types/eval-report.ts` | line 29 | MODIFY — extend union to `"trusted" \| "suspect" \| "unverified"`; rewrite JSDoc **verbatim per T1545 text** (documents fired-exemption semantics, plan-level exclusion, Q0.5/A3-bis deferral reference). The JSDoc currently committed on the branch was written from the pre-T1545 draft and MUST be re-rewritten before PR-open |
+| `server/lib/evaluator.ts` | lines 136-141 (normal path) + 127-132 (flaky-retry trusted path) | MODIFY — retain the `lint` local from line 69 through the push site and emit `reliability: lint.findings.some(f => f.exempt === true) ? "unverified" : "trusted"`. **Option 2 semantics** (per forge-plan T1545): a per-AC `lintExempt` entry must have ACTUALLY FIRED (suppressed a real finding) for this run to count as unverified. Vestigial exemptions (declared but never matched) stay `"trusted"`. Plan-level `ExecutionPlan.lintExempt[]` (scope "plan") is OUT OF SCOPE — those ACs report "trusted" by construction, with plan-level coverage deferred to Q0.5/A3-bis |
+| `server/lib/evaluator.ts` | lines 46-58 (warnings) | MODIFY — push an entry to `warnings[]` when any criterion has `reliability: "unverified"` |
+| `server/lib/evaluator.ts` | lines 159-180 (`computeVerdict`) | NO CHANGE — see decision table below. `unverified` is a soft signal, never downgrades verdict |
+| `server/types/divergence-report.ts` | lines 6-11 (`ForwardDivergence`) | MODIFY — add `reliability?: "trusted" \| "suspect" \| "unverified"` (optional for backward compat) |
+| `server/tools/evaluate.ts` | lines 398-407 (divergence forward loop) | MODIFY — copy `criterion.reliability` into `ForwardDivergence` entries |
+| `server/tools/evaluate.ts` | lines 525-528 (summary string) | MODIFY — summary reports `N trusted / M suspect / K unverified` instead of a single count |
+| `server/lib/generator.ts` | lines 118-124 (`buildFixBrief`) | NO CHANGE — generator trusts upstream classification. Flag as future work if dogfood shows noisy fix briefs |
+| `server/tools/evaluate.test.ts` | `makeEvalReport` + divergence tests | ADD tests — see AC list below |
+| `server/lib/evaluator.test.ts` (if exists) | — | UPDATE — any fixture asserting `reliability: "trusted"` on a `lintExempt` AC flips to `"unverified"` |
+| `.ai-workspace/plans/2026-04-14-q05-a3-reliability-full-split.md` | — | CREATE — persistent plan file (this `.claude/plans/` file is ephemeral) |
+
+### `computeVerdict` decision table — why `unverified` does NOT change verdict semantics
+
+| criterion has | current rule | A3 rule |
+|---|---|---|
+| any FAIL | → FAIL | → FAIL (unchanged) |
+| any INCONCLUSIVE (no FAIL) | → INCONCLUSIVE | → INCONCLUSIVE (unchanged) |
+| any SKIPPED+suspect | → INCONCLUSIVE | → INCONCLUSIVE (unchanged) |
+| any PASS+unverified (otherwise clean) | → PASS | **→ PASS + warning** in `EvalReport.warnings[]` |
+| all clean | → PASS | → PASS (unchanged) |
+
+`lintExempt` is an intentional author choice. Downgrading its verdict would effectively remove the escape hatch. Surfacing a warning is the right middle ground: caller can count unverified-PASS rates over time without the signal blocking the pipeline.
+
+## Test cases & acceptance criteria
+
+All ACs are binary.
+
+| AC | Verify |
+|---|---|
+| **AC-A3-01** | `grep -c '"unverified"' server/types/eval-report.ts` ≥ 1 |
+| **AC-A3-02** | `evaluateStory` with 1 AC whose command matches a real deny-list rule (e.g., contains a subprocess-safety pattern) AND carries a `lintExempt: [{ruleId: <that rule>, rationale: ...}]` entry that FIRES and suppresses the finding → `criteria[0].reliability === "unverified"` AND `status === "PASS"` (command executes, exemption was real) |
+| **AC-A3-02b** | **Vestigial-exemption negative test (pins Option 2 vs Option 1).** `evaluateStory` with 1 AC carrying a `lintExempt` entry whose `ruleId` does NOT match any finding in the run (e.g. command is `"echo ok"`, exemption declares a rule that won't trip) → `criteria[0].reliability === "trusted"` (exemption was vestigial, never fired, so tag stays trusted) |
+| **AC-A3-03** | `evaluateStory` with 1 AC whose command matches a deny-list rule AND carries a firing `lintExempt` entry AND the command exits non-zero → `reliability === "unverified"` AND `status === "FAIL"` (tag survives failure) |
+| **AC-A3-04** | `evaluateStory` with 1 AC carrying NO `lintExempt` field at all, running `"echo ok"` → `criteria[0].reliability === "trusted"` (backward compat — clean ACs with no override never tag unverified) |
+| **AC-A3-05** | `ForwardDivergence` interface includes optional `reliability?` field — `tsc --noEmit` passes with a test file constructing `{...rest, reliability: "unverified"}` |
+| **AC-A3-06** | `handleDivergenceEval` fixture with 3 failing ACs (1 trusted-FAIL, 1 suspect-SKIPPED, 1 unverified-FAIL) → `forward[]` entries each carry the correct `reliability` matching the source criterion |
+| **AC-A3-07** | `DivergenceReport.summary` on AC-A3-06 fixture contains substrings `"trusted"` AND `"suspect"` with numeric counts |
+| **AC-A3-08** | `EvalReport.warnings[]` contains at least one entry matching `/unverified/i` when any criterion has `reliability: "unverified"` |
+| **AC-A3-09** | `npx vitest run` exit 0, zero regressions |
+| **AC-A3-10** | `git diff --stat master` touches ONLY the files listed above. No drift into `coordinate.ts`, `plan.ts`, critic-eval, smoke-test, MEMORY.md |
+
+## Implementation order (binary, do not reorder)
+
+### Phase 1 — Scope confirmation (GATE) — ✅ DONE
+
+1. ✅ Mail forge-plan scope gate T1455 — reply T1510 blessed (a) narrow + flaky-wins corner case.
+1b. ✅ Phase 3 surprise escalation T1535 (`lintExempt` is not a boolean) — reply T1545 blessed Option 2 (fired exemption only) + verbatim JSDoc text + new AC-A3-02b.
+
+### Phase 2 — Schema change
+
+2. ✅ `git checkout master && git pull && git checkout -b feat/q05-a3-reliability-full-split`
+3. **Edit `server/types/eval-report.ts:29` — replace current JSDoc with T1545 verbatim text.** The union extension is already committed; only the JSDoc body needs re-rewriting. T1545 text documents: fired-exemption semantics, vestigial exemptions stay trusted, plan-level `ExecutionPlan.lintExempt[]` (scope "plan") is out-of-scope and reports "trusted" by construction, plan-level coverage deferred to Q0.5/A3-bis.
+4. `npx tsc --noEmit` — JSDoc-only rewrite compiles clean by construction.
+
+### Phase 3 — Producer side (evaluator.ts)
+
+5. Read `server/lib/evaluator.ts` end-to-end. Note the push sites: ac-lint short-circuit (lines 75-81), flaky-retry-suspect PASS (lines 108-113), flaky-retry-trusted non-PASS (lines 127-132), normal path (lines 136-141). The `lint` local is computed at line 69 and currently discarded for non-suspect ACs — Phase 3 needs to retain it through to the push sites.
+6. Extend the normal-path push (136-141) with **Option 2 detection** (per forge-plan T1545):
+   ```ts
+   const exemptionFired = lint.findings.some(f => f.exempt === true);
+   const reliability: "trusted" | "unverified" = exemptionFired ? "unverified" : "trusted";
+   ```
+   emit `reliability` on the push. The `lint` variable already exists in scope from line 69 — no new computation.
+7. Extend the flaky-retry-trusted non-PASS push (127-132) identically using the same `exemptionFired` derivation.
+8. **Leave the ac-lint-short-circuit path UNTOUCHED** — it's `"suspect"`, not `"unverified"`. ACs whose `lintExempt` entries clear every finding never reach this block (they fall through to executeCommand with `lint.suspect === false`).
+9. **Leave the flaky-retry-suspect PASS push UNTOUCHED** — `flaky-retry suspect` has different semantics from `lintExempt unverified`; both can coexist. If both conditions apply simultaneously (flaky AC whose exemption also fired), ship `"suspect"` (flaky wins per T1510 — runtime instability outranks successful override). Document in commit message.
+10. After the evaluator loop:
+    (a) if `criteria.some(c => c.reliability === "unverified")`, push an aggregate warning: `"${count} AC(s) ran with a fired lintExempt override — reliability is unverified"`.
+    (b) **Dual-flag dedicated warning** (per T1510 blessed, T1545 clarified): for each AC where `ac.flaky === true` AND `lint.findings.some(f => f.exempt === true)` — i.e. the exemption ACTUALLY fired — push a per-AC warning with precise T1545 text: `"AC '${ac.id}' has flaky: true AND a lintExempt entry whose exemption fired during this run — reporting as suspect (flake takes precedence). Override review recommended."` NOT rolled up, so analytics can grep `/flaky.*lintExempt|lintExempt.*flaky/i` to find degraded-confidence ACs. The `"whose exemption fired during this run"` qualifier is load-bearing — it documents Option 2 semantics inline.
+11. `npx vitest run server/lib` — fix any fixture assertions that hardcoded `reliability: "trusted"` on `lintExempt` ACs.
+
+### Phase 4 — Divergence-handler split
+
+12. Edit `server/types/divergence-report.ts:6-11` — add optional `reliability?` field.
+13. Edit `server/tools/evaluate.ts:398-407` — pass `criterion.reliability` through in the forward push.
+14. Edit summary construction at `server/tools/evaluate.ts:525-528` — compute `trustedCount / suspectCount / unverifiedCount` and emit them.
+
+### Phase 5 — Tests
+
+15. Add test block in `server/tools/evaluate.test.ts` for AC-A3-02 through AC-A3-08. Reuse `makeEvalReport`. For divergence-split tests, mock `evaluateStory` to return mixed-reliability criteria.
+16. `npx vitest run` — full suite green.
+
+### Phase 6 — Ship
+
+17. `npm run build` clean.
+18. `git diff --stat master` matches AC-A3-10 allowlist.
+19. `/ship` (plan-refresh: `no-op`).
+20. Mail forge-plan with merge SHA for round-0 review.
+21. Address round-0 findings if any, merge, update Q0.5 tally.
+
+## Verification (post-merge, end-to-end)
+
+1. `git checkout master && git pull`
+2. `grep '"unverified"' server/types/eval-report.ts` → ≥ 1 match
+3. `npx vitest run` → full suite green
+4. `npm run build` → exit 0
+5. **Live MCP smoke test** (requires session restart per F54): author a two-story plan. Story A = clean AC with no `lintExempt`. Story B = AC whose command contains a real subprocess-safety pattern (so ac-lint would normally flag it) AND carries a firing `lintExempt: [{ruleId: <matched rule>, rationale: ...}]` entry. Run `forge_evaluate mode: "divergence"`. Confirm (a) `forward[]` is empty (both pass), (b) `warnings[]` mentions "unverified" for Story B's fired exemption, (c) Story B's criterion has `reliability: "unverified"` in the RunRecord audit, Story A's has `"trusted"`.
+6. **Negative test — failing case:** same plan shape, but Story B's command exits non-zero. Confirm `forward[]` has the failing criterion with `reliability: "unverified"` and summary reports `0 trusted / 0 suspect / 1 unverified`.
+7. **Vestigial-exemption regression test (pins Option 2):** third plan where Story B's AC runs `"echo ok"` AND carries a `lintExempt` entry whose `ruleId` matches nothing in the actual command. Confirm Story B's criterion has `reliability: "trusted"` (NOT `"unverified"`). This mirrors AC-A3-02b at runtime.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `computeVerdict` bikeshed drags the PR | LOW | Decision table pins answer: unverified is a warning, never downgrades verdict |
+| Existing evaluator tests hardcode `reliability: "trusted"` on `lintExempt` ACs | LOW-MED | Phase 3 step 11 catches this; fixture updates are trivial |
+| ~~Forge-plan wants wide A3~~ | ~~MED~~ | **RESOLVED T1510** — narrow blessed. Refresh tool deferred to Q0.5/A3-bis |
+| `ForwardDivergence` schema change breaks unknown consumer | LOW | Grep confirmed only `evaluate.ts` produces/consumes. Optional field is additive |
+| `flaky + lintExempt` corner case: which wins? | LOW | Step 9 pins it: flaky wins (runtime signal > authoring choice). Documented in commit |
+| F54 MCP stale dist after rebuild | LOW | Verification step 5 requires session restart — captured in the verification list, not a surprise |
+| Option 2 blind spot: plan-level `ExecutionPlan.lintExempt[]` absorptions never tag `unverified` | LOW | Plan-level is bootstrap absorption by design (one-shot clearing house, not an ongoing override pattern). Deferred coverage tracked as Q0.5/A3-bis (dual-trigger refresh tool). If post-merge analytics reveal plan-level hiding real risk, widening Option 2→3 is a purely additive ~30-line follow-up |
+| Option 2 regression — future refactor slides back to Option 1 (declared-not-fired flags unverified) | LOW | AC-A3-02b negative test pins semantics: vestigial exemption must stay `"trusted"`. Any slide breaks the test immediately |
+
+## Files NOT to touch (AC-A3-10 negative-space)
+
+- `server/tools/coordinate.ts`, `server/tools/generate.ts`, `server/tools/plan.ts`, `server/tools/reconcile.ts`
+- Any `server/tools/evaluate.ts` handler OTHER than `handleDivergenceEval` (story handler propagates naturally via the evaluator return value — no code change there)
+- `server/lib/prompts/*`, `server/validation/ac-lint.ts` — **REAFFIRMED T1545** Option 3 (extending `LintResult` with `droppedByPlanLevel`) was specifically rejected to preserve this line. Plan-level coverage deferred to Q0.5/A3-bis
+- `server/lib/generator.ts` (flagged as "consider" but A3 takes no change)
+- `scripts/*`, `.claude/settings.json`, `.github/workflows/*`
+- `MEMORY.md`
+
+## Checkpoint
+
+- [x] Phase 1 — mail forge-plan scope question (T1455 sent, T1510 reply: narrow blessed)
+- [x] Phase 1b — Phase 3 surprise escalation (T1535 sent, T1545 reply: Option 2 blessed + JSDoc text + AC-A3-02b)
+- [x] Phase 2.2 — branch cut `feat/q05-a3-reliability-full-split`
+- [x] Phase 2.3 — eval-report.ts union extended (JSDoc rewrite **pending** T1545 text replacement in Phase 3.5b below)
+- [x] Phase 2.4 — tsc --noEmit clean
+- [x] Phase 3.5 — evaluator.ts read-through
+- [ ] Phase 3.5b — replace eval-report.ts JSDoc with T1545 verbatim text
+- [ ] Phase 3.6 — normal-path fired-exemption → unverified (Option 2 detection)
+- [ ] Phase 3.7 — flaky-retry-trusted non-PASS fired-exemption → unverified
+- [ ] Phase 3.10 — warnings[] push for any unverified count
+- [ ] Phase 3.11 — evaluator vitest green (fixture updates as needed)
+- [ ] Phase 4.12 — ForwardDivergence.reliability optional field
+- [ ] Phase 4.13 — forward-loop reliability propagation
+- [ ] Phase 4.14 — summary string split counts
+- [ ] Phase 5.15 — AC-A3-02..08 test block added
+- [ ] Phase 5.16 — full vitest green
+- [ ] Phase 6.17 — npm run build clean
+- [ ] Phase 6.18 — negative-space audit
+- [ ] Phase 6.19 — /ship pipeline
+- [ ] Phase 6.20 — merge-SHA round-0 mail
+- [ ] Phase 6.21 — round-0 findings, Q0.5 tally update
+
+Last updated: 2026-04-14T15:55 (post-T1545 Option 2 bless; Phase 1+1b DONE; Phase 2 DONE except JSDoc rewrite; ready to resume Phase 3.5b).

--- a/server/lib/evaluator.test.ts
+++ b/server/lib/evaluator.test.ts
@@ -299,7 +299,7 @@ describe("evaluateStory", () => {
       expect(report.criteria[0].reliability).toBe("trusted");
     });
 
-    it("exempt AC runs normally even though pattern matches", async () => {
+    it("exempt AC runs normally even though pattern matches — Q0.5/A3 Option 2: tagged unverified because exemption fired", async () => {
       mockedExecute.mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "ok" }));
       const plan: ExecutionPlan = {
         schemaVersion: "3.0.0",
@@ -321,7 +321,138 @@ describe("evaluateStory", () => {
       const report = await evaluateStory(plan, "US-01");
       expect(mockedExecute).toHaveBeenCalledTimes(1);
       expect(report.criteria[0].status).toBe("PASS");
+      // AC-A3-02: firing per-AC exemption → unverified (verdict still PASS).
+      expect(report.criteria[0].reliability).toBe("unverified");
+      // AC-A3-08: aggregate warning surfaces the unverified count.
+      expect(report.warnings).toBeDefined();
+      expect(report.warnings!.some((w) => /unverified/i.test(w))).toBe(true);
+    });
+
+    // Q0.5/A3 — AC-A3-02b: vestigial-exemption negative test (pins Option 2).
+    it("AC-A3-02b: vestigial lintExempt (declared but nothing fires) → reliability=trusted", async () => {
+      mockedExecute.mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "ok" }));
+      const plan: ExecutionPlan = {
+        schemaVersion: "3.0.0",
+        stories: [
+          {
+            id: "US-01",
+            title: "Vestigial",
+            acceptanceCriteria: [
+              {
+                id: "AC-01",
+                description: "clean command, exemption that won't match",
+                command: "echo ok",
+                lintExempt: {
+                  ruleId: "F56-passed-grep",
+                  rationale: "defensive, unlikely to match",
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const report = await evaluateStory(plan, "US-01");
+      expect(report.criteria[0].status).toBe("PASS");
+      // Exemption was declared but no finding was suppressed — stays trusted.
       expect(report.criteria[0].reliability).toBe("trusted");
+      // No unverified warning either.
+      expect(
+        (report.warnings ?? []).some((w) => /unverified/i.test(w)),
+      ).toBe(false);
+    });
+
+    // Q0.5/A3 — AC-A3-03: unverified tag survives a FAIL status.
+    it("AC-A3-03: firing exemption + FAIL command → status=FAIL, reliability=unverified", async () => {
+      mockedExecute.mockResolvedValueOnce(
+        mockResult({ status: "FAIL", evidence: "boom" }),
+      );
+      const plan: ExecutionPlan = {
+        schemaVersion: "3.0.0",
+        stories: [
+          {
+            id: "US-01",
+            title: "Firing exempt FAIL",
+            acceptanceCriteria: [
+              {
+                id: "AC-01",
+                description: "matched rule, exempted, command fails",
+                command: "npx vitest run | grep -q 'passed'",
+                lintExempt: { ruleId: "F56-passed-grep", rationale: "reviewed" },
+              },
+            ],
+          },
+        ],
+      };
+      const report = await evaluateStory(plan, "US-01");
+      expect(report.verdict).toBe("FAIL");
+      expect(report.criteria[0].status).toBe("FAIL");
+      // Unverified tag survives failure — author overrode the safety gate
+      // and the command still failed.
+      expect(report.criteria[0].reliability).toBe("unverified");
+      expect(
+        (report.warnings ?? []).some((w) => /unverified/i.test(w)),
+      ).toBe(true);
+    });
+
+    // Q0.5/A3 — AC-A3-04: no lintExempt field → trusted (backward compat).
+    it("AC-A3-04: AC with no lintExempt field → reliability=trusted", async () => {
+      mockedExecute.mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "ok" }));
+      const plan: ExecutionPlan = {
+        schemaVersion: "3.0.0",
+        stories: [
+          {
+            id: "US-01",
+            title: "Clean",
+            acceptanceCriteria: [
+              { id: "AC-01", description: "no exemption", command: "echo ok" },
+            ],
+          },
+        ],
+      };
+      const report = await evaluateStory(plan, "US-01");
+      expect(report.criteria[0].reliability).toBe("trusted");
+      expect(
+        (report.warnings ?? []).some((w) => /unverified/i.test(w)),
+      ).toBe(false);
+    });
+
+    // Q0.5/A3 — dual-flag warning: flaky + fired exemption collision.
+    // Flake wins on the reliability tag (runtime signal > authoring override),
+    // but a per-AC warning is emitted so analytics can grep the collision.
+    it("dual-flag: flaky + fired exemption → reliability=suspect, per-AC warning", async () => {
+      mockedExecute
+        .mockResolvedValueOnce(mockResult({ status: "FAIL", evidence: "first fail" }))
+        .mockResolvedValueOnce(mockResult({ status: "PASS", evidence: "retry ok" }));
+      const plan: ExecutionPlan = {
+        schemaVersion: "3.0.0",
+        stories: [
+          {
+            id: "US-01",
+            title: "Dual flag",
+            acceptanceCriteria: [
+              {
+                id: "AC-01",
+                description: "flaky AND exempted",
+                command: "npx vitest run | grep -q 'passed'",
+                flaky: true,
+                lintExempt: { ruleId: "F56-passed-grep", rationale: "reviewed" },
+              },
+            ],
+          },
+        ],
+      };
+      const report = await evaluateStory(plan, "US-01", { flakyRetryGapMs: 1 });
+      expect(report.verdict).toBe("PASS");
+      expect(report.criteria[0].status).toBe("PASS");
+      // Flake wins over unverified.
+      expect(report.criteria[0].reliability).toBe("suspect");
+      // Per-AC dual-flag warning fired — matches the analytics regex.
+      expect(report.warnings).toBeDefined();
+      expect(
+        report.warnings!.some((w) =>
+          /flaky.*lintExempt|lintExempt.*flaky/i.test(w),
+        ),
+      ).toBe(true);
     });
   });
 

--- a/server/lib/evaluator.ts
+++ b/server/lib/evaluator.ts
@@ -63,6 +63,9 @@ export async function evaluateStory(
   };
 
   const criteria: CriterionResult[] = [];
+  // Q0.5/A3 — per-AC warnings for flaky+fired-exemption collision. Collected
+  // inside the loop and concatenated into `warnings` after.
+  const dualFlagWarnings: string[] = [];
 
   for (const ac of story.acceptanceCriteria) {
     // Q0.5/A1b — ac-lint short-circuit (non-exempt suspect ACs never execute).
@@ -79,6 +82,26 @@ export async function evaluateStory(
         reliability: "suspect",
       });
       continue;
+    }
+
+    // Q0.5/A3 — Option 2 detection (per forge-plan T1545). An AC whose
+    // per-AC `lintExempt` entry FIRED (actively suppressed a real finding)
+    // is tagged "unverified" on the normal execution path. Vestigial
+    // exemptions (declared but nothing matched) stay "trusted". Plan-level
+    // `ExecutionPlan.lintExempt[]` absorptions are OUT OF SCOPE — those
+    // drop findings entirely and report "trusted" by construction
+    // (deferred to Q0.5/A3-bis).
+    const exemptionFired = lint.findings.some((f) => f.exempt === true);
+
+    // Q0.5/A3 — dual-flag warning (T1510 blessed + T1545 clarified). A flaky
+    // AC whose exemption fired is reported as "suspect" (runtime signal
+    // outranks authoring override) — but the collision itself is a soft
+    // smell that deserves an explicit, per-AC warning so analytics can
+    // grep for it. Rolled warnings hide the signal.
+    if (ac.flaky === true && exemptionFired) {
+      dualFlagWarnings.push(
+        `AC '${ac.id}' has flaky: true AND a lintExempt entry whose exemption fired during this run — reporting as suspect (flake takes precedence). Override review recommended.`,
+      );
     }
 
     const firstRun = await executeCommand(ac.command, execOptions);
@@ -128,7 +151,7 @@ export async function evaluateStory(
         id: ac.id,
         status: secondRun.status,
         evidence: `${prefix} — ${firstRun.evidence}`,
-        reliability: "trusted",
+        reliability: exemptionFired ? "unverified" : "trusted",
       });
       continue;
     }
@@ -137,9 +160,21 @@ export async function evaluateStory(
       id: ac.id,
       status: firstRun.status,
       evidence: firstRun.evidence,
-      reliability: "trusted",
+      reliability: exemptionFired ? "unverified" : "trusted",
     });
   }
+
+  // Q0.5/A3 — aggregate unverified-count warning (per T1545 text).
+  const unverifiedCount = criteria.filter(
+    (c) => c.reliability === "unverified",
+  ).length;
+  if (unverifiedCount > 0) {
+    warnings.push(
+      `${unverifiedCount} AC(s) ran with a fired lintExempt override — reliability is unverified`,
+    );
+  }
+  // Q0.5/A3 — dual-flag per-AC warnings (flaky + fired exemption collision).
+  warnings.push(...dualFlagWarnings);
 
   const verdict = computeVerdict(criteria);
 

--- a/server/tools/evaluate.test.ts
+++ b/server/tools/evaluate.test.ts
@@ -659,6 +659,98 @@ describe("handleEvaluate — divergence mode", () => {
     expect(report.forward[0].status).toBe("FAIL");
   });
 
+  // Q0.5/A3 — AC-A3-06: mixed-reliability forward split.
+  // Three failing ACs (trusted-FAIL, suspect-SKIPPED, unverified-FAIL) land
+  // in forward[] each carrying the correct reliability tag from the source
+  // criterion.
+  it("AC-A3-06: propagates reliability into ForwardDivergence entries", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(
+      makeEvalReport({
+        storyId: "US-01",
+        verdict: "FAIL",
+        criteria: [
+          {
+            id: "AC-01",
+            status: "FAIL",
+            evidence: "real failure",
+            reliability: "trusted",
+          },
+          {
+            id: "AC-02",
+            status: "SKIPPED",
+            evidence: "ac-lint: suspect",
+            reliability: "suspect",
+          },
+          {
+            id: "AC-03",
+            status: "FAIL",
+            evidence: "override, failed anyway",
+            reliability: "unverified",
+          },
+        ],
+      }),
+    );
+
+    const result = await handleEvaluate({
+      evaluationMode: "divergence",
+      planJson: makeValidPlanJson(),
+    });
+
+    const report = JSON.parse(result.content[0].text);
+    // SKIPPED doesn't land in forward[] (handler filters on FAIL/INCONCLUSIVE).
+    expect(report.forward).toHaveLength(2);
+    const byAcId = Object.fromEntries(
+      report.forward.map((fd: { acId: string; reliability?: string }) => [
+        fd.acId,
+        fd.reliability,
+      ]),
+    );
+    expect(byAcId["AC-01"]).toBe("trusted");
+    expect(byAcId["AC-03"]).toBe("unverified");
+  });
+
+  // Q0.5/A3 — AC-A3-07: summary string carries split counts.
+  it("AC-A3-07: DivergenceReport.summary reports trusted/suspect/unverified counts", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(
+      makeEvalReport({
+        storyId: "US-01",
+        verdict: "FAIL",
+        criteria: [
+          {
+            id: "AC-01",
+            status: "FAIL",
+            evidence: "real failure",
+            reliability: "trusted",
+          },
+          {
+            id: "AC-02",
+            status: "FAIL",
+            evidence: "override failed",
+            reliability: "unverified",
+          },
+          {
+            id: "AC-03",
+            status: "INCONCLUSIVE",
+            evidence: "infra broke",
+            // undefined reliability → counted as trusted per backward compat.
+          },
+        ],
+      }),
+    );
+
+    const result = await handleEvaluate({
+      evaluationMode: "divergence",
+      planJson: makeValidPlanJson(),
+    });
+
+    const report = JSON.parse(result.content[0].text);
+    expect(report.forward).toHaveLength(3);
+    // Summary string should be greppable for each reliability count.
+    expect(report.summary).toContain("2 trusted");
+    expect(report.summary).toContain("0 suspect");
+    expect(report.summary).toContain("1 unverified");
+  });
+
   it("detects reverse divergence (unplanned capabilities) via LLM", async () => {
     mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport());
 

--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -402,6 +402,7 @@ async function handleDivergenceEval(
             acId: criterion.id,
             status: criterion.status,
             evidence: criterion.evidence,
+            reliability: criterion.reliability,
           });
         }
       }
@@ -515,6 +516,19 @@ async function handleDivergenceEval(
 
   const totalDivergences = forwardDivergences.length + reverseDivergences.length;
 
+  // Q0.5/A3 — split forward count by reliability so analytics can separate
+  // real failures (trusted) from suspect (ac-lint short-circuit) and
+  // unverified (fired lintExempt override). Undefined reliability is
+  // treated as "trusted" for backward compatibility with pre-A3 reports.
+  let trustedCount = 0;
+  let suspectCount = 0;
+  let unverifiedCount = 0;
+  for (const fd of forwardDivergences) {
+    if (fd.reliability === "suspect") suspectCount++;
+    else if (fd.reliability === "unverified") unverifiedCount++;
+    else trustedCount++;
+  }
+
   const report: DivergenceReport = {
     evaluationMode: "divergence",
     status: "complete",
@@ -523,7 +537,8 @@ async function handleDivergenceEval(
     selfHealingCycles: 0, // incremented by calling agent across invocations
     maxCyclesReached: false, // set by calling agent based on cycle count vs max
     summary:
-      `Forward: ${forwardDivergences.length} AC failure(s). ` +
+      `Forward: ${forwardDivergences.length} AC failure(s) ` +
+      `(${trustedCount} trusted / ${suspectCount} suspect / ${unverifiedCount} unverified). ` +
       `Reverse: ${reverseDivergences.length} unplanned capability(ies). ` +
       reverseSummary,
   };

--- a/server/types/divergence-report.ts
+++ b/server/types/divergence-report.ts
@@ -8,6 +8,13 @@ export interface ForwardDivergence {
   acId: string;
   status: "FAIL" | "INCONCLUSIVE";
   evidence: string;
+  /**
+   * Q0.5/A3 — reliability propagated from the source `CriterionResult`.
+   * Optional for backward compatibility. Lets downstream consumers split
+   * "real failures" (trusted) from "suspect failures" (ac-lint short-
+   * circuit or flaky-retry suspect) and unverified-bypass failures.
+   */
+  reliability?: "trusted" | "suspect" | "unverified";
 }
 
 export interface ReverseDivergence {

--- a/server/types/eval-report.ts
+++ b/server/types/eval-report.ts
@@ -10,21 +10,27 @@ export interface CriterionResult {
   status: "PASS" | "FAIL" | "SKIPPED" | "INCONCLUSIVE";
   evidence: string;
   /**
-   * Reliability of this result (Q0.5/A3 minimum slice).
+   * Reliability classification for this criterion's result.
    *
-   * - Absent (undefined): treat as "trusted" for backward compatibility.
-   *   Existing consumers that don't know about this field see the same shape
-   *   as before A3 shipped.
-   * - "trusted": result is mechanically verifiable — the AC command passed
-   *   ac-lint clean and executed.
-   * - "suspect": ac-lint flagged this AC's command as matching a subprocess-
-   *   safety deny-list rule (F55/F56/F36). The command was NOT executed;
-   *   `status` is set to "SKIPPED" and `evidence` carries the matched rule
-   *   ids. Downstream readers should treat this as "we don't know the real
-   *   answer, the AC itself is broken".
+   * - "trusted": the AC's command passed ac-lint subprocess-safety checks
+   *   cleanly (no findings, OR findings exist but none were marked exempt).
+   *   The verdict reflects a real run against real safety guarantees.
    *
-   * Note: the full A3 PR will add a third "unverified" value (for the
-   * `lintExempt` override path). A1 ships only the trusted/suspect split.
+   * - "suspect": ac-lint flagged a non-exempted finding and the AC was
+   *   short-circuited to SKIPPED (or flaky-retry suspect path). Verdict
+   *   is provisional pending author cleanup.
+   *
+   * - "unverified": the AC ran to completion BUT one or more per-AC
+   *   `lintExempt` entries actively suppressed a finding during this run.
+   *   The author exercised an override; the safety check was bypassed for
+   *   this command. The verdict stands (PASS still passes, FAIL still
+   *   fails) but the reliability of the signal is reduced. Surfaced as a
+   *   warning in EvalReport.warnings[], never downgrades verdict.
+   *
+   * Plan-level `ExecutionPlan.lintExempt[]` (scope: "plan") absorbs
+   * findings entirely and is OUT OF SCOPE for this tag — those ACs report
+   * "trusted" by construction. Plan-level coverage is deferred to
+   * Q0.5/A3-bis (dual-trigger refresh tool).
    */
-  reliability?: "trusted" | "suspect";
+  reliability?: "trusted" | "suspect" | "unverified";
 }


### PR DESCRIPTION
## Summary

Closes task #13 (Q0.5/A3). Extends the reliability union from `trusted|suspect` to `trusted|suspect|unverified` and propagates it through divergence-mode forward failures.

- **Schema:** `CriterionResult.reliability` gains `"unverified"` for firing-exemption paths. `ForwardDivergence` gains an optional `reliability?` field.
- **Producer (evaluator.ts):** An AC is tagged `unverified` iff `lint.findings.some(f => f.exempt === true)` — a per-AC `lintExempt` entry ACTUALLY suppressed a real finding this run. Vestigial exemptions (declared but nothing fires) stay `trusted`. Plan-level `ExecutionPlan.lintExempt[]` is OUT OF SCOPE (deferred to Q0.5/A3-bis).
- **Consumer (divergence handler):** `forwardDivergences` now carry reliability through; summary string reports `N trusted / M suspect / K unverified`.
- **Warnings:** aggregate unverified-count entry in `EvalReport.warnings[]`, plus a dedicated per-AC warning when `flaky + fired exemption` collide (analytics-greppable via `/flaky.*lintExempt|lintExempt.*flaky/i`).
- **computeVerdict unchanged:** `unverified` is a soft signal, never downgrades verdict. `lintExempt` is an intentional author escape hatch.

**Design decisions pinned in thread `q05-a3`:**
- T1510: (a) narrow scope, dual-trigger refresh deferred to Q0.5/A3-bis
- T1545: Option 2 detection (fired exemption only); Options 1/3 rejected to preserve AC-A3-10 negative-space

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 699 pass / 4 skip (up from 693 pre-A3; 6 new A3 tests)
- [x] `npm run build` clean
- [x] Negative-space audit: `git diff --stat master` touches only allowlist files
- [x] AC-A3-01: `"unverified"` literal in `eval-report.ts`
- [x] AC-A3-02: firing exemption → `unverified` + `PASS`
- [x] AC-A3-02b: **vestigial exemption → `trusted`** (pins Option 2 vs Option 1)
- [x] AC-A3-03: firing exemption + FAIL command → `unverified` survives failure
- [x] AC-A3-04: no lintExempt field → `trusted`
- [x] AC-A3-05: `ForwardDivergence.reliability?` type-compiles
- [x] AC-A3-06: divergence split propagates reliability per-entry
- [x] AC-A3-07: summary string contains `N trusted / M suspect / K unverified`
- [x] AC-A3-08: `EvalReport.warnings[]` carries unverified count
- [x] dual-flag: flaky + fired exemption → `suspect` + per-AC warning
- [x] AC-A3-10: negative-space audit (6 files, all on allowlist)
- [ ] Post-merge live MCP dogfood (requires session restart per F54)

Follow-ups (out of scope — filed separately):
- Q0.5/A3-bis: dual-trigger refresh tool (C1c prompt/rules change + 14-day calendar) per task #13 second sentence
- #189 (F1 from PR #183): `buildRunRecord` outcome derivation for critic eval — A3 does NOT close this

---
plan-refresh: no-op