### PR TITLE
feat(q05-a3bis): dual-trigger lintExempt refresh + plan.ts hook

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import { evaluateInputSchema, handleEvaluate } from "./tools/evaluate.js";
 import { generateInputSchema, handleGenerate } from "./tools/generate.js";
 import { coordinateInputSchema, handleCoordinate } from "./tools/coordinate.js";
 import { reconcileInputSchema, handleReconcile } from "./tools/reconcile.js";
+import { lintRefreshInputSchema, handleLintRefresh } from "./tools/lint-refresh.js";
 
 const server = new McpServer({
   name: "forge",
@@ -83,6 +84,21 @@ server.registerTool(
     annotations: { readOnlyHint: false },
   },
   handleReconcile
+);
+
+server.registerTool(
+  "forge_lint_refresh",
+  {
+    title: "Forge Lint Refresh",
+    description:
+      "Q0.5/A3-bis — re-validate every `lintExempt` entry in an execution plan against the current ac-lint rule surface. " +
+      "Two staleness triggers: rule-set hash drift (rules/prompt changed) and 14-day calendar. " +
+      "Returns a LintRefreshReport listing stale exemptions with their original rationale and current findings. " +
+      "Does NOT mutate the plan — reports only. Also auto-fires as a side effect of forge_plan(documentTier:'update').",
+    inputSchema: lintRefreshInputSchema,
+    annotations: { readOnlyHint: false },
+  },
+  handleLintRefresh,
 );
 
 async function main() {

--- a/server/lib/lint-audit.test.ts
+++ b/server/lib/lint-audit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Q0.5/A3-bis — lint-audit primitive tests.
+ * Covers AC-bis-01..04 (hash stability + isStale precedence).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { getAcLintRulesHash } from "./prompts/shared/ac-subprocess-rules.js";
+import {
+  computePlanSlug,
+  isStale,
+  loadAudit,
+  writeAudit,
+} from "./lint-audit.js";
+import type { LintAuditEntry } from "../types/lint-audit.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "forge-lint-audit-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+const baseEntry = (overrides: Partial<LintAuditEntry> = {}): LintAuditEntry => ({
+  planId: "plans__2026-04-14-sample",
+  planPath: ".ai-workspace/plans/2026-04-14-sample.md",
+  lastAuditedAt: "2026-04-14T00:00:00.000Z",
+  ruleHash: "a".repeat(64),
+  perAcExemptCount: 0,
+  planLevelExemptCount: 0,
+  ...overrides,
+});
+
+describe("getAcLintRulesHash — AC-bis-01", () => {
+  it("returns a stable 64-char hex string across calls", () => {
+    const h1 = getAcLintRulesHash();
+    const h2 = getAcLintRulesHash();
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("isStale — AC-bis-02..04", () => {
+  const now = new Date("2026-04-14T12:00:00.000Z");
+
+  it("AC-bis-02: returns 'rule-change' when hash differs", () => {
+    const entry = baseEntry({
+      ruleHash: "a".repeat(64),
+      lastAuditedAt: "2026-04-14T00:00:00.000Z",
+    });
+    expect(isStale(entry, "b".repeat(64), now)).toBe("rule-change");
+  });
+
+  it("AC-bis-03: returns '14d-elapsed' when hash matches and age > 14 days", () => {
+    const entry = baseEntry({
+      ruleHash: "c".repeat(64),
+      lastAuditedAt: "2026-03-30T00:00:00.000Z", // 15 days before `now`
+    });
+    expect(isStale(entry, "c".repeat(64), now)).toBe("14d-elapsed");
+  });
+
+  it("AC-bis-04: returns null when hash matches and age < 14 days", () => {
+    const entry = baseEntry({
+      ruleHash: "d".repeat(64),
+      lastAuditedAt: "2026-04-10T00:00:00.000Z", // 4 days before `now`
+    });
+    expect(isStale(entry, "d".repeat(64), now)).toBeNull();
+  });
+
+  it("hash-change beats calendar (precedence check)", () => {
+    const entry = baseEntry({
+      ruleHash: "e".repeat(64),
+      lastAuditedAt: "2026-03-01T00:00:00.000Z", // well over 14 days
+    });
+    expect(isStale(entry, "f".repeat(64), now)).toBe("rule-change");
+  });
+});
+
+describe("computePlanSlug", () => {
+  it("combines parent dir and basename without .md", () => {
+    expect(computePlanSlug(".ai-workspace/plans/2026-04-14-foo.md")).toBe(
+      "plans__2026-04-14-foo",
+    );
+  });
+
+  it("disambiguates siblings in different parent dirs", () => {
+    const a = computePlanSlug("phases/phase-01.md");
+    const b = computePlanSlug("archive/phase-01.md");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("loadAudit / writeAudit round-trip", () => {
+  it("returns null when no audit file exists", async () => {
+    const result = await loadAudit(tempDir, "plans/missing.md");
+    expect(result).toBeNull();
+  });
+
+  it("persists and reads back an entry under the computed slug", async () => {
+    const entry = baseEntry({
+      planPath: "plans/round-trip.md",
+      planId: "plans__round-trip",
+      perAcExemptCount: 2,
+      planLevelExemptCount: 1,
+    });
+    await writeAudit(tempDir, entry);
+    const loaded = await loadAudit(tempDir, "plans/round-trip.md");
+    expect(loaded).toEqual(entry);
+  });
+});

--- a/server/lib/lint-audit.ts
+++ b/server/lib/lint-audit.ts
@@ -1,0 +1,88 @@
+/**
+ * Q0.5/A3-bis — Lint-exemption audit persistence.
+ *
+ * Read/write helpers for `.ai-workspace/lint-audit/{planSlug}.audit.json`.
+ * Pure over (projectPath, planPath, fs, now) so tests can drive it against
+ * a tmp dir.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+import type {
+  LintAuditEntry,
+  LintRefreshTriggerReason,
+} from "../types/lint-audit.js";
+
+const FOURTEEN_DAYS_MS = 14 * 86_400 * 1_000;
+
+/**
+ * Stable identifier for a plan file: `{parentDirName}__{basename-without-md}`.
+ * Collision-resistant across sibling dirs (e.g., `phases/phase-01.md` vs
+ * `archive/phase-01.md`).
+ */
+export function computePlanSlug(planPath: string): string {
+  const parent = basename(dirname(planPath));
+  const base = basename(planPath).replace(/\.(md|json)$/i, "");
+  return `${parent}__${base}`;
+}
+
+function auditFilePath(projectPath: string, planPath: string): string {
+  return join(
+    projectPath,
+    ".ai-workspace",
+    "lint-audit",
+    `${computePlanSlug(planPath)}.audit.json`,
+  );
+}
+
+/**
+ * Read the audit entry for a plan. Returns `null` when the file does not
+ * exist (absent baseline = drift, per AC-bis-06). Re-throws on other IO or
+ * JSON-parse errors so the caller's non-fatal wrapper can surface them.
+ */
+export async function loadAudit(
+  projectPath: string,
+  planPath: string,
+): Promise<LintAuditEntry | null> {
+  const path = auditFilePath(projectPath, planPath);
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  return JSON.parse(raw) as LintAuditEntry;
+}
+
+/**
+ * Write an audit entry. Creates `.ai-workspace/lint-audit/` if missing.
+ */
+export async function writeAudit(
+  projectPath: string,
+  entry: LintAuditEntry,
+): Promise<void> {
+  const path = auditFilePath(projectPath, entry.planPath);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(entry, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Determine whether an audit entry is stale against the current rule surface.
+ *
+ * Precedence: hash drift beats calendar — if rules changed we always
+ * re-review, regardless of how recent the last audit was.
+ *
+ * Returns `null` when fresh.
+ */
+export function isStale(
+  entry: LintAuditEntry,
+  currentHash: string,
+  now: Date,
+): Exclude<LintRefreshTriggerReason, "none"> | null {
+  if (entry.ruleHash !== currentHash) return "rule-change";
+  const ageMs = now.getTime() - new Date(entry.lastAuditedAt).getTime();
+  if (ageMs > FOURTEEN_DAYS_MS) return "14d-elapsed";
+  return null;
+}

--- a/server/lib/prompts/shared/ac-subprocess-rules.ts
+++ b/server/lib/prompts/shared/ac-subprocess-rules.ts
@@ -6,9 +6,12 @@
  *   - `server/lib/prompts/critic.ts` — embeds AC_SUBPROCESS_RULES_PROMPT +
  *     cites AC_LINT_RULES by id in findings (Q0.5/A2).
  *   - `server/validation/ac-lint.ts` — mechanical lint at the primitive boundary.
+ *   - `server/lib/lint-audit.ts` — calls `getAcLintRulesHash()` for staleness check (Q0.5/A3-bis).
  *
  * Do NOT duplicate these patterns elsewhere — import from here.
  */
+
+import { createHash } from "node:crypto";
 
 /**
  * Human-readable prompt block embedded into planner/critic system prompts.
@@ -125,3 +128,30 @@ export const AC_LINT_RULES: AcLintRule[] = [
     rightExample: "curl localhost:3000/api/classes | jq '.UserCache'",
   },
 ];
+
+/**
+ * Q0.5/A3-bis — Stable hash over the live rule surface. Used by `lint-audit`
+ * to detect rule-set drift since an exemption was last reviewed. Cached for
+ * the process lifetime: the underlying constants are module-frozen, so the
+ * hash cannot change after the first call.
+ */
+let cachedHash: string | null = null;
+export function getAcLintRulesHash(): string {
+  if (cachedHash !== null) return cachedHash;
+  const serializedRules = JSON.stringify(
+    AC_LINT_RULES.map((r) => ({
+      id: r.id,
+      description: r.description,
+      pattern: r.pattern.source,
+      severity: r.severity,
+      wrongExample: r.wrongExample,
+      rightExample: r.rightExample,
+    })),
+  );
+  cachedHash = createHash("sha256")
+    .update(AC_SUBPROCESS_RULES_PROMPT)
+    .update("\u0000")
+    .update(serializedRules)
+    .digest("hex");
+  return cachedHash;
+}

--- a/server/smoke/mcp-surface.test.ts
+++ b/server/smoke/mcp-surface.test.ts
@@ -79,13 +79,14 @@ describe("MCP surface smoke", () => {
     }
   });
 
-  it("lists all 5 forge tools", async () => {
+  it("lists all 6 forge tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
       "forge_coordinate",
       "forge_evaluate",
       "forge_generate",
+      "forge_lint_refresh",
       "forge_plan",
       "forge_reconcile",
     ]);

--- a/server/tools/lint-refresh.test.ts
+++ b/server/tools/lint-refresh.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Q0.5/A3-bis — lint-refresh tool tests.
+ * Covers AC-bis-05..09.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { runLintRefresh } from "./lint-refresh.js";
+import { getAcLintRulesHash } from "../lib/prompts/shared/ac-subprocess-rules.js";
+import type { ExecutionPlan } from "../types/execution-plan.js";
+import type { LintAuditEntry } from "../types/lint-audit.js";
+import { computePlanSlug } from "../lib/lint-audit.js";
+
+let tempDir: string;
+let plansDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "forge-lint-refresh-test-"));
+  plansDir = join(tempDir, ".ai-workspace", "plans");
+  await mkdir(plansDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+async function writePlanFile(name: string, plan: ExecutionPlan): Promise<string> {
+  const path = join(plansDir, name);
+  await writeFile(path, JSON.stringify(plan), "utf-8");
+  return path;
+}
+
+function auditPathFor(planPath: string): string {
+  return join(
+    tempDir,
+    ".ai-workspace",
+    "lint-audit",
+    `${computePlanSlug(planPath)}.audit.json`,
+  );
+}
+
+const cleanPlan = (): ExecutionPlan =>
+  ({
+    schemaVersion: "3.0.0",
+    stories: [
+      {
+        id: "US-01",
+        title: "Clean plan — no exemptions",
+        acceptanceCriteria: [
+          { id: "AC01", description: "Happy path", command: "echo ok" },
+        ],
+      },
+    ],
+  }) as unknown as ExecutionPlan;
+
+const exemptPlan = (): ExecutionPlan =>
+  ({
+    schemaVersion: "3.0.0",
+    lintExempt: [
+      {
+        scope: "plan",
+        rules: ["F36-source-tree-grep"],
+        batch: ["AC02"],
+        rationale: "bootstrap absorption — auth-module source greps grandfathered in",
+      },
+    ],
+    stories: [
+      {
+        id: "US-01",
+        title: "Plan with per-AC + plan-level exemptions",
+        acceptanceCriteria: [
+          {
+            id: "AC01",
+            description: "Per-AC exempt",
+            command: "grep -rn 'Redis' src/",
+            lintExempt: {
+              ruleId: "F36-source-tree-grep",
+              rationale: "legacy cache probe pending migration",
+            },
+          },
+          {
+            id: "AC02",
+            description: "Plan-level exempt",
+            command: "grep -rn 'AuthService' server/auth/",
+          },
+        ],
+      },
+    ],
+  }) as unknown as ExecutionPlan;
+
+describe("runLintRefresh — AC-bis-05..09", () => {
+  it("AC-bis-05: clean plan returns triggered:false and writes baseline audit", async () => {
+    const planPath = await writePlanFile("clean.json", cleanPlan());
+    const report = await runLintRefresh(planPath, { projectPath: tempDir });
+
+    expect(report.triggered).toBe(false);
+    expect(report.triggerReason).toBe("none");
+    expect(report.staleEntries).toEqual([]);
+
+    const auditRaw = await readFile(auditPathFor(planPath), "utf-8");
+    const entry = JSON.parse(auditRaw) as LintAuditEntry;
+    expect(entry.perAcExemptCount).toBe(0);
+    expect(entry.planLevelExemptCount).toBe(0);
+    expect(entry.ruleHash).toBe(getAcLintRulesHash());
+  });
+
+  it("AC-bis-06: first-run on exempt plan drifts with rule-change reason + counts both scopes", async () => {
+    const planPath = await writePlanFile("exempt.json", exemptPlan());
+    const report = await runLintRefresh(planPath, { projectPath: tempDir });
+
+    expect(report.triggered).toBe(true);
+    expect(report.triggerReason).toBe("rule-change");
+
+    const auditRaw = await readFile(auditPathFor(planPath), "utf-8");
+    const entry = JSON.parse(auditRaw) as LintAuditEntry;
+    expect(entry.perAcExemptCount).toBe(1);
+    expect(entry.planLevelExemptCount).toBe(1);
+  });
+
+  it("AC-bis-07: re-running immediately returns triggered:false", async () => {
+    const planPath = await writePlanFile("exempt.json", exemptPlan());
+    await runLintRefresh(planPath, { projectPath: tempDir });
+    const second = await runLintRefresh(planPath, { projectPath: tempDir });
+
+    expect(second.triggered).toBe(false);
+    expect(second.triggerReason).toBe("none");
+  });
+
+  it("AC-bis-08: mutating lastAuditedAt to 15 days ago triggers 14d-elapsed", async () => {
+    const planPath = await writePlanFile("exempt.json", exemptPlan());
+    await runLintRefresh(planPath, { projectPath: tempDir });
+
+    // Hand-edit the audit file to push lastAuditedAt back 15 days.
+    const auditPath = auditPathFor(planPath);
+    const entry = JSON.parse(await readFile(auditPath, "utf-8")) as LintAuditEntry;
+    const fifteenDaysAgo = new Date(Date.now() - 15 * 86_400 * 1000).toISOString();
+    entry.lastAuditedAt = fifteenDaysAgo;
+    await writeFile(auditPath, JSON.stringify(entry), "utf-8");
+
+    const report = await runLintRefresh(planPath, { projectPath: tempDir });
+    expect(report.triggered).toBe(true);
+    expect(report.triggerReason).toBe("14d-elapsed");
+  });
+
+  it("AC-bis-09: re-lint actually re-runs lintAcCommand without the exemption — findings reach the report", async () => {
+    const planPath = await writePlanFile("exempt.json", exemptPlan());
+    const report = await runLintRefresh(planPath, { projectPath: tempDir });
+
+    // Per-AC exemption entry must surface the F36 finding that the exemption
+    // would normally suppress (exempt flag stripped).
+    const perAcEntry = report.staleEntries.find(
+      (e) => e.scope === "per-ac" && e.exemptionId === "AC01:F36-source-tree-grep",
+    );
+    expect(perAcEntry).toBeDefined();
+    expect(perAcEntry!.currentFindings.length).toBeGreaterThan(0);
+    expect(perAcEntry!.currentFindings[0]).toContain("F36-source-tree-grep");
+
+    // Plan-level exemption entry must surface the AC02 finding.
+    const planEntry = report.staleEntries.find((e) => e.scope === "plan-level");
+    expect(planEntry).toBeDefined();
+    expect(planEntry!.currentFindings.some((f) => f.startsWith("AC02"))).toBe(true);
+  });
+});

--- a/server/tools/lint-refresh.ts
+++ b/server/tools/lint-refresh.ts
@@ -1,0 +1,259 @@
+/**
+ * Q0.5/A3-bis — forge_lint_refresh tool.
+ *
+ * Pure re-validation pass over every `lintExempt` entry in an execution plan:
+ * - Compares the stored rule-surface hash against the current one
+ * - Flags entries older than 14 days even when the hash matches
+ * - Re-runs `lintAcCommand` against each exempt AC *without* its exemption and
+ *   collects current findings so a human can decide whether the override is
+ *   still warranted
+ *
+ * Does NOT mutate the plan. Writes the fresh audit record only when the
+ * refresh actually fires.
+ */
+
+import { z } from "zod";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+import { loadPlan } from "../lib/plan-loader.js";
+import { lintAcCommand } from "../validation/ac-lint.js";
+import { getAcLintRulesHash } from "../lib/prompts/shared/ac-subprocess-rules.js";
+import {
+  computePlanSlug,
+  isStale,
+  loadAudit,
+  writeAudit,
+} from "../lib/lint-audit.js";
+import type {
+  LintAuditEntry,
+  LintRefreshReport,
+  LintRefreshStaleEntry,
+  LintRefreshTriggerReason,
+} from "../types/lint-audit.js";
+import type {
+  AcceptanceCriterion,
+  ExecutionPlan,
+  Story,
+} from "../types/execution-plan.js";
+
+// ── Input schema ──────────────────────────────────────────
+
+export const lintRefreshInputSchema = {
+  planPath: z
+    .string()
+    .describe("Path to execution plan JSON file"),
+  force: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, skip the staleness check and always re-lint. Default false.",
+    ),
+  projectPath: z
+    .string()
+    .optional()
+    .describe(
+      "Project root for .ai-workspace/lint-audit/ persistence. Defaults to the plan file's ancestor (two dirs up from planPath).",
+    ),
+  now: z
+    .string()
+    .optional()
+    .describe("ISO-8601 override for 'current time' — test hook."),
+};
+
+export interface LintRefreshInput {
+  planPath: string;
+  force?: boolean;
+  projectPath?: string;
+  now?: string;
+}
+
+type McpResponse = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+// ── Helpers ──────────────────────────────────────────────
+
+/** Default project root = the directory containing `.ai-workspace/plans/` */
+function defaultProjectPath(planPath: string): string {
+  const abs = isAbsolute(planPath) ? planPath : resolve(planPath);
+  // planPath = <root>/.ai-workspace/plans/<file>.json → go up two levels
+  return resolve(dirname(abs), "..", "..");
+}
+
+function allAcs(plan: ExecutionPlan): Array<{ story: Story; ac: AcceptanceCriterion }> {
+  const out: Array<{ story: Story; ac: AcceptanceCriterion }> = [];
+  for (const story of plan.stories) {
+    for (const ac of story.acceptanceCriteria ?? []) {
+      out.push({ story, ac });
+    }
+  }
+  return out;
+}
+
+function countExemptions(plan: ExecutionPlan): {
+  perAc: number;
+  planLevel: number;
+} {
+  let perAc = 0;
+  for (const { ac } of allAcs(plan)) {
+    if (!ac.lintExempt) continue;
+    const arr = Array.isArray(ac.lintExempt) ? ac.lintExempt : [ac.lintExempt];
+    perAc += arr.length;
+  }
+  const planLevel = plan.lintExempt?.length ?? 0;
+  return { perAc, planLevel };
+}
+
+function collectStaleEntries(plan: ExecutionPlan): LintRefreshStaleEntry[] {
+  const out: LintRefreshStaleEntry[] = [];
+
+  // Per-AC exemptions: re-lint without the exemption and capture raw findings.
+  for (const { ac } of allAcs(plan)) {
+    if (!ac.lintExempt) continue;
+    const result = lintAcCommand(ac.command);
+    const exemptArr = Array.isArray(ac.lintExempt) ? ac.lintExempt : [ac.lintExempt];
+    for (const exempt of exemptArr) {
+      out.push({
+        exemptionId: `${ac.id}:${exempt.ruleId}`,
+        scope: "per-ac",
+        rationale: exempt.rationale ?? "",
+        currentFindings: result.findings
+          .filter((f) => f.ruleId === exempt.ruleId)
+          .map((f) => `${f.ruleId}: ${f.snippet}`),
+      });
+    }
+  }
+
+  // Plan-level exemptions: bootstrap-absorption entries. Re-lint every AC in
+  // the matching batch against the exempted rules *without* the absorption.
+  for (const planExempt of plan.lintExempt ?? []) {
+    const batchSet = new Set(planExempt.batch);
+    const rulesSet = new Set(planExempt.rules);
+    const findings: string[] = [];
+    for (const { ac } of allAcs(plan)) {
+      if (!batchSet.has(ac.id)) continue;
+      const result = lintAcCommand(ac.command);
+      for (const f of result.findings) {
+        if (rulesSet.has(f.ruleId)) {
+          findings.push(`${ac.id} · ${f.ruleId}: ${f.snippet}`);
+        }
+      }
+    }
+    out.push({
+      exemptionId: `plan:${planExempt.rules.join(",")}`,
+      scope: "plan-level",
+      rationale: planExempt.rationale,
+      currentFindings: findings,
+    });
+  }
+
+  return out;
+}
+
+// ── Core ─────────────────────────────────────────────────
+
+/**
+ * Pure functional entry point — reused by `server/tools/plan.ts`'s
+ * `documentTier: "update"` hook. Any thrown error is the caller's to catch
+ * (the hook wraps this in try/catch so plan-update never blocks on refresh).
+ */
+export async function runLintRefresh(
+  planPath: string,
+  opts: {
+    force?: boolean;
+    projectPath?: string;
+    now?: Date;
+    /**
+     * Pre-loaded plan to audit instead of reading `planPath` from disk. Used
+     * by `plan.ts`'s `documentTier: "update"` hook so the refresh sees the
+     * freshly-revised plan in memory rather than the stale on-disk copy.
+     * The `planPath` is still used for slug computation and audit location.
+     */
+    plan?: ExecutionPlan;
+  } = {},
+): Promise<LintRefreshReport> {
+  const projectPath = opts.projectPath ?? defaultProjectPath(planPath);
+  const now = opts.now ?? new Date();
+  const currentHash = getAcLintRulesHash();
+
+  const plan: ExecutionPlan = opts.plan ?? loadPlan(planPath);
+  const counts = countExemptions(plan);
+
+  // No exemptions at all → write a baseline audit and return triggered:false.
+  // AC-bis-05 expects this behaviour so downstream tooling can still see a
+  // fresh audit file even when nothing was exempt.
+  if (counts.perAc === 0 && counts.planLevel === 0) {
+    const entry: LintAuditEntry = {
+      planId: computePlanSlug(planPath),
+      planPath,
+      lastAuditedAt: now.toISOString(),
+      ruleHash: currentHash,
+      perAcExemptCount: 0,
+      planLevelExemptCount: 0,
+    };
+    await writeAudit(projectPath, entry);
+    return {
+      triggered: false,
+      triggerReason: "none",
+      staleEntries: [],
+    };
+  }
+
+  const existing = await loadAudit(projectPath, planPath);
+  let reason: LintRefreshTriggerReason;
+
+  if (opts.force) {
+    reason = existing ? (isStale(existing, currentHash, now) ?? "rule-change") : "rule-change";
+  } else if (!existing) {
+    // Absent baseline = treat as rule-change drift (AC-bis-06).
+    reason = "rule-change";
+  } else {
+    const staleness = isStale(existing, currentHash, now);
+    if (!staleness) {
+      return { triggered: false, triggerReason: "none", staleEntries: [] };
+    }
+    reason = staleness;
+  }
+
+  const staleEntries = collectStaleEntries(plan);
+
+  const fresh: LintAuditEntry = {
+    planId: computePlanSlug(planPath),
+    planPath,
+    lastAuditedAt: now.toISOString(),
+    ruleHash: currentHash,
+    perAcExemptCount: counts.perAc,
+    planLevelExemptCount: counts.planLevel,
+  };
+  await writeAudit(projectPath, fresh);
+
+  return {
+    triggered: true,
+    triggerReason: reason,
+    staleEntries,
+  };
+}
+
+// ── MCP handler ──────────────────────────────────────────
+
+export async function handleLintRefresh(
+  input: LintRefreshInput,
+): Promise<McpResponse> {
+  try {
+    const report = await runLintRefresh(input.planPath, {
+      force: input.force,
+      projectPath: input.projectPath,
+      now: input.now ? new Date(input.now) : undefined,
+    });
+    return {
+      content: [{ type: "text", text: JSON.stringify(report, null, 2) }],
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{ type: "text", text: `forge_lint_refresh error: ${message}` }],
+      isError: true,
+    };
+  }
+}

--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -1097,6 +1097,113 @@ describe("documentTier: update", () => {
     expect(Array.isArray(resp.critiqueRounds)).toBe(true);
     expect((resp.critiqueRounds as unknown[]).length).toBeGreaterThan(0);
   });
+
+  // Q0.5/A3-bis — lintRefresh hook on the update branch.
+  describe("lintRefresh hook (Q0.5/A3-bis)", () => {
+    const { mkdtempSync, writeFileSync, mkdirSync, rmSync } = require("node:fs");
+    const { join } = require("node:path");
+    const { tmpdir } = require("node:os");
+
+    let tempDir: string;
+    let planPath: string;
+
+    const exemptPlan = () => ({
+      schemaVersion: "3.0.0",
+      stories: [
+        {
+          id: "US-01",
+          title: "Exempt plan",
+          dependencies: [],
+          acceptanceCriteria: [
+            {
+              id: "AC-01",
+              description: "per-ac exempt",
+              command: "grep -rn 'Redis' src/",
+              lintExempt: {
+                ruleId: "F36-source-tree-grep",
+                rationale: "legacy cache probe",
+              },
+            },
+          ],
+          affectedPaths: ["src/"],
+        },
+      ],
+    });
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "forge-plan-lintrefresh-"));
+      const plansDir = join(tempDir, ".ai-workspace", "plans");
+      mkdirSync(plansDir, { recursive: true });
+      planPath = join(plansDir, "exempt.json");
+      writeFileSync(planPath, JSON.stringify(exemptPlan()), "utf-8");
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("AC-bis-12: fires runLintRefresh once and populates lintRefresh field", async () => {
+      mockedCallClaude.mockResolvedValueOnce(makeCallResult(exemptPlan()));
+
+      const result = await handlePlan({
+        intent: "update plan",
+        documentTier: "update",
+        currentPlan: JSON.stringify(exemptPlan()),
+        implementationNotes: "A3-bis hook wiring test",
+        tier: "quick",
+        planPath,
+        projectPath: tempDir,
+      });
+
+      const resp = result as typeof result & { lintRefresh?: unknown };
+      expect(resp.lintRefresh).toBeDefined();
+      expect(resp.lintRefresh).not.toBeNull();
+      const report = resp.lintRefresh as {
+        triggered: boolean;
+        triggerReason: string;
+        staleEntries: unknown[];
+      };
+      expect(report.triggered).toBe(true);
+      expect(report.triggerReason).toBe("rule-change");
+      expect(Array.isArray(report.staleEntries)).toBe(true);
+      expect(report.staleEntries.length).toBeGreaterThan(0);
+    });
+
+    it("AC-bis-13: thrown error inside the hook is caught; lintRefresh carries { error } and the rest of the response is baseline", async () => {
+      mockedCallClaude.mockResolvedValueOnce(makeCallResult(exemptPlan()));
+
+      // Pre-seed a corrupt audit file at the exact slug location so the
+      // second runLintRefresh call inside the hook hits a JSON parse error.
+      const auditDir = join(tempDir, ".ai-workspace", "lint-audit");
+      mkdirSync(auditDir, { recursive: true });
+      writeFileSync(
+        join(auditDir, "plans__exempt.audit.json"),
+        "{not valid json",
+        "utf-8",
+      );
+
+      const result = await handlePlan({
+        intent: "update plan",
+        documentTier: "update",
+        currentPlan: JSON.stringify(exemptPlan()),
+        implementationNotes: "A3-bis hook error swallow test",
+        tier: "quick",
+        planPath,
+        projectPath: tempDir,
+      });
+
+      const resp = result as typeof result & {
+        lintRefresh?: unknown;
+        updatedPlan?: unknown;
+      };
+      // Hook failed non-fatally: error object in lintRefresh
+      expect(resp.lintRefresh).toBeDefined();
+      expect(resp.lintRefresh).toHaveProperty("error");
+      // Baseline update response still intact: text blob + updatedPlan still present
+      expect(result.content[0].text).toContain("=== UPDATED PLAN ===");
+      expect(resp.updatedPlan).toBeDefined();
+    });
+  });
 });
 
 describe("backward compatibility (no documentTier)", () => {

--- a/server/tools/plan.ts
+++ b/server/tools/plan.ts
@@ -18,6 +18,8 @@ import { validateExecutionPlan } from "../validation/execution-plan.js";
 import { lintPlan, type LintPlanReport } from "../validation/ac-lint.js";
 import { validateMasterPlan } from "../validation/master-plan.js";
 import { writeRunRecord, type RunRecord } from "../lib/run-record.js";
+import { runLintRefresh } from "./lint-refresh.js";
+import type { LintRefreshReport } from "../types/lint-audit.js";
 import { RunContext, trackedCallClaude } from "../lib/run-context.js";
 import type { ExecutionPlan } from "../types/execution-plan.js";
 import type { MasterPlan } from "../types/master-plan.js";
@@ -119,6 +121,15 @@ export const planInputSchema = {
     .string()
     .optional()
     .describe("Existing plan JSON string to update. Required for update tier."),
+  planPath: z
+    .string()
+    .optional()
+    .describe(
+      "Absolute path to the execution plan on disk. Optional for update tier — " +
+      "when provided, the A3-bis lintRefresh hook fires at the end of the update " +
+      "and persists audit state under .ai-workspace/lint-audit/. No effect on " +
+      "master/phase/default tiers.",
+    ),
   context: z
     .array(
       z.object({
@@ -900,7 +911,7 @@ async function handlePhasePlan(options: HandlePlanOptions) {
  * Handle update mode: revise an existing plan based on implementation notes.
  */
 async function handleUpdatePlan(options: HandlePlanOptions) {
-  const { currentPlan, implementationNotes, projectPath, tier, context, maxContextChars, strictLint } = options;
+  const { currentPlan, implementationNotes, projectPath, tier, context, maxContextChars, strictLint, planPath } = options;
   if (!currentPlan || !implementationNotes) {
     return {
       content: [{ type: "text" as const, text: "Error: currentPlan and implementationNotes are required for documentTier 'update'." }],
@@ -999,11 +1010,26 @@ async function handleUpdatePlan(options: HandlePlanOptions) {
   // existing external consumers (none known in this repo — grep confirms
   // only server/tools/reconcile.ts depends on the envelope shape) continue
   // to work without modification.
+  // Q0.5/A3-bis — lintRefresh hook. Non-fatal: any error is caught and
+  // surfaced as `lintRefresh: { error }` so the update path is never blocked.
+  // Requires planPath so the audit can persist under .ai-workspace/lint-audit/.
+  let lintRefresh: LintRefreshReport | { error: string } | null = null;
+  if (planPath) {
+    try {
+      lintRefresh = await runLintRefresh(planPath, { plan, projectPath });
+    } catch (err) {
+      lintRefresh = {
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
   return {
     content: [{ type: "text" as const, text: sections.join("\n\n") }],
     updatedPlan: plan,
     critiqueRounds: critiqueRounds.length > 0 ? critiqueRounds : null,
     lintReport,
+    lintRefresh,
   };
 }
 
@@ -1122,6 +1148,7 @@ interface HandlePlanOptions {
   phaseId?: string;
   implementationNotes?: string;
   currentPlan?: string;
+  planPath?: string;
   context?: Array<{ label: string; content: string }>;
   maxContextChars?: number;
   strictLint?: boolean;

--- a/server/types/lint-audit.ts
+++ b/server/types/lint-audit.ts
@@ -1,0 +1,46 @@
+/**
+ * Q0.5/A3-bis — Lint-exemption audit state.
+ *
+ * Tracks when each plan's `lintExempt` overrides were last re-validated against
+ * the current ac-lint rule surface. Two staleness triggers: rule-set hash drift
+ * (`AC_LINT_RULES` / `AC_SUBPROCESS_RULES_PROMPT` changed) and 14-day calendar.
+ *
+ * Persisted to `.ai-workspace/lint-audit/{planSlug}.audit.json` (committed).
+ */
+
+export interface LintAuditEntry {
+  /** Stable plan identifier (parentDir__basename, no .md). */
+  planId: string;
+  /** Original plan path the audit was computed against (informational). */
+  planPath: string;
+  /** ISO-8601 of the last successful re-validation. */
+  lastAuditedAt: string;
+  /** Hash of the rule surface at last audit (`getAcLintRulesHash()`). */
+  ruleHash: string;
+  /** Number of per-AC `lintExempt: true` ACs in the plan at audit time. */
+  perAcExemptCount: number;
+  /** Number of plan-level `lintExempt[]` entries in the plan at audit time. */
+  planLevelExemptCount: number;
+}
+
+export type LintRefreshTriggerReason =
+  | "rule-change"
+  | "14d-elapsed"
+  | "none";
+
+export interface LintRefreshStaleEntry {
+  /** Identifier for the exempt AC or plan-level rule. */
+  exemptionId: string;
+  /** Where the exemption lives: per-AC override or plan-level deny-list bypass. */
+  scope: "per-ac" | "plan-level";
+  /** The original rationale string (verbatim from the plan). */
+  rationale: string;
+  /** Lint findings produced by re-running the rule WITHOUT the exemption. */
+  currentFindings: string[];
+}
+
+export interface LintRefreshReport {
+  triggered: boolean;
+  triggerReason: LintRefreshTriggerReason;
+  staleEntries: LintRefreshStaleEntry[];
+}


### PR DESCRIPTION
## Summary

Closes the staleness gap that Q0.5/A3 (v0.29.0) deferred. Every `lintExempt`
override (per-AC AND plan-level) is now re-validated against the current
ac-lint rule surface on two triggers:

- **rule-change** — sha256 drift of `AC_SUBPROCESS_RULES_PROMPT` + `AC_LINT_RULES` via new `getAcLintRulesHash()`
- **14d-elapsed** — calendar timeout even when the hash matches

The refresh reports only; it never mutates the plan. Humans (or a follow-up
`forge_reconcile`) decide whether to drop, rewrite, or re-accept each stale
exemption.

New primitive `forge_lint_refresh` is callable standalone (with `force: true`
to skip the staleness check) and also auto-fires as a non-fatal side effect at
the end of `forge_plan(documentTier: 'update')` when `planPath` is provided.
Hook failure is swallowed into `lintRefresh: { error }` so the update path is
never blocked.

Audit state persists under `.ai-workspace/lint-audit/{planSlug}.audit.json`.
Slug = `<parentDir>__<basename>` for cross-dir collision resistance.

### Files (9)
- `server/lib/prompts/shared/ac-subprocess-rules.ts` — `getAcLintRulesHash()` (cached, pure)
- `server/types/lint-audit.ts` — `LintAuditEntry`, `LintRefreshReport`, `LintRefreshStaleEntry`
- `server/lib/lint-audit.ts` — `loadAudit` / `writeAudit` / `isStale` / `computePlanSlug`
- `server/lib/lint-audit.test.ts` — AC-bis-01..04 (9 tests)
- `server/tools/lint-refresh.ts` — `runLintRefresh` core + MCP handler
- `server/tools/lint-refresh.test.ts` — AC-bis-05..09 (5 tests)
- `server/tools/plan.ts` — update-branch hook insertion + `planPath` optional input
- `server/tools/plan.test.ts` — AC-bis-12..13 (2 tests)
- `server/index.ts` — tool registration

## Test plan
- [x] AC-bis-01..04 — hash stability + isStale precedence (9/9 green)
- [x] AC-bis-05 — clean plan baseline audit
- [x] AC-bis-06 — first-run drift with both-scope counts
- [x] AC-bis-07 — immediate re-run is triggered:false
- [x] AC-bis-08 — 15-day age triggers 14d-elapsed
- [x] AC-bis-09 — re-lint reaches findings without the exemption
- [x] AC-bis-10 — full vitest run clean (715/715, 4 skipped, 0 regressions)
- [x] AC-bis-11 — negative-space audit (9 files, no drift into reconcile/evaluate/coordinate/generator/evaluator/ac-lint/MEMORY.md)
- [x] AC-bis-12 — forge_plan(update) with planPath fires hook once, populates lintRefresh
- [x] AC-bis-13 — hook error swallowed into lintRefresh: { error }, rest of response unchanged
- [x] `npm run build` clean

---
plan-refresh: no-op