### PR TITLE
chore(q05-a3bis-polish): close #198-#203 batch

### DIFF
--- a/server/lib/lint-audit.test.ts
+++ b/server/lib/lint-audit.test.ts
@@ -8,7 +8,10 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { getAcLintRulesHash } from "./prompts/shared/ac-subprocess-rules.js";
+import {
+  __resetAcLintRulesHashCache,
+  getAcLintRulesHash,
+} from "./prompts/shared/ac-subprocess-rules.js";
 import {
   computePlanSlug,
   isStale,
@@ -93,6 +96,23 @@ describe("computePlanSlug", () => {
     const a = computePlanSlug("phases/phase-01.md");
     const b = computePlanSlug("archive/phase-01.md");
     expect(a).not.toBe(b);
+  });
+
+  it("AC-bis-polish-03: strips any extension via path.parse().name", () => {
+    expect(computePlanSlug("plans/foo.yaml")).toBe("plans__foo");
+    expect(computePlanSlug("plans/bar")).toBe("plans__bar");
+  });
+});
+
+describe("__resetAcLintRulesHashCache — AC-bis-polish-04", () => {
+  it("recomputes the hash after a reset (cache is actually cleared)", () => {
+    const h1 = getAcLintRulesHash();
+    __resetAcLintRulesHashCache();
+    const h2 = getAcLintRulesHash();
+    // Still deterministic (rules didn't change), but the second call must
+    // have re-executed the hash pipeline rather than returning a frozen null.
+    expect(h2).toBe(h1);
+    expect(h2).toMatch(/^[0-9a-f]{64}$/);
   });
 });
 

--- a/server/lib/lint-audit.ts
+++ b/server/lib/lint-audit.ts
@@ -7,12 +7,9 @@
  */
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { dirname, join, parse } from "node:path";
 
-import type {
-  LintAuditEntry,
-  LintRefreshTriggerReason,
-} from "../types/lint-audit.js";
+import type { LintAuditEntry } from "../types/lint-audit.js";
 
 const FOURTEEN_DAYS_MS = 14 * 86_400 * 1_000;
 
@@ -22,9 +19,9 @@ const FOURTEEN_DAYS_MS = 14 * 86_400 * 1_000;
  * `archive/phase-01.md`).
  */
 export function computePlanSlug(planPath: string): string {
-  const parent = basename(dirname(planPath));
-  const base = basename(planPath).replace(/\.(md|json)$/i, "");
-  return `${parent}__${base}`;
+  const parsed = parse(planPath);
+  const parent = parse(parsed.dir).base;
+  return `${parent}__${parsed.name}`;
 }
 
 function auditFilePath(projectPath: string, planPath: string): string {
@@ -80,7 +77,7 @@ export function isStale(
   entry: LintAuditEntry,
   currentHash: string,
   now: Date,
-): Exclude<LintRefreshTriggerReason, "none"> | null {
+): "rule-change" | "14d-elapsed" | null {
   if (entry.ruleHash !== currentHash) return "rule-change";
   const ageMs = now.getTime() - new Date(entry.lastAuditedAt).getTime();
   if (ageMs > FOURTEEN_DAYS_MS) return "14d-elapsed";

--- a/server/lib/prompts/shared/ac-subprocess-rules.ts
+++ b/server/lib/prompts/shared/ac-subprocess-rules.ts
@@ -155,3 +155,9 @@ export function getAcLintRulesHash(): string {
     .digest("hex");
   return cachedHash;
 }
+
+/** Test-only: reset the module-local hash cache. Prefixed with `__` so it is
+ *  clearly not part of the production API. */
+export function __resetAcLintRulesHashCache(): void {
+  cachedHash = null;
+}

--- a/server/tools/lint-refresh.test.ts
+++ b/server/tools/lint-refresh.test.ts
@@ -157,10 +157,62 @@ describe("runLintRefresh — AC-bis-05..09", () => {
     expect(perAcEntry).toBeDefined();
     expect(perAcEntry!.currentFindings.length).toBeGreaterThan(0);
     expect(perAcEntry!.currentFindings[0]).toContain("F36-source-tree-grep");
+    // #199: exemption that still matches a rule is NOT obsolete.
+    expect(perAcEntry!.isObsolete).toBe(false);
 
     // Plan-level exemption entry must surface the AC02 finding.
     const planEntry = report.staleEntries.find((e) => e.scope === "plan-level");
     expect(planEntry).toBeDefined();
     expect(planEntry!.currentFindings.some((f) => f.startsWith("AC02"))).toBe(true);
+  });
+
+  it("AC-bis-polish-01 (#198): force:true on a fresh audit labels reason 'forced', not 'rule-change'", async () => {
+    const planPath = await writePlanFile("exempt.json", exemptPlan());
+    // Establish a fresh baseline audit first.
+    await runLintRefresh(planPath, { projectPath: tempDir });
+
+    // Force-refresh immediately — audit is fresh, so isStale returns null,
+    // and the force branch must label the refresh "forced" instead of
+    // reporting a bogus "rule-change".
+    const forced = await runLintRefresh(planPath, {
+      projectPath: tempDir,
+      force: true,
+    });
+    expect(forced.triggered).toBe(true);
+    expect(forced.triggerReason).toBe("forced");
+  });
+
+  it("AC-bis-polish-02 (#199): exemption with zero current findings is flagged isObsolete:true", async () => {
+    // Per-AC exemption that does NOT trip any current rule — safe to drop.
+    const plan = {
+      schemaVersion: "3.0.0",
+      stories: [
+        {
+          id: "US-01",
+          title: "Obsolete exemption",
+          acceptanceCriteria: [
+            {
+              id: "AC01",
+              description: "Harmless command still exempted",
+              command: "echo ok",
+              lintExempt: {
+                ruleId: "F36-source-tree-grep",
+                rationale: "once upon a time this used grep",
+              },
+            },
+          ],
+        },
+      ],
+    } as unknown as ExecutionPlan;
+
+    const planPath = await writePlanFile("obsolete.json", plan);
+    const report = await runLintRefresh(planPath, { projectPath: tempDir });
+
+    const entry = report.staleEntries.find(
+      (e) => e.exemptionId === "AC01:F36-source-tree-grep",
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.currentFindings).toEqual([]);
+    expect(entry!.isObsolete).toBe(true);
   });
 });

--- a/server/tools/lint-refresh.ts
+++ b/server/tools/lint-refresh.ts
@@ -107,20 +107,30 @@ function countExemptions(plan: ExecutionPlan): {
 
 function collectStaleEntries(plan: ExecutionPlan): LintRefreshStaleEntry[] {
   const out: LintRefreshStaleEntry[] = [];
+  const lintCache = new Map<string, ReturnType<typeof lintAcCommand>>();
+  const getLintResult = (ac: { id: string; command: string }) => {
+    const cached = lintCache.get(ac.id);
+    if (cached) return cached;
+    const fresh = lintAcCommand(ac.command);
+    lintCache.set(ac.id, fresh);
+    return fresh;
+  };
 
   // Per-AC exemptions: re-lint without the exemption and capture raw findings.
   for (const { ac } of allAcs(plan)) {
     if (!ac.lintExempt) continue;
-    const result = lintAcCommand(ac.command);
+    const result = getLintResult(ac);
     const exemptArr = Array.isArray(ac.lintExempt) ? ac.lintExempt : [ac.lintExempt];
     for (const exempt of exemptArr) {
+      const currentFindings = result.findings
+        .filter((f) => f.ruleId === exempt.ruleId)
+        .map((f) => `${f.ruleId}: ${f.snippet}`);
       out.push({
         exemptionId: `${ac.id}:${exempt.ruleId}`,
         scope: "per-ac",
         rationale: exempt.rationale ?? "",
-        currentFindings: result.findings
-          .filter((f) => f.ruleId === exempt.ruleId)
-          .map((f) => `${f.ruleId}: ${f.snippet}`),
+        currentFindings,
+        isObsolete: currentFindings.length === 0,
       });
     }
   }
@@ -133,7 +143,7 @@ function collectStaleEntries(plan: ExecutionPlan): LintRefreshStaleEntry[] {
     const findings: string[] = [];
     for (const { ac } of allAcs(plan)) {
       if (!batchSet.has(ac.id)) continue;
-      const result = lintAcCommand(ac.command);
+      const result = getLintResult(ac);
       for (const f of result.findings) {
         if (rulesSet.has(f.ruleId)) {
           findings.push(`${ac.id} · ${f.ruleId}: ${f.snippet}`);
@@ -145,6 +155,7 @@ function collectStaleEntries(plan: ExecutionPlan): LintRefreshStaleEntry[] {
       scope: "plan-level",
       rationale: planExempt.rationale,
       currentFindings: findings,
+      isObsolete: findings.length === 0,
     });
   }
 
@@ -204,7 +215,9 @@ export async function runLintRefresh(
   let reason: LintRefreshTriggerReason;
 
   if (opts.force) {
-    reason = existing ? (isStale(existing, currentHash, now) ?? "rule-change") : "rule-change";
+    // Honest labelling: only tag drift reasons when drift actually exists.
+    // A forced refresh on a fresh audit is labelled "forced", not a fake "rule-change".
+    reason = existing ? (isStale(existing, currentHash, now) ?? "forced") : "rule-change";
   } else if (!existing) {
     // Absent baseline = treat as rule-change drift (AC-bis-06).
     reason = "rule-change";

--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import type { CallClaudeResult } from "../lib/anthropic.js";
 
 // Mock the anthropic module
@@ -1100,10 +1103,6 @@ describe("documentTier: update", () => {
 
   // Q0.5/A3-bis — lintRefresh hook on the update branch.
   describe("lintRefresh hook (Q0.5/A3-bis)", () => {
-    const { mkdtempSync, writeFileSync, mkdirSync, rmSync } = require("node:fs");
-    const { join } = require("node:path");
-    const { tmpdir } = require("node:os");
-
     let tempDir: string;
     let planPath: string;
 

--- a/server/types/lint-audit.ts
+++ b/server/types/lint-audit.ts
@@ -26,6 +26,7 @@ export interface LintAuditEntry {
 export type LintRefreshTriggerReason =
   | "rule-change"
   | "14d-elapsed"
+  | "forced"
   | "none";
 
 export interface LintRefreshStaleEntry {
@@ -37,6 +38,8 @@ export interface LintRefreshStaleEntry {
   rationale: string;
   /** Lint findings produced by re-running the rule WITHOUT the exemption. */
   currentFindings: string[];
+  /** True when re-lint produced zero findings — the exemption is now safe to drop. */
+  isObsolete?: boolean;
 }
 
 export interface LintRefreshReport {


### PR DESCRIPTION
## Summary

Closes the 6 ship-review enhancements from A3-bis (#197 / v0.30.0) in a single polish PR. All six are style/refactor/tiny perf — no behavior change to the v0.30.0 hook contract.

- **#198 E1** — force branch now reports `"forced"` instead of fabricating `"rule-change"`. Added `"forced"` to `LintRefreshTriggerReason` union.
- **#199 E2** — `LintRefreshStaleEntry` gains `isObsolete?: boolean`, set when the re-lint produced zero findings (exemption safe to drop).
- **#200 E3** — `collectStaleEntries` caches `lintAcCommand(ac.command)` by `ac.id` across both per-AC and plan-level loops. Eliminates redundant re-lints when multiple plan-level exempts target overlapping ACs.
- **#201 E4 (slug)** — `computePlanSlug` uses `path.parse().name` instead of a regex strip, so `foo.yaml` / extension-less plans slug cleanly.
- **#202 E5** — hoisted `node:fs` / `node:path` / `node:os` imports in `plan.test.ts` out of `require()` into top-of-file ESM imports (consistency with the rest of the suite).
- **#203 E6** — exported `__resetAcLintRulesHashCache()` test helper. `__` prefix signals test-only.

Fixes #198, #199, #200, #201, #202, #203

## Test plan

- [x] `npx vitest run` → 719 passed, 4 skipped (was 715 pre-change; added 4 polish micro-tests)
- [x] `npx vitest run server/smoke/mcp-surface.test.ts` → 6/6 (explicit smoke run per the new local-vs-CI lesson from A3-bis ship)
- [x] `tsc --noEmit` → clean
- [x] `npm run build` → clean
- [x] `git diff --stat master` → 7 server files only (types + 2 lib + 2 tool + 2 test), zero drift into reconcile/evaluate/coordinate/generate/plan.ts/ac-lint.ts
- [x] AC-bis-13 regression guard → existing `forge_plan(update)` non-fatal hook test still green (plan.ts untouched)

New micro-tests:
- `AC-bis-polish-01` — `force:true` on a fresh audit → `triggerReason: "forced"` (not `"rule-change"`)
- `AC-bis-polish-02` — exempt AC whose command trips no current rules → `isObsolete: true, currentFindings: []`
- `AC-bis-polish-03` — `computePlanSlug("plans/foo.yaml")` → `"plans__foo"` (extension-agnostic)
- `AC-bis-polish-04` — hash cache reset → recomputation yields matching stable hash

---
plan-refresh: no-op