### PR TITLE
fix(q05-task34): kill 40 lint errors + wire lint into CI

### DIFF
--- a/.ai-workspace/plans/2026-04-14-q05-task34-lint-debt-ci-wiring.md
+++ b/.ai-workspace/plans/2026-04-14-q05-task34-lint-debt-ci-wiring.md
@@ -1,0 +1,118 @@
+# Q0.5 Task #34 — Lint debt fix + wire `npm run lint` into CI
+
+## Context
+
+Task #33 (`.ai-workspace/plans/2026-04-14-q05-q1-gitignore-design.md`, shipped v0.30.3 as PR #207) surfaced 40 pre-existing ESLint errors in `server/**` test files. That task's AC-11 had to be weakened mid-flight from "`npm run lint` exits 0" to "no NEW errors vs master" because the debt was outside its scope and bundling the fix would have been F7 "fix two things in one PR, break both."
+
+The debt grew unchecked because **CI never runs `npm run lint`.** `.github/workflows/ci.yml` on master (v0.30.3) invokes only `npm ci --ignore-scripts`, `npm run build`, the dist-drift guard, `npm test`, and a commit-message validator. There is no lint step. Every PR that added an `any` in a test file quietly regressed the baseline with no signal.
+
+This task fixes the debt AND closes the hole so it can't regrow. Both halves must land together — fixing the errors without wiring CI leaves the same gap open; wiring CI without fixing the errors reddens every future PR.
+
+### Baseline (measured on origin/master @ v0.30.3, commit d9a3bf7)
+
+- `npm run lint` exits non-zero with **40 errors, 0 warnings** across 10 files.
+- Rule breakdown:
+  - `@typescript-eslint/no-explicit-any` — 32 errors
+  - `@typescript-eslint/no-this-alias` — 5 errors
+  - `@typescript-eslint/no-unused-vars` — 2 errors
+  - `@typescript-eslint/no-unsafe-function-type` — 1 error
+- Files (10 total):
+  - `server/lib/audit.ts` (1) — **not a test file, production source** (unused-var on `_entry` at line 74, `for await` iteration counter where the value is intentionally unused)
+  - `server/lib/executor.test.ts` (1)
+  - `server/lib/test-utils.ts` (3) — **not a `.test.ts` file, a shared helper**
+  - `server/tools/coordinate.test.ts` (1)
+  - `server/tools/divergence-cwd.test.ts` (3)
+  - `server/tools/evaluate-critic.test.ts` (3)
+  - `server/tools/evaluate.test.ts` (3)
+  - `server/tools/plan.test.ts` (11)
+  - `server/tools/three-tier-integration.test.ts` (8)
+  - `server/validation/ac-lint.test.ts` (6)
+
+### Why the mix matters
+
+~80% of the debt is `no-explicit-any`, which can be mechanically converted to `unknown` + narrowing, or to proper types drawn from the surrounding fixtures. The remaining ~20% needs real judgment: `no-this-alias` implies a refactor to arrow functions or typed closures, `no-unsafe-function-type` means finding the real signature, and `no-unused-vars` means deleting or prefixing. A pure find-and-replace will leave 8 errors behind — the executor should not under-scope this as "swap `any` for `unknown`."
+
+## Goal
+
+Invariants that must hold when done:
+
+1. `npm run lint` exits 0 on the PR branch. Every current error is fixed with real types or real refactors — **not** suppressed with file-level `/* eslint-disable */` or per-line `// eslint-disable-next-line`.
+2. `npm test` still passes (no regression in test behavior caused by type tightening).
+3. `npm run build` still passes.
+4. `.github/workflows/ci.yml` invokes `npm run lint` as a required job step, so any future regression fails CI before merge.
+5. The AC-11 contract promoted: after this lands, future PRs can hold the stronger "`npm run lint` exits 0" instead of the delta-based wording used in PR #207.
+
+## Binary AC
+
+Executor is done when ALL of these hold. Each is checkable with a single command.
+
+- [ ] AC-1 — **Zero lint errors on the branch.** `npm run lint 2>&1 | tail -5 | grep -c "0 errors"` returns `1`, OR `npm run lint` exits 0. Either check is acceptable; executor picks the shape of the wrapper.
+- [ ] AC-2 — **No blanket disables introduced.** `git diff origin/master...HEAD -- 'server/**/*.ts' | grep -cE '^\+.*eslint-disable'` returns `0`. (Disable comments may exist on master — delta against master must be zero new ones.)
+- [ ] AC-3 — **Rule set unchanged.** `git diff origin/master...HEAD -- eslint.config.js .eslintrc* 2>&1 | wc -l` returns `0`. Do not weaken rule severities or add `ignorePatterns` to make the errors disappear.
+- [ ] AC-4 — **CI runs lint.** `MSYS_NO_PATHCONV=1 git show HEAD:.github/workflows/ci.yml | grep -c 'npm run lint'` returns `≥ 1`.
+- [ ] AC-5 — **CI lint step is required, not `continue-on-error`.** `MSYS_NO_PATHCONV=1 git show HEAD:.github/workflows/ci.yml | grep -A2 'npm run lint' | grep -c 'continue-on-error'` returns `0`.
+- [ ] AC-6 — **Tests still pass.** `npm test` exits `0`.
+- [ ] AC-7 — **Build still passes.** `npm run build` exits `0`.
+- [ ] AC-8 — **No behavioral test changes.** `git diff origin/master...HEAD --stat -- 'server/**/*.test.ts' 'server/lib/test-utils.ts' | tail -1` shows only type-level changes. Reviewer spot-checks 3 random files and confirms assertions, fixtures, and control flow are unchanged — only type annotations. (Reviewer judgment AC; not automatable.)
+- [ ] AC-9 — **CI green on the PR.** All required checks pass before merge, including the new lint step.
+- [ ] AC-10 — **Error count moves to 0, not "fewer".** `npm run lint 2>&1 | grep -cE '^\s*[0-9]+:[0-9]+\s+error'` returns `0`. Belt-and-braces check against a subtle partial fix.
+
+## Out of scope
+
+- Do not touch `server/**/*.ts` files that are NOT in the 10-file baseline list above. No drive-by fixes in production source. `server/lib/audit.ts` is the only production-source (non-test) file in the baseline — fix it per the Critical files hint and do not let it open a lane for other production edits.
+- Do not rename, relocate, or delete any test file.
+- Do not modify ESLint rule config (`eslint.config.js`, `.eslintrc*`, `tsconfig.json` lint-relevant fields).
+- Do not add new test cases or change assertions.
+- Do not bundle Q3 (F56→F55 rename), the `/delegate` skill build, or any other pending task.
+- Do not force-push or rewrite history.
+
+## Ordering constraints
+
+The two halves (error fixes + CI wiring) must land in the same PR. Rationale: if CI wiring lands first, CI reddens; if fixes land first, the debt can regrow before CI catches up. One PR, executor picks commit shape (one commit or two is fine — the AC is the contract).
+
+## Verification procedure
+
+On the PR branch, reviewer runs:
+
+```
+npm ci
+npm run build
+npm test
+npm run lint                                 # must exit 0
+MSYS_NO_PATHCONV=1 git show HEAD:.github/workflows/ci.yml | grep 'npm run lint'  # must print ≥ 1 line
+git diff origin/master...HEAD -- 'server/**/*.ts' | grep -cE '^\+.*eslint-disable'   # must print 0
+git diff origin/master...HEAD -- eslint.config.js | wc -l   # must print 0
+```
+
+Reviewer then spot-checks 3 randomly chosen test files for AC-8 (type-only diff). If any assertion changed shape, kick back.
+
+## Critical files
+
+Guidance only — executor chooses the exact edits.
+
+- `server/lib/audit.ts` — 1 `no-unused-vars` error at line 74 on `_entry` in a `for await (const _entry of dir)` iteration counter. The value is intentionally unused (the loop is counting iterations, not reading entries). Fix shape: replace `_entry` with `_` (which most `no-unused-vars` rule configs exempt), OR rewrite the loop to use a direct count (`for (let i = 0; ...)`) if `opendir` supports it cleanly. Both are one-line surgical fixes. Do NOT suppress with `eslint-disable` (AC-2 blocks that). Do NOT modify the rule config (AC-3 blocks that). This is the ONLY production-source edit permitted by this task — do not let it cascade into other drive-by fixes in `server/lib/`.
+- `server/lib/executor.test.ts` — 1 `no-unsafe-function-type` error at line 36 (look at the actual signature of the function being passed; prefer `(...args: unknown[]) => unknown` or the real type from the production import).
+- `server/lib/test-utils.ts` — 3 `no-explicit-any` errors at lines 29, 31. Shared helper; any type tightening here ripples into every test that imports it.
+- `server/tools/coordinate.test.ts` — 1 `no-unused-vars` on `_cs` at line 294 (leading underscore suggests the lint rule is misconfigured to NOT exempt underscore-prefixed vars, OR the variable can just be deleted — executor picks).
+- `server/tools/divergence-cwd.test.ts`, `evaluate-critic.test.ts`, `evaluate.test.ts`, `three-tier-integration.test.ts` — each has a `const self = this` pattern around line 55-75 (`no-this-alias`) plus `no-explicit-any` on the adjacent function signature. Refactoring these four together will likely share a common arrow-function pattern.
+- `server/tools/plan.test.ts` — heaviest file (11 errors). `this`-alias at line 47, plus 10 `no-explicit-any` spread across lines 33-949. Executor should look for a shared fixture/helper type first — many of the `any`s are likely the same object shape.
+- `server/validation/ac-lint.test.ts` — 6 `no-explicit-any` around fixture construction and a `linter` helper call.
+- `.github/workflows/ci.yml` — add a `Lint` step (name: executor's choice) after the build step and before the test step, or in parallel — ordering is executor's call. Must not be `continue-on-error`.
+
+## Checkpoint
+
+- [x] Plan drafted (planner)
+- [x] Baseline captured: 40 errors on v0.30.3 (done, see Context)
+- [x] Plan amendment applied: file list corrected from 9 to 10 (added `server/lib/audit.ts`); root cause was planner tail-reading lint output on the first pass, caught by executor's first-pass re-enumeration (commit 2 on this branch, 2026-04-15)
+- [ ] Brief delivered to lucky-iris on thread `q05-task34-lint-debt`
+- [ ] Executor acks with dirty-worktree pre-flight + HEAD SHA + tool check
+- [ ] AC-1..AC-8 pass locally on executor's branch
+- [ ] AC-10 (belt-and-braces zero-count check) passes
+- [ ] PR opened with `plan-refresh: no-op`
+- [ ] AC-9 (CI green, including new lint step) passes
+- [ ] Stateless review PASS
+- [ ] Merged + released
+- [ ] Plan updated to reflect shipped reality (planner, post-merge)
+- [ ] q05/Q1 plan retroactively note: "AC-11 contract now promotable to `exits 0` on future PRs"
+
+Last updated: 2026-04-15T00:30:00+08:00 — amended file list from 9 to 10 (added `server/lib/audit.ts`) per blocker thread q05-task34-lint-debt. Amendment rides executor's branch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build (tsc compiles server/ → dist/)
         run: npm run build
 
+      - name: Lint (eslint server/ — must exit 0)
+        run: npm run lint
+
       - name: dist/ drift guard (no ghost stubs outside PH-01 coordinator)
         shell: bash
         run: |

--- a/server/lib/audit.ts
+++ b/server/lib/audit.ts
@@ -71,7 +71,7 @@ export class AuditLog {
       let count = 0;
       let exceeded = false;
       try {
-        for await (const _entry of dir) {
+        while ((await dir.read()) !== null) {
           count++;
           if (count >= FILE_COUNT_WARNING_THRESHOLD) {
             exceeded = true;
@@ -79,16 +79,10 @@ export class AuditLog {
           }
         }
       } finally {
-        // opendir's async iterator closes the handle automatically when
-        // exhausted, but an early `break` leaves it open — close it.
-        if (!exceeded) {
-          // Iterator already closed the handle on exhaustion; nothing to do.
-        } else {
-          try {
-            await dir.close();
-          } catch {
-            // Already closed — ignore.
-          }
+        try {
+          await dir.close();
+        } catch {
+          // Already closed — ignore.
         }
       }
 

--- a/server/lib/executor.test.ts
+++ b/server/lib/executor.test.ts
@@ -33,7 +33,11 @@ function simulateExec(
   stderr: string,
 ) {
   mockedExec.mockImplementationOnce((_cmd, _opts, callback) => {
-    (callback as Function)(error, stdout, stderr);
+    (callback as (err: Error | null, stdout: string, stderr: string) => void)(
+      error,
+      stdout,
+      stderr,
+    );
     return {} as ReturnType<typeof exec>;
   });
 }

--- a/server/lib/test-utils.ts
+++ b/server/lib/test-utils.ts
@@ -25,11 +25,14 @@ export function extractPlanJson(text: string): string {
  * specified content strings. Useful for identifying specific LLM calls
  * without relying on fragile index positions.
  */
-export function findCallByContent(
-  mockCalls: Array<[any, ...any[]]>,
+export function findCallByContent<
+  T = { messages: Array<{ content: string }> },
+>(
+  mockCalls: ReadonlyArray<readonly unknown[]>,
   contentMatches: string[],
-): any {
-  const match = mockCalls.find(([arg]) => {
+): T {
+  const match = mockCalls.find((call) => {
+    const arg = call[0] as { messages?: Array<{ content?: unknown }> };
     const messages: Array<{ content?: unknown }> = arg?.messages ?? [];
     const text = messages
       .map((m) => (typeof m?.content === "string" ? m.content : ""))
@@ -41,5 +44,5 @@ export function findCallByContent(
       `No mock call found containing all of: ${contentMatches.join(", ")}`,
     );
   }
-  return match[0];
+  return match[0] as T;
 }

--- a/server/tools/coordinate.test.ts
+++ b/server/tools/coordinate.test.ts
@@ -291,7 +291,11 @@ describe("handleCoordinate — integration", () => {
     const b2 = JSON.parse(r2.content[0].text).brief;
 
     // Compare all fields except configSource
-    const strip = (b: Record<string, unknown>) => { const { configSource: _cs, ...rest } = b; return rest; };
+    const strip = (b: Record<string, unknown>) => {
+      const rest = { ...b };
+      delete rest.configSource;
+      return rest;
+    };
     expect(JSON.stringify(strip(b1))).toBe(JSON.stringify(strip(b2)));
   });
 

--- a/server/tools/divergence-cwd.test.ts
+++ b/server/tools/divergence-cwd.test.ts
@@ -52,10 +52,9 @@ vi.mock("../lib/run-context.js", async () => {
     toolName = "forge_evaluate";
 
     constructor() {
-      const self = this;
       this.cost.summarize = () => ({
-        inputTokens: self._inputTokens,
-        outputTokens: self._outputTokens,
+        inputTokens: this._inputTokens,
+        outputTokens: this._outputTokens,
         estimatedCostUsd: 0.001,
         breakdown: [],
         isOAuthAuth: false,
@@ -66,8 +65,15 @@ vi.mock("../lib/run-context.js", async () => {
   return {
     RunContext: MockRunContext,
     trackedCallClaude: vi.fn(
-      async (ctx: any, _stage: string, _role: string, options: any) => {
-        const result = await mockedClaude(options);
+      async (
+        ctx: { _inputTokens?: number; _outputTokens?: number } | null,
+        _stage: string,
+        _role: string,
+        options: unknown,
+      ) => {
+        const result = await mockedClaude(
+          options as Parameters<typeof mockedClaude>[0],
+        );
         if (ctx && result.usage) {
           ctx._inputTokens =
             (ctx._inputTokens ?? 0) + result.usage.inputTokens;

--- a/server/tools/evaluate-critic.test.ts
+++ b/server/tools/evaluate-critic.test.ts
@@ -48,10 +48,9 @@ vi.mock("../lib/run-context.js", async () => {
     toolName = "forge_evaluate";
 
     constructor() {
-      const self = this;
       this.cost.summarize = () => ({
-        inputTokens: self._inputTokens,
-        outputTokens: self._outputTokens,
+        inputTokens: this._inputTokens,
+        outputTokens: this._outputTokens,
         estimatedCostUsd: 0.001,
         breakdown: [],
         isOAuthAuth: false,
@@ -62,8 +61,15 @@ vi.mock("../lib/run-context.js", async () => {
   return {
     RunContext: MockRunContext,
     trackedCallClaude: vi.fn(
-      async (ctx: any, _stage: string, _role: string, options: any) => {
-        const result = await mockedClaude(options);
+      async (
+        ctx: { _inputTokens?: number; _outputTokens?: number } | null,
+        _stage: string,
+        _role: string,
+        options: unknown,
+      ) => {
+        const result = await mockedClaude(
+          options as Parameters<typeof mockedClaude>[0],
+        );
         if (ctx && result.usage) {
           ctx._inputTokens =
             (ctx._inputTokens ?? 0) + result.usage.inputTokens;

--- a/server/tools/evaluate.test.ts
+++ b/server/tools/evaluate.test.ts
@@ -59,10 +59,9 @@ vi.mock("../lib/run-context.js", async () => {
     toolName = "forge_evaluate";
 
     constructor() {
-      const self = this;
       this.cost.summarize = () => ({
-        inputTokens: self._inputTokens,
-        outputTokens: self._outputTokens,
+        inputTokens: this._inputTokens,
+        outputTokens: this._outputTokens,
         estimatedCostUsd: 0.001,
         breakdown: [],
         isOAuthAuth: false,
@@ -73,8 +72,15 @@ vi.mock("../lib/run-context.js", async () => {
   return {
     RunContext: MockRunContext,
     trackedCallClaude: vi.fn(
-      async (ctx: any, _stage: string, _role: string, options: any) => {
-        const result = await mockedClaude(options);
+      async (
+        ctx: { _inputTokens?: number; _outputTokens?: number } | null,
+        _stage: string,
+        _role: string,
+        options: unknown,
+      ) => {
+        const result = await mockedClaude(
+          options as Parameters<typeof mockedClaude>[0],
+        );
         if (ctx && result.usage) {
           ctx._inputTokens =
             (ctx._inputTokens ?? 0) + result.usage.inputTokens;

--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -30,8 +30,8 @@ vi.mock("../lib/run-context.js", async () => {
     _outputTokens = 0;
     cost = {
       summarize: () => ({
-        inputTokens: (this as any)._inputTokens ?? 0,
-        outputTokens: (this as any)._outputTokens ?? 0,
+        inputTokens: this._inputTokens ?? 0,
+        outputTokens: this._outputTokens ?? 0,
         estimatedCostUsd: 0.001,
         breakdown: [],
         isOAuthAuth: false,
@@ -43,11 +43,9 @@ vi.mock("../lib/run-context.js", async () => {
     toolName = "forge_plan";
 
     constructor() {
-      // Bind summarize to the instance
-      const self = this;
       this.cost.summarize = () => ({
-        inputTokens: self._inputTokens,
-        outputTokens: self._outputTokens,
+        inputTokens: this._inputTokens,
+        outputTokens: this._outputTokens,
         estimatedCostUsd: 0.001,
         breakdown: [],
         isOAuthAuth: false,
@@ -57,8 +55,15 @@ vi.mock("../lib/run-context.js", async () => {
 
   return {
     RunContext: MockRunContext,
-    trackedCallClaude: vi.fn(async (ctx: any, _stage: string, _role: string, options: any) => {
-      const result = await mockedClaude(options);
+    trackedCallClaude: vi.fn(async (
+      ctx: { _inputTokens?: number; _outputTokens?: number } | null,
+      _stage: string,
+      _role: string,
+      options: unknown,
+    ) => {
+      const result = await mockedClaude(
+        options as Parameters<typeof mockedClaude>[0],
+      );
       if (ctx && result.usage) {
         ctx._inputTokens = (ctx._inputTokens ?? 0) + result.usage.inputTokens;
         ctx._outputTokens = (ctx._outputTokens ?? 0) + result.usage.outputTokens;
@@ -253,9 +258,12 @@ describe("handlePlan", () => {
         .mockResolvedValueOnce(makeCriticResult());
 
       const result = await handlePlan({ intent: "add feature" });
-      expect((result as any).lintReport).toBeDefined();
-      expect((result as any).lintReport.suspectAcIds).toEqual(["AC-01"]);
-      expect((result as any).lintReport.findings.length).toBeGreaterThan(0);
+      const lintResult = result as {
+        lintReport: { suspectAcIds: string[]; findings: unknown[] };
+      };
+      expect(lintResult.lintReport).toBeDefined();
+      expect(lintResult.lintReport.suspectAcIds).toEqual(["AC-01"]);
+      expect(lintResult.lintReport.findings.length).toBeGreaterThan(0);
       expect(result.content[0].text).toContain("AC-LINT WARNINGS");
     });
   });
@@ -723,7 +731,7 @@ describe("documentTier: master", () => {
 
     expect(result.content[0].text).toContain("Error");
     expect(result.content[0].text).toContain("visionDoc");
-    expect((result as any).isError).toBe(true);
+    expect((result as { isError?: boolean }).isError).toBe(true);
   });
 
   it("runs master critique loop on thorough tier", async () => {
@@ -833,7 +841,7 @@ describe("documentTier: phase", () => {
     });
 
     expect(result.content[0].text).toContain("Error");
-    expect((result as any).isError).toBe(true);
+    expect((result as { isError?: boolean }).isError).toBe(true);
   });
 
   it("includes phase context rules in the planner prompt", async () => {
@@ -946,7 +954,7 @@ describe("documentTier: update", () => {
     });
 
     expect(result.content[0].text).toContain("Error");
-    expect((result as any).isError).toBe(true);
+    expect((result as { isError?: boolean }).isError).toBe(true);
   });
 
   it("defaults to standard tier (1 critique round) for updates", async () => {

--- a/server/tools/three-tier-integration.test.ts
+++ b/server/tools/three-tier-integration.test.ts
@@ -58,10 +58,9 @@ vi.mock("../lib/run-context.js", async () => {
     toolName = "forge_plan";
 
     constructor() {
-      const self = this;
       this.cost.summarize = () => ({
-        inputTokens: self._inputTokens,
-        outputTokens: self._outputTokens,
+        inputTokens: this._inputTokens,
+        outputTokens: this._outputTokens,
         estimatedCostUsd: 0.001,
         breakdown: [],
         isOAuthAuth: false,
@@ -72,8 +71,15 @@ vi.mock("../lib/run-context.js", async () => {
   return {
     RunContext: MockRunContext,
     trackedCallClaude: vi.fn(
-      async (ctx: any, _stage: string, _role: string, options: any) => {
-        const result = await mockedClaude(options);
+      async (
+        ctx: { _inputTokens?: number; _outputTokens?: number } | null,
+        _stage: string,
+        _role: string,
+        options: unknown,
+      ) => {
+        const result = await mockedClaude(
+          options as Parameters<typeof mockedClaude>[0],
+        );
         if (ctx && result.usage) {
           ctx._inputTokens =
             (ctx._inputTokens ?? 0) + result.usage.inputTokens;
@@ -246,7 +252,7 @@ describe("three-tier integration: PRD → master → phase → coherence", () =>
     });
 
     // Verify master plan was produced
-    expect((masterResult as any).isError).toBeUndefined();
+    expect((masterResult as { isError?: boolean }).isError).toBeUndefined();
     expect(masterResult.content[0].text).toContain("MASTER PLAN");
     expect(masterResult.content[0].text).toContain('"schemaVersion": "1.0.0"');
 
@@ -269,7 +275,7 @@ describe("three-tier integration: PRD → master → phase → coherence", () =>
     });
 
     // Verify phase plan was produced
-    expect((phaseResult as any).isError).toBeUndefined();
+    expect((phaseResult as { isError?: boolean }).isError).toBeUndefined();
     expect(phaseResult.content[0].text).toContain("PHASE PLAN (PH-01)");
     expect(phaseResult.content[0].text).toContain('"schemaVersion": "3.0.0"');
 
@@ -293,7 +299,7 @@ describe("three-tier integration: PRD → master → phase → coherence", () =>
     });
 
     // Verify coherence eval succeeded with no gaps
-    expect((evalResult as any).isError).toBeUndefined();
+    expect((evalResult as { isError?: boolean }).isError).toBeUndefined();
     const evalReport = JSON.parse(evalResult.content[0].text);
     expect(evalReport.evaluationMode).toBe("coherence");
     expect(evalReport.status).toBe("complete");
@@ -425,7 +431,7 @@ describe("three-tier integration: PRD → master → phase → coherence", () =>
     });
 
     // Should degrade gracefully, not crash
-    expect((evalResult as any).isError).toBeUndefined();
+    expect((evalResult as { isError?: boolean }).isError).toBeUndefined();
     const evalReport = JSON.parse(evalResult.content[0].text);
     expect(evalReport.evaluationMode).toBe("coherence");
     expect(evalReport.status).toBe("eval-failed");
@@ -553,7 +559,7 @@ describe("three-tier integration: PRD → master → phase → coherence", () =>
     }
 
     // Verify dependency references are valid
-    const phaseIds = new Set(parsed.phases.map((p: any) => p.id));
+    const phaseIds = new Set(parsed.phases.map((p: { id: string }) => p.id));
     for (const phase of parsed.phases) {
       for (const dep of phase.dependencies) {
         expect(phaseIds.has(dep)).toBe(true);

--- a/server/validation/ac-lint.test.ts
+++ b/server/validation/ac-lint.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { lintAcCommand, lintPlan, type LintExemptPlan } from "./ac-lint.js";
+import {
+  lintAcCommand,
+  lintPlan,
+  type LintExemptPlan,
+  type LintablePlan,
+  type LintExempt,
+} from "./ac-lint.js";
 import type { LintExemptPlan as LintExemptPlanMirror } from "../types/execution-plan.js";
 import { AC_LINT_RULES } from "../lib/prompts/shared/ac-subprocess-rules.js";
 
@@ -249,7 +255,13 @@ describe("lintAcCommand — lintExempt precedence", () => {
 });
 
 describe("lintPlan — governance cap and plan-level aggregation", () => {
-  function mkPlan(acs: Array<{ id: string; command: string; lintExempt?: any }>) {
+  function mkPlan(
+    acs: Array<{
+      id: string;
+      command: string;
+      lintExempt?: LintExempt | LintExempt[];
+    }>,
+  ): LintablePlan {
     return {
       stories: [
         {
@@ -326,11 +338,11 @@ describe("lintPlan — governance cap and plan-level aggregation", () => {
 describe("lintPlan — Q0.5/C1-bis plan-level lintExempt", () => {
   // Shape that matches LintablePlan (stories + optional plan-level lintExempt).
   function mkPlanWithExempt(
-    planLevel: any,
+    planLevel: unknown,
     acs: Array<{ id: string; command: string }>,
-  ): any {
+  ): LintablePlan {
     return {
-      lintExempt: planLevel,
+      lintExempt: planLevel as LintExemptPlan[] | undefined,
       stories: [
         {
           id: "US-01",
@@ -378,7 +390,7 @@ describe("lintPlan — Q0.5/C1-bis plan-level lintExempt", () => {
 
   it("plan-level AND per-AC: per-AC 3-cap still applies; plan-level does not contribute to cap", () => {
     // 3 per-AC exempts (at cap) + 1 plan-level entry (no cap contribution)
-    const plan: any = {
+    const plan = {
       lintExempt: [
         {
           scope: "plan",
@@ -412,7 +424,7 @@ describe("lintPlan — Q0.5/C1-bis plan-level lintExempt", () => {
           ],
         },
       ],
-    };
+    } as unknown as LintablePlan;
     const report = lintPlan(plan);
     expect(report.lintExemptCount).toBe(3);
     expect(report.governanceViolation).toBe(false);
@@ -517,7 +529,7 @@ describe("lintPlan — Q0.5/C1-bis plan-level lintExempt", () => {
   // empty-string rationale distinct from missing, array-of-non-object entries.
   it("plan-level entry with non-string rule element → throws", () => {
     const plan = mkPlanWithExempt(
-      [{ scope: "plan", rules: [123 as any], batch: "b", rationale: "r" }],
+      [{ scope: "plan", rules: [123 as unknown as string], batch: "b", rationale: "r" }],
       [{ id: "AC-01", command: "echo PASS" }],
     );
     expect(() => lintPlan(plan)).toThrow(/not in AC_LINT_RULES/);
@@ -532,7 +544,7 @@ describe("lintPlan — Q0.5/C1-bis plan-level lintExempt", () => {
   });
 
   it("plan-level entry array element is null → throws", () => {
-    const plan: any = {
+    const plan = {
       lintExempt: [null],
       stories: [
         {
@@ -540,7 +552,7 @@ describe("lintPlan — Q0.5/C1-bis plan-level lintExempt", () => {
           acceptanceCriteria: [{ id: "AC-01", description: "a", command: "echo PASS" }],
         },
       ],
-    };
+    } as unknown as LintablePlan;
     expect(() => lintPlan(plan)).toThrow(/must be an object/);
   });
 


### PR DESCRIPTION
## Summary

Clears the 40 pre-existing `server/**` lint errors surfaced during PR #207 (task #33) and wires `npm run lint` into `.github/workflows/ci.yml` so the debt cannot regrow. Both halves land together per the plan's ordering constraint.

## Context

PR #207 had to weaken its AC-11 mid-flight from `npm run lint exits 0` to `no NEW errors vs master` because the 40 pre-existing errors were out of scope for the gitignore redesign, and CI had never run `npm run lint` (only build + drift-guard + tests + commit-msg validator). This PR closes both halves of the debt.

After merge, future PRs can hold the stronger `npm run lint exits 0` contract instead of the delta-based wording.

## Plan

`.ai-workspace/plans/2026-04-14-q05-task34-lint-debt-ci-wiring.md` (promoted to master in commit 1 of this PR, amended mid-PR per thread `q05-task34-lint-debt`).

## Mid-flight amendment (read this FIRST, reviewer)

On first pass I re-ran `npm run lint` against master and found **10 distinct files, not 9** — `server/lib/audit.ts:74` has a `no-unused-vars` error on a `_entry` iteration counter. The plan's rule-breakdown counts (32+5+2+1=40) were right; the file enumeration was short by one.

This hit a stop-on-contradiction: AC-1 requires 0 errors, Out-of-scope forbade touching production source outside the baseline list. I stopped, sent a `priority: blocker` mail on the thread, and got an Option A unblock (add `audit.ts` to the baseline). The amendment patch is committed as `6c95455` on this branch per plan rule 9 (amendments ride the executor's PR branch, never a parallel planner commit on master).

**Reviewer: do not blindly re-run `npm run lint` and fail on the pre-existing 40-error baseline** — that was the v0.30.3 state. This PR fixes all 40.

## AC status (10 binary AC, all PASS locally)

| AC | Check | Result |
|----|-------|--------|
| AC-1 | `npm run lint` exits 0 | **PASS** |
| AC-2 | No new `eslint-disable` in diff | **PASS** (`grep -c` = 0) |
| AC-3 | `eslint.config.js` unchanged | **PASS** (diff = 0 lines) |
| AC-4 | `ci.yml` invokes `npm run lint` | **PASS** (`grep -c` = 1) |
| AC-5 | Lint step not `continue-on-error` | **PASS** (`grep -c` = 0) |
| AC-6 | `npm test` exits 0 | **PASS** (719 pass, 4 skipped) |
| AC-7 | `npm run build` exits 0 | **PASS** |
| AC-8 | Test-file diff is type-level only | **PASS** (9 files changed, 111 insertions, 56 deletions — reviewer spot-check welcome) |
| AC-9 | CI green on PR | **pending** (this PR) |
| AC-10 | Zero error-count lines in lint output | **PASS** (`grep -c` = 0) |

## Fixes by rule

- **`no-explicit-any` (32)** — replaced with real types from production imports (`LintExempt`, `LintExemptPlan`, `LintablePlan` in ac-lint.test.ts; `CallClaudeOptions` via `Parameters<typeof mockedClaude>[0]` in the 5 mock files) or `unknown` + narrowing.
- **`no-this-alias` (5)** — deleted redundant `const self = this` in 5 `MockRunContext` constructors. Arrow functions preserve `this`, so the alias was dead code; inlined `this._inputTokens` / `this._outputTokens` directly.
- **`no-unused-vars` (2)** —
  - `server/lib/audit.ts:74` — rewrote `for await (const _entry of dir)` as `while ((await dir.read()) !== null)` to avoid the iteration-variable binding entirely. Preserved behavior: still counts up to `FILE_COUNT_WARNING_THRESHOLD`, still closes handle in `finally`. `audit.test.ts` all 6 tests pass. (The `_`-prefix rename was rejected because the ESLint config only exempts underscore-prefixed *arguments*, not declarations — AC-3 blocks rule-config changes.)
  - `server/tools/coordinate.test.ts:294` — replaced `const { configSource: _cs, ...rest } = b` with `const rest = { ...b }; delete rest.configSource;` — same behavior, no unused binding.
- **`no-unsafe-function-type` (1)** — `server/lib/executor.test.ts:36` — typed the exec callback as `(err: Error \| null, stdout: string, stderr: string) => void`.

## CI wiring

Added a `Lint` step after `Build` in `.github/workflows/ci.yml`:

```yaml
- name: Lint (eslint server/ — must exit 0)
  run: npm run lint
```

No `continue-on-error`. Fail-fast ordering: lint runs before tests so future CI red shows up on the cheap check first.

## Commits

1. `6c95455` — `docs(plan)`: promote plan file + apply amendment patches 1–5 (9→10 file list, audit.ts hint, checkpoint update)
2. `5d5bb87` — `fix(q05-task34)`: 40 error fixes + CI wiring

Commit shape chosen per plan's "executor picks commit shape" freedom.

## Out of scope (not touched)

- `eslint.config.js` unchanged (AC-3)
- No new test cases or assertion changes (AC-8)
- No drive-by fixes in production source beyond `server/lib/audit.ts` (the amended baseline)
- Q3 rename, `/delegate` skill build, CLAUDE.md consolidation — all separate tasks

## Test plan

- [x] `npm run lint` exits 0 locally
- [x] `npm run build` exits 0 locally
- [x] `npm test` — 719 passed, 4 skipped, 0 failed
- [x] `git diff origin/master...HEAD -- 'server/**/*.ts' | grep -cE '^\+.*eslint-disable'` → 0
- [x] `git diff origin/master...HEAD -- eslint.config.js | wc -l` → 0
- [ ] CI green (this PR, AC-9)
- [ ] Stateless review by forge-plan

## Closes / unblocks

- Closes the CI gap from PR #207 (task #33 → task #34 followup)
- Unblocks future PRs to use the stronger `npm run lint exits 0` AC contract
- Thread: `q05-task34-lint-debt` (mailbox)

---
plan-refresh: no-op