### PR TITLE
fix(q1/task-21): rewrite 5 hazardous PH01-US-06 ACs to F-rule-safe patterns

### DIFF
--- a/.ai-workspace/audits/2026-04-15-task21-baseline.md
+++ b/.ai-workspace/audits/2026-04-15-task21-baseline.md
@@ -1,0 +1,22 @@
+# Task #21 — PH01-US-06 pre-rewrite baseline
+
+Captured on master `@ 919e0a7` before any rewrite. Each line records the exit
+code of the ORIGINAL (pre-rewrite) `command` field for the 5 hazardous ACs
+under `stories[id=PH01-US-06].acceptanceCriteria` in
+`.ai-workspace/plans/forge-coordinate-phase-PH-01.json`.
+
+The rewrite is semantics-preserving (AC-4 contract): each rewritten command
+must match the exit code recorded here, or be flagged `latent-prior-failure`
+(none were).
+
+Measurement procedure: each original command was executed verbatim in the
+project root via MSYS bash; `$?` was captured immediately after.
+
+PH01-US-06-AC01b: 0
+PH01-US-06-AC02b: 0
+PH01-US-06-AC03b: 0
+PH01-US-06-AC04: 0
+PH01-US-06-AC05: 0
+
+All five originals pass on master. The rewrite must therefore produce
+exit-0 for all five rewritten commands on this PR branch.

--- a/.ai-workspace/plans/2026-04-15-q1-ph01-us-06-ac-rewrite.md
+++ b/.ai-workspace/plans/2026-04-15-q1-ph01-us-06-ac-rewrite.md
@@ -33,20 +33,20 @@ When this plan is done, **all 5 hazardous ACs in PH01-US-06 use F-rule-safe patt
   ```bash
   export MSYS_NO_PATHCONV=1
   for id in PH01-US-06-AC01b PH01-US-06-AC02b PH01-US-06-AC03b PH01-US-06-AC04 PH01-US-06-AC05; do
-    diff <(git show origin/master:.ai-workspace/plans/forge-coordinate-phase-PH-01.json | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{const j=JSON.parse(d);const s=j.userStories.find(u=>u.id==="PH01-US-06");const a=s.acceptanceCriteria.find(x=>x.id===process.argv[1]);console.log(a.command)})' "$id") \
-         <(node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{const j=JSON.parse(d);const s=j.userStories.find(u=>u.id==="PH01-US-06");const a=s.acceptanceCriteria.find(x=>x.id===process.argv[1]);console.log(a.command)})' "$id" < .ai-workspace/plans/forge-coordinate-phase-PH-01.json) \
+    diff <(git show origin/master:.ai-workspace/plans/forge-coordinate-phase-PH-01.json | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{const j=JSON.parse(d);const s=j.stories.find(u=>u.id==="PH01-US-06");const a=s.acceptanceCriteria.find(x=>x.id===process.argv[1]);console.log(a.command)})' "$id") \
+         <(node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{const j=JSON.parse(d);const s=j.stories.find(u=>u.id==="PH01-US-06");const a=s.acceptanceCriteria.find(x=>x.id===process.argv[1]);console.log(a.command)})' "$id" < .ai-workspace/plans/forge-coordinate-phase-PH-01.json) \
          > /dev/null && echo "UNCHANGED $id"
   done
   ```
   Prints zero `UNCHANGED` lines.
 - [ ] **AC-2 — Zero F-55 hazards remain in the 5 rewritten commands.** None of the 5 rewritten commands contains the literal substrings `2>/dev/null |`, `2>&1 | grep`, or `| grep -q 'passed'`. Reviewer command:
   ```bash
-  node -e 'const j=require("./.ai-workspace/plans/forge-coordinate-phase-PH-01.json");const s=j.userStories.find(u=>u.id==="PH01-US-06");const ids=["PH01-US-06-AC01b","PH01-US-06-AC02b","PH01-US-06-AC03b","PH01-US-06-AC04","PH01-US-06-AC05"];let bad=0;for(const id of ids){const c=s.acceptanceCriteria.find(x=>x.id===id).command;if(c.includes("2>/dev/null |")||c.includes("2>&1 | grep")||c.includes("| grep -q '\''passed'\''")){console.log("HAZARD",id,c);bad++}}process.exit(bad===0?0:1)'
+  node -e 'const j=require("./.ai-workspace/plans/forge-coordinate-phase-PH-01.json");const s=j.stories.find(u=>u.id==="PH01-US-06");const ids=["PH01-US-06-AC01b","PH01-US-06-AC02b","PH01-US-06-AC03b","PH01-US-06-AC04","PH01-US-06-AC05"];let bad=0;for(const id of ids){const c=s.acceptanceCriteria.find(x=>x.id===id).command;if(c.includes("2>/dev/null |")||c.includes("2>&1 | grep")||c.includes("| grep -q '\''passed'\''")){console.log("HAZARD",id,c);bad++}}process.exit(bad===0?0:1)'
   ```
   Exits 0.
 - [ ] **AC-3 — Zero F-36 source-tree-grep hazards remain in AC04.** `PH01-US-06-AC04`'s rewritten command does not contain `grep -n 'callClaude` or `grep -rn callClaude` against `server/**` paths, AND does not contain the `echo EMPTY-OK | grep -q EMPTY-OK` verification-theatre tail. Reviewer command:
   ```bash
-  node -e 'const j=require("./.ai-workspace/plans/forge-coordinate-phase-PH-01.json");const s=j.userStories.find(u=>u.id==="PH01-US-06");const c=s.acceptanceCriteria.find(x=>x.id==="PH01-US-06-AC04").command;if(c.includes("grep -n \x27callClaude")||c.includes("grep -rn callClaude")||c.includes("echo EMPTY-OK | grep -q EMPTY-OK")){console.log("HAZARD",c);process.exit(1)}'
+  node -e 'const j=require("./.ai-workspace/plans/forge-coordinate-phase-PH-01.json");const s=j.stories.find(u=>u.id==="PH01-US-06");const c=s.acceptanceCriteria.find(x=>x.id==="PH01-US-06-AC04").command;if(c.includes("grep -n \x27callClaude")||c.includes("grep -rn callClaude")||c.includes("echo EMPTY-OK | grep -q EMPTY-OK")){console.log("HAZARD",c);process.exit(1)}'
   ```
   Exits 0.
 - [ ] **AC-4 — Rewrite is semantics-preserving against the PR branch, with a documented baseline.** The executor must:
@@ -84,7 +84,7 @@ AC-1 and AC-4 must hold **simultaneously on the same commit** — a rewrite that
 
 ## Critical files
 
-- `.ai-workspace/plans/forge-coordinate-phase-PH-01.json` — the only JSON file that changes. 5 AC `command` fields under `userStories[id=PH01-US-06].acceptanceCriteria`.
+- `.ai-workspace/plans/forge-coordinate-phase-PH-01.json` — the only JSON file that changes. 5 AC `command` fields under `stories[id=PH01-US-06].acceptanceCriteria` (JSON schema uses `stories`, not `userStories` — planner's original draft had this wrong; fixed via amendment commit on the executor's branch, 2026-04-15).
 - `server/validation/ac-lint.test.ts` — **read-only**. The executor's AC-5 check runs it; do not edit.
 - `server/lib/coordinator.ts`, `server/lib/topo-sort.ts`, `server/lib/run-reader.ts` — **read-only**. AC04's rewrite still needs to verify *something* about these files; whatever check the executor picks must run against the file tree without grepping inside source lines in the F-36 hazard way. One safe option: use `node -e` with `fs.readFileSync().includes("callClaude")` against an explicit file list.
 - `scripts/q1-task21-acceptance.sh` — new file, wraps AC-1..AC-9 in a single executable script per hard-rule 8 (task #34 + task #22 precedent).

--- a/.ai-workspace/plans/2026-04-15-q1-ph01-us-06-ac-rewrite.md
+++ b/.ai-workspace/plans/2026-04-15-q1-ph01-us-06-ac-rewrite.md
@@ -1,0 +1,131 @@
+# Q1 / Task #21 — PH01-US-06 AC rewrite (6 ACs: 5 subprocess-safety + 1 source-tree-grep)
+
+## Context
+
+Task #22 shipped (v0.30.5) a rationale-refresh AFFIRM for the C1-bootstrap lintExempt blocks across 9 phase JSONs. Under AFFIRM those blocks still exempt PH-01 phase JSONs from F-36/F-55/F-56, so the hazardous ACs continue to live in the file — but the post-audit line was clear: *new* drift must use F-rule-safe patterns, and the 65 PH-01 ACs are now tracked as two follow-ups:
+
+- **Task #21 (this plan)** — the 6 ACs that live under `PH01-US-06` (unit-test scaffold consolidation) are the smallest, most-referenced story in PH-01 and the natural *template* batch. Rewriting them first establishes the exact safe-pattern vocabulary that task #40 will then apply to the remaining ~59 orphaned ACs across US-01..US-05.
+- **Task #40** — the ~59 orphan rewrite, blocked on this plan landing first.
+
+The 6 hazardous ACs, read out of `forge-coordinate-phase-PH-01.json` on master `@ 05ea273`:
+
+| AC id | Hazard class | Current command (abridged) |
+|---|---|---|
+| `PH01-US-06-AC01b` | F-55 captured-output (vitest json pipe + `2>/dev/null`) | `npx vitest run …topo-sort.test.ts --reporter=json 2>/dev/null \| node -e '…numTotalTests>=5…'` |
+| `PH01-US-06-AC02b` | F-55 captured-output | same shape, `run-reader.test.ts`, `>=5` |
+| `PH01-US-06-AC03b` | F-55 captured-output | same shape, `coordinator.test.ts`, `>=8` |
+| `PH01-US-06-AC04`  | F-36 source-tree-grep + verification-theatre `echo EMPTY-OK \| grep -q EMPTY-OK` | `test -z "$(grep -n 'callClaude…' server/lib/…)" && echo EMPTY-OK \| grep -q EMPTY-OK` |
+| `PH01-US-06-AC05`  | F-55 pipe-to-grep false-green | `npx vitest run …coordinator.test.ts -t 'NFR-C02…' 2>&1 \| grep -q 'passed'` |
+
+That's **4 F-55 + 1 F-36 = 5 hazards in 5 ACs**. Task #21's nominal "6 ACs: 5 subprocess-safety + 1 source-tree-grep" count includes **AC04 as BOTH subprocess-safety (command-substitution `$()` swallowing grep's exit) AND source-tree-grep**, counted twice. The rewrite must address all 5 ACs listed above; the "6" is the count of distinct hazards, not distinct ACs.
+
+PH01-US-06 also contains `AC01`, `AC02`, `AC03`, `AC06`, `AC07` which are plain `npx vitest run <file>` / `npx tsc --noEmit` — **no F-55/F-36 hazard, no rewrite needed**, confirmed by re-reading lines 437-486 of the phase JSON.
+
+**Why now.** Task #22 proved the PH-01 phase JSONs are read-only at runtime (critic-mode loader passes them as opaque LLM context, never execs AC commands). That means the rewrite has zero blast radius on forge-coordinate runtime — the only thing that could break is ac-lint, which the rewrite is explicitly designed to satisfy.
+
+## Goal
+
+When this plan is done, **all 5 hazardous ACs in PH01-US-06 use F-rule-safe patterns**, `ac-lint` reports zero violations against the rewritten ACs, and the rewritten AC commands still produce the same pass/fail answer as the originals when run against the PH-01 code (i.e. the rewrite is **semantics-preserving** — no AC becomes stricter or looser).
+
+## Binary AC
+
+- [ ] **AC-1 — All 5 hazardous ACs rewritten to F-rule-safe patterns.** For the 5 AC ids listed in Context (`PH01-US-06-AC01b`, `AC02b`, `AC03b`, `AC04`, `AC05`), the `command` field on the PR branch differs from `origin/master`. Reviewer command (MUST be run with `MSYS_NO_PATHCONV=1` exported for the whole wrapper on Windows MSYS bash — `git show <rev>:<path>` silently path-mangles otherwise; task #22 learning #2):
+  ```bash
+  export MSYS_NO_PATHCONV=1
+  for id in PH01-US-06-AC01b PH01-US-06-AC02b PH01-US-06-AC03b PH01-US-06-AC04 PH01-US-06-AC05; do
+    diff <(git show origin/master:.ai-workspace/plans/forge-coordinate-phase-PH-01.json | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{const j=JSON.parse(d);const s=j.userStories.find(u=>u.id==="PH01-US-06");const a=s.acceptanceCriteria.find(x=>x.id===process.argv[1]);console.log(a.command)})' "$id") \
+         <(node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{const j=JSON.parse(d);const s=j.userStories.find(u=>u.id==="PH01-US-06");const a=s.acceptanceCriteria.find(x=>x.id===process.argv[1]);console.log(a.command)})' "$id" < .ai-workspace/plans/forge-coordinate-phase-PH-01.json) \
+         > /dev/null && echo "UNCHANGED $id"
+  done
+  ```
+  Prints zero `UNCHANGED` lines.
+- [ ] **AC-2 — Zero F-55 hazards remain in the 5 rewritten commands.** None of the 5 rewritten commands contains the literal substrings `2>/dev/null |`, `2>&1 | grep`, or `| grep -q 'passed'`. Reviewer command:
+  ```bash
+  node -e 'const j=require("./.ai-workspace/plans/forge-coordinate-phase-PH-01.json");const s=j.userStories.find(u=>u.id==="PH01-US-06");const ids=["PH01-US-06-AC01b","PH01-US-06-AC02b","PH01-US-06-AC03b","PH01-US-06-AC04","PH01-US-06-AC05"];let bad=0;for(const id of ids){const c=s.acceptanceCriteria.find(x=>x.id===id).command;if(c.includes("2>/dev/null |")||c.includes("2>&1 | grep")||c.includes("| grep -q '\''passed'\''")){console.log("HAZARD",id,c);bad++}}process.exit(bad===0?0:1)'
+  ```
+  Exits 0.
+- [ ] **AC-3 — Zero F-36 source-tree-grep hazards remain in AC04.** `PH01-US-06-AC04`'s rewritten command does not contain `grep -n 'callClaude` or `grep -rn callClaude` against `server/**` paths, AND does not contain the `echo EMPTY-OK | grep -q EMPTY-OK` verification-theatre tail. Reviewer command:
+  ```bash
+  node -e 'const j=require("./.ai-workspace/plans/forge-coordinate-phase-PH-01.json");const s=j.userStories.find(u=>u.id==="PH01-US-06");const c=s.acceptanceCriteria.find(x=>x.id==="PH01-US-06-AC04").command;if(c.includes("grep -n \x27callClaude")||c.includes("grep -rn callClaude")||c.includes("echo EMPTY-OK | grep -q EMPTY-OK")){console.log("HAZARD",c);process.exit(1)}'
+  ```
+  Exits 0.
+- [ ] **AC-4 — Rewrite is semantics-preserving against the PR branch, with a documented baseline.** The executor must:
+  a. Before any rewrite, record each ORIGINAL command's exit code against `origin/master` in a new file `.ai-workspace/audits/2026-04-15-task21-baseline.md`. Format: five lines of the form `PH01-US-06-AC0Xy: <exit-code>` (plus a short prose note if the command was unrunnable, e.g. shell syntax error). This captures the pre-rewrite ground truth.
+  b. After rewrite, the rewritten command for each of the 5 AC ids must run to completion on the PR branch WITHOUT a shell-syntax error AND produce an exit code that matches the baseline from (a) — i.e. if the original exited 0 on master, the rewrite exits 0 on the PR branch; if the original exited non-zero on master (pre-existing latent failure), the rewrite is allowed to exit non-zero **iff** the executor records `latent-prior-failure` next to that AC in the baseline file AND flags it to the planner as an amendment request. The rewrite must NEVER turn a passing original into a failing rewrite.
+  Reviewer command:
+  ```bash
+  test -f .ai-workspace/audits/2026-04-15-task21-baseline.md && \
+  for id in PH01-US-06-AC01b PH01-US-06-AC02b PH01-US-06-AC03b PH01-US-06-AC04 PH01-US-06-AC05; do
+    grep -q "^${id}: " .ai-workspace/audits/2026-04-15-task21-baseline.md && echo "BASELINED $id" || echo "MISSING $id"
+  done
+  ```
+  Prints 5 `BASELINED` lines and zero `MISSING` lines. Reviewer ALSO reads the baseline file and independently re-runs the acceptance wrapper to confirm rewritten-command exit codes match the recorded baseline (or are flagged `latent-prior-failure`).
+- [ ] **AC-5 — ac-lint clean against the rewritten file.** `npx vitest run server/validation/ac-lint.test.ts` exits 0 with zero failures (absolute — ac-lint is clean on master @ 05ea273 per task #22 baseline 52/52; this is the one tool-output AC that is safe as absolute).
+- [ ] **AC-6 — Build is delta-clean vs master.** `npm run build` exits 0 AND produces no new errors that are not present on `origin/master`. If master's build exits 0 at delegate-gate time (expected per task #22 baseline), this collapses to "exits 0". Delegate gate confirms baseline.
+- [ ] **AC-7 — Lint is delta-clean vs master.** `npm run lint` produces no new errors vs `origin/master`. Framed delta-based per CLAUDE.md "What didn't work" rule on absolute tool-output ACs with latent debt; task #34 wired lint into CI at zero errors, so in practice this collapses to "exits 0" — but the delta framing protects the executor if any transient lint debt has been introduced since v0.30.5.
+- [ ] **AC-8 — Tests are delta-clean vs master.** `npm test` produces no new failures vs `origin/master`. Same delta framing as AC-7. Task #22 baseline was 719 passed / 4 skipped / 0 failed; rewrite is expected to preserve that.
+- [ ] **AC-9 — No drive-by edits.** `git diff origin/master...HEAD --stat` shows changes confined to `.ai-workspace/plans/forge-coordinate-phase-PH-01.json`, `.ai-workspace/plans/2026-04-15-q1-ph01-us-06-ac-rewrite.md` (this plan file), `.ai-workspace/audits/2026-04-15-task21-baseline.md` (AC-4 baseline record), `scripts/q1-task21-acceptance.sh` (hard-rule-8 acceptance wrapper per task #34 + task #22 precedent), and the PR's own dotfiles. No `server/**` source changes. No other `.ai-workspace/plans/*.json` edits. No `forge-generate-phase-PH-01.json` edits (task #40's turf).
+- [ ] **AC-10 — CI green on the PR**, including lint and smoke-gate.
+
+## Out of scope
+
+- **Do not touch any AC in `PH01-US-06` that is NOT one of the 5 listed.** `PH01-US-06-AC01`, `AC02`, `AC03`, `AC06`, `AC07` are already F-rule-safe. Editing them is an AC-9 violation.
+- **Do not touch any other user story in `forge-coordinate-phase-PH-01.json`.** US-01 through US-05 are task #40's scope. Task #21 is a **template run** — US-06 only.
+- **Do not touch `forge-generate-phase-PH-01.json`.** Task #40 covers PH-01 across both coordinate + generate phase files.
+- **Do not edit `server/**`.** The rewrite is pure JSON content editing.
+- **Do not edit the `lintExempt` block.** Task #22 just refreshed it on AFFIRM. Keep the exemption in place — that's what lets this PR land without ac-lint redding first. The rewrite's purpose is *new-drift hygiene*, not *bootstrap cleanup*.
+- **Do not rewrite `PH01-US-06-AC04` as two separate ACs.** Keep it as a single AC id with a single `command` field. If the single-command rewrite feels hacky, use a `bash -c` one-liner — the storage model is "one AC = one command string."
+- **Do not modify `eslint.config.js`, `.github/workflows/*.yml`, or `tsconfig.json`.**
+- **Do not force-push or rewrite history.**
+
+## Ordering constraints
+
+AC-1 and AC-4 must hold **simultaneously on the same commit** — a rewrite that satisfies AC-1 but fails AC-4 is a regression (semantics changed). The executor's acceptance wrapper must run AC-4 before claiming done.
+
+## Critical files
+
+- `.ai-workspace/plans/forge-coordinate-phase-PH-01.json` — the only JSON file that changes. 5 AC `command` fields under `userStories[id=PH01-US-06].acceptanceCriteria`.
+- `server/validation/ac-lint.test.ts` — **read-only**. The executor's AC-5 check runs it; do not edit.
+- `server/lib/coordinator.ts`, `server/lib/topo-sort.ts`, `server/lib/run-reader.ts` — **read-only**. AC04's rewrite still needs to verify *something* about these files; whatever check the executor picks must run against the file tree without grepping inside source lines in the F-36 hazard way. One safe option: use `node -e` with `fs.readFileSync().includes("callClaude")` against an explicit file list.
+- `scripts/q1-task21-acceptance.sh` — new file, wraps AC-1..AC-9 in a single executable script per hard-rule 8 (task #34 + task #22 precedent).
+
+## Verification procedure
+
+Reviewer runs (on PR branch, fresh checkout):
+
+```bash
+git fetch origin && git checkout <pr-branch>
+git diff origin/master...HEAD --stat                                 # AC-9
+npm ci && npm run build && npm test && npm run lint                  # AC-6..AC-8
+npx vitest run server/validation/ac-lint.test.ts                     # AC-5
+bash scripts/q1-task21-acceptance.sh                                 # wraps AC-1..AC-4
+```
+
+Then reviewer independently runs the AC-1, AC-2, AC-3, AC-4 reviewer commands verbatim from the Binary AC section (not via the wrapper — independent verification).
+
+## Safe-pattern reference (non-prescriptive)
+
+The executor picks exact bash, but here are the known-safe patterns from F-55/F-36 rule docs — these are **suggestions, not mandates**:
+
+- **Vitest test-count regression guard (replaces F-55 pipe-to-node):** capture exit code first, then parse JSON from a temp file. Example shape — `npx vitest run <file> --reporter=json --outputFile=<tmp> && node -e 'const r=require("<tmp>");process.exit((r.numTotalTests||0)>=<N>?0:1)'`. Key property: vitest's exit code is respected; parse only runs on success.
+- **Vitest single-test name check (replaces F-55 `2>&1 | grep -q 'passed'`):** vitest's `-t '<pattern>'` already exits 0 iff the matching tests pass. Just `npx vitest run <file> -t '<pattern>'` — drop the pipe entirely.
+- **Source-file content check without source-tree grep (replaces F-36):** `node -e 'const fs=require("fs");const files=[…];for(const f of files){if(fs.readFileSync(f,"utf8").includes("callClaude")){console.error("found in",f);process.exit(1)}}'`. Key property: checks the same files the original grep checked, but via explicit `readFileSync` — no subshell, no `$()` output swallowing, and the failure message names the file.
+
+If the executor finds a better pattern, use it — AC-2/AC-3/AC-4 are the contract, not these snippets.
+
+## Checkpoint
+
+- [x] Context measured (planner): 5 hazardous ACs identified in lines 437-486 of `forge-coordinate-phase-PH-01.json`, non-hazardous ACs confirmed as AC01/AC02/AC03/AC06/AC07
+- [x] Plan drafted (planner)
+- [x] Plan run through `/coherent-plan` (3 MAJOR findings, all fixed: MSYS_NO_PATHCONV on AC-1, AC-4 baseline framing, AC-7/AC-8 delta framing)
+- [ ] Baselines measured: AC-5 / AC-6 / AC-7 / AC-8 against master via `/delegate gate`
+- [ ] Brief delivered via `/delegate` to executor
+- [ ] Executor ack received with pre-flight clean
+- [ ] Executor ships PR, acceptance wrapper green locally
+- [ ] CI green (AC-10)
+- [ ] Stateless review PASS
+- [ ] Merged + released
+- [ ] Plan updated to shipped reality
+- [ ] Unblock task #40 — this run's rewrite patterns are the template
+
+Last updated: 2026-04-15 (planner draft, pre-critique)

--- a/.ai-workspace/plans/forge-coordinate-phase-PH-01.json
+++ b/.ai-workspace/plans/forge-coordinate-phase-PH-01.json
@@ -443,7 +443,7 @@
         {
           "id": "PH01-US-06-AC01b",
           "description": "topo-sort.test.ts has at least 5 tests (regression guard)",
-          "command": "npx vitest run server/lib/topo-sort.test.ts --reporter=json 2>/dev/null | node -e 'let d=\"\";process.stdin.on(\"data\",c=>d+=c);process.stdin.on(\"end\",()=>{try{const r=JSON.parse(d);const n=r.numTotalTests||0;process.exit(n>=5?0:1)}catch(e){process.exit(1)}});'"
+          "command": "rm -f .vitest-topo.json && npx vitest run server/lib/topo-sort.test.ts --reporter=json --outputFile=.vitest-topo.json && node -e 'const fs=require(\"fs\");const r=JSON.parse(fs.readFileSync(\".vitest-topo.json\",\"utf8\"));process.exit((r.numTotalTests||0)>=5?0:1)' && rm -f .vitest-topo.json"
         },
         {
           "id": "PH01-US-06-AC02",
@@ -453,7 +453,7 @@
         {
           "id": "PH01-US-06-AC02b",
           "description": "run-reader.test.ts has at least 5 tests (regression guard)",
-          "command": "npx vitest run server/lib/run-reader.test.ts --reporter=json 2>/dev/null | node -e 'let d=\"\";process.stdin.on(\"data\",c=>d+=c);process.stdin.on(\"end\",()=>{try{const r=JSON.parse(d);const n=r.numTotalTests||0;process.exit(n>=5?0:1)}catch(e){process.exit(1)}});'"
+          "command": "rm -f .vitest-runreader.json && npx vitest run server/lib/run-reader.test.ts --reporter=json --outputFile=.vitest-runreader.json && node -e 'const fs=require(\"fs\");const r=JSON.parse(fs.readFileSync(\".vitest-runreader.json\",\"utf8\"));process.exit((r.numTotalTests||0)>=5?0:1)' && rm -f .vitest-runreader.json"
         },
         {
           "id": "PH01-US-06-AC03",
@@ -463,17 +463,17 @@
         {
           "id": "PH01-US-06-AC03b",
           "description": "coordinator.test.ts has at least 8 tests covering assessPhase + brief assembly (regression guard)",
-          "command": "npx vitest run server/lib/coordinator.test.ts --reporter=json 2>/dev/null | node -e 'let d=\"\";process.stdin.on(\"data\",c=>d+=c);process.stdin.on(\"end\",()=>{try{const r=JSON.parse(d);const n=r.numTotalTests||0;process.exit(n>=8?0:1)}catch(e){process.exit(1)}});'"
+          "command": "rm -f .vitest-coordinator.json && npx vitest run server/lib/coordinator.test.ts --reporter=json --outputFile=.vitest-coordinator.json && node -e 'const fs=require(\"fs\");const r=JSON.parse(fs.readFileSync(\".vitest-coordinator.json\",\"utf8\"));process.exit((r.numTotalTests||0)>=8?0:1)' && rm -f .vitest-coordinator.json"
         },
         {
           "id": "PH01-US-06-AC04",
           "description": "NFR-C01 advisory mode $0: grep finds zero callClaude/trackedCallClaude references in the PH-01 file set",
-          "command": "test -z \"$(grep -n 'callClaude\\|trackedCallClaude' server/lib/coordinator.ts server/lib/topo-sort.ts server/lib/run-reader.ts server/lib/run-record.ts server/validation/execution-plan.ts server/types/coordinate-result.ts server/tools/coordinate.ts 2>/dev/null)\" && echo EMPTY-OK | grep -q EMPTY-OK"
+          "command": "node -e 'const fs=require(\"fs\");const files=[\"server/lib/coordinator.ts\",\"server/lib/topo-sort.ts\",\"server/lib/run-reader.ts\",\"server/lib/run-record.ts\",\"server/validation/execution-plan.ts\",\"server/types/coordinate-result.ts\",\"server/tools/coordinate.ts\"];let bad=0;for(const f of files){const c=fs.readFileSync(f,\"utf8\");if(c.includes(\"callClaude\")||c.includes(\"trackedCallClaude\")){console.error(\"FOUND in\",f);bad++}}process.exit(bad===0?0:1)'"
         },
         {
           "id": "PH01-US-06-AC05",
           "description": "NFR-C02 deterministic dispatch: calling assessPhase twice on identical inputs returns structurally equal results (excluding timestamp fields)",
-          "command": "npx vitest run server/lib/coordinator.test.ts -t 'NFR-C02|deterministic.*dispatch|determinism' 2>&1 | grep -q 'passed'"
+          "command": "npx vitest run server/lib/coordinator.test.ts -t 'NFR-C02|deterministic.*dispatch|determinism'"
         },
         {
           "id": "PH01-US-06-AC06",

--- a/scripts/q1-task21-acceptance.sh
+++ b/scripts/q1-task21-acceptance.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Task #21 — PH01-US-06 AC rewrite acceptance wrapper.
+# Runs AC-1..AC-9 from .ai-workspace/plans/2026-04-15-q1-ph01-us-06-ac-rewrite.md
+# in order. Exits 0 iff all pass.
+#
+# MSYS_NO_PATHCONV=1 prevents Windows MSYS bash from silently mangling
+# /<path> arguments passed to git — task #22 learning #2.
+export MSYS_NO_PATHCONV=1
+
+set -u
+FAIL=0
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+PHASE_JSON=".ai-workspace/plans/forge-coordinate-phase-PH-01.json"
+BASELINE=".ai-workspace/audits/2026-04-15-task21-baseline.md"
+IDS=(PH01-US-06-AC01b PH01-US-06-AC02b PH01-US-06-AC03b PH01-US-06-AC04 PH01-US-06-AC05)
+
+# Helper: extract an AC command field from the phase JSON on the current worktree.
+get_cmd () {
+  node -e "const j=JSON.parse(require('fs').readFileSync('$PHASE_JSON','utf8'));const s=j.stories.find(u=>u.id==='PH01-US-06');const a=s.acceptanceCriteria.find(x=>x.id===process.argv[1]);if(!a){console.error('MISSING',process.argv[1]);process.exit(2)}process.stdout.write(a.command)" "$1"
+}
+
+# Helper: extract the same command field from origin/master.
+get_cmd_master () {
+  git show "origin/master:$PHASE_JSON" 2>/dev/null | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const j=JSON.parse(d);const s=j.stories.find(u=>u.id==='PH01-US-06');const a=s.acceptanceCriteria.find(x=>x.id===process.argv[1]);if(!a){console.error('MISSING',process.argv[1]);process.exit(2)}process.stdout.write(a.command)})" "$1"
+}
+
+header () { printf '\n=== %s ===\n' "$1"; }
+pass   () { printf 'PASS %s\n' "$1"; }
+fail   () { printf 'FAIL %s — %s\n' "$1" "$2"; FAIL=1; }
+
+# ---------------- AC-1 ----------------
+# Each of the 5 ACs differs from origin/master.
+header "AC-1 — 5 hazardous ACs rewritten"
+for id in "${IDS[@]}"; do
+  cur=$(get_cmd "$id")
+  old=$(get_cmd_master "$id" 2>/dev/null || true)
+  if [ -z "$old" ]; then
+    fail "AC-1" "could not read $id from origin/master (is origin fetched?)"
+  elif [ "$cur" = "$old" ]; then
+    fail "AC-1" "$id UNCHANGED vs origin/master"
+  else
+    pass "AC-1/$id"
+  fi
+done
+
+# ---------------- AC-2 ----------------
+# Zero F-55 hazards in the 5 rewritten commands.
+header "AC-2 — zero F-55 hazards"
+node -e '
+const fs = require("fs");
+const j = JSON.parse(fs.readFileSync(".ai-workspace/plans/forge-coordinate-phase-PH-01.json", "utf8"));
+const s = j.stories.find(u => u.id === "PH01-US-06");
+const ids = ["PH01-US-06-AC01b","PH01-US-06-AC02b","PH01-US-06-AC03b","PH01-US-06-AC04","PH01-US-06-AC05"];
+let bad = 0;
+for (const id of ids) {
+  const c = s.acceptanceCriteria.find(x => x.id === id).command;
+  if (c.includes("2>/dev/null |") || c.includes("2>&1 | grep") || c.includes("| grep -q \u0027passed\u0027")) {
+    console.log("HAZARD", id, c);
+    bad++;
+  }
+}
+process.exit(bad === 0 ? 0 : 1)
+'
+if [ $? -eq 0 ]; then pass "AC-2"; else fail "AC-2" "F-55 hazard remains"; fi
+
+# ---------------- AC-3 ----------------
+# Zero F-36 source-tree-grep + verification-theatre in AC04.
+header "AC-3 — zero F-36 hazards in AC04"
+node -e '
+const fs = require("fs");
+const j = JSON.parse(fs.readFileSync(".ai-workspace/plans/forge-coordinate-phase-PH-01.json", "utf8"));
+const s = j.stories.find(u => u.id === "PH01-US-06");
+const c = s.acceptanceCriteria.find(x => x.id === "PH01-US-06-AC04").command;
+if (c.includes("grep -n \u0027callClaude") || c.includes("grep -rn callClaude") || c.includes("echo EMPTY-OK | grep -q EMPTY-OK")) {
+  console.log("HAZARD", c);
+  process.exit(1);
+}
+'
+if [ $? -eq 0 ]; then pass "AC-3"; else fail "AC-3" "F-36 hazard remains"; fi
+
+# ---------------- AC-4 ----------------
+# Baseline file exists, every id baselined, and rewritten commands match baseline exit codes.
+header "AC-4 — semantics-preserving vs baseline"
+if [ ! -f "$BASELINE" ]; then
+  fail "AC-4" "missing baseline file $BASELINE"
+else
+  for id in "${IDS[@]}"; do
+    if ! grep -q "^${id}: " "$BASELINE"; then
+      fail "AC-4" "MISSING baseline for $id"
+    else
+      expected=$(grep "^${id}: " "$BASELINE" | head -1 | sed -E 's/^[^:]+: *([0-9]+).*/\1/')
+      cmd=$(get_cmd "$id")
+      bash -c "$cmd" > /dev/null 2>&1
+      got=$?
+      if [ "$got" = "$expected" ]; then
+        pass "AC-4/$id (baseline=$expected, rewrite=$got)"
+      else
+        # Allow latent-prior-failure escape hatch.
+        if grep -q "^${id}: .*latent-prior-failure" "$BASELINE"; then
+          pass "AC-4/$id (latent-prior-failure flagged)"
+        else
+          fail "AC-4" "$id baseline=$expected rewrite=$got (no latent flag)"
+        fi
+      fi
+    fi
+  done
+fi
+
+# ---------------- AC-5 ----------------
+header "AC-5 — ac-lint clean"
+npx vitest run server/validation/ac-lint.test.ts > /tmp/q1t21-aclint.log 2>&1
+if [ $? -eq 0 ]; then pass "AC-5"; else fail "AC-5" "see /tmp/q1t21-aclint.log"; fi
+
+# ---------------- AC-6 ----------------
+header "AC-6 — npm run build"
+npm run build > /tmp/q1t21-build.log 2>&1
+if [ $? -eq 0 ]; then pass "AC-6"; else fail "AC-6" "see /tmp/q1t21-build.log"; fi
+
+# ---------------- AC-7 ----------------
+header "AC-7 — npm run lint"
+npm run lint > /tmp/q1t21-lint.log 2>&1
+if [ $? -eq 0 ]; then pass "AC-7"; else fail "AC-7" "see /tmp/q1t21-lint.log"; fi
+
+# ---------------- AC-8 ----------------
+header "AC-8 — npm test"
+npm test > /tmp/q1t21-test.log 2>&1
+if [ $? -eq 0 ]; then pass "AC-8"; else fail "AC-8" "see /tmp/q1t21-test.log"; fi
+
+# ---------------- AC-9 ----------------
+# No drive-by edits: diff vs origin/master confined to allowlist.
+header "AC-9 — no drive-by edits"
+ALLOW_RE='^(\.ai-workspace/plans/forge-coordinate-phase-PH-01\.json|\.ai-workspace/plans/2026-04-15-q1-ph01-us-06-ac-rewrite\.md|\.ai-workspace/audits/2026-04-15-task21-baseline\.md|scripts/q1-task21-acceptance\.sh)$'
+unexpected=$(git diff origin/master...HEAD --name-only | grep -vE "$ALLOW_RE" || true)
+if [ -z "$unexpected" ]; then
+  pass "AC-9"
+else
+  fail "AC-9" "unexpected files: $unexpected"
+fi
+
+# ---------------- Summary ----------------
+header "SUMMARY"
+if [ "$FAIL" -eq 0 ]; then
+  echo "ALL GREEN"
+  exit 0
+else
+  echo "FAILURES PRESENT"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Task #21 — Q1 PH01-US-06 AC rewrite. The 5 ACs under `PH01-US-06` in `.ai-workspace/plans/forge-coordinate-phase-PH-01.json` that carried F-55 (captured-output / pipe-to-grep) and F-36 (source-tree-grep + verification-theatre) hazards are rewritten to safe patterns. Semantics preserved (baseline-verified exit-code match). No `server/**` changes.

## Changes

- **`forge-coordinate-phase-PH-01.json` — 5 AC `command` fields under `stories[id=PH01-US-06].acceptanceCriteria`:**
  - `AC01b/AC02b/AC03b` (F-55 fix): swapped `vitest ... --reporter=json 2>/dev/null | node -e '...'` for `rm -f .vitest-<name>.json && vitest ... --outputFile=.vitest-<name>.json && node -e 'JSON.parse(fs.readFileSync(...))...' && rm -f .vitest-<name>.json`. `&&` chaining makes vitest's exit code gate the parse; project-local temp file avoids bash -c quoting gymnastics.
  - `AC04` (F-36 fix): swapped `test -z \"\$(grep -n 'callClaude' server/lib/... 2>/dev/null)\" && echo EMPTY-OK | grep -q EMPTY-OK` for `node -e 'fs.readFileSync(f,\"utf8\").includes(\"callClaude\")'` over the same explicit 7-file list. No grep, no \$(), no verification-theatre echo tail.
  - `AC05` (F-55 fix): dropped the `2>&1 | grep -q 'passed'` tail — vitest `-t` already exits 0 iff matching tests pass.
- **`.ai-workspace/audits/2026-04-15-task21-baseline.md`** — new file. Records each ORIGINAL command's exit code (all 5 = exit 0) against master @ 919e0a7 before rewrite. This is the semantics-preservation contract: rewrite must match baseline.
- **`scripts/q1-task21-acceptance.sh`** — new file. Hard-rule-8 acceptance wrapper. Exports \`MSYS_NO_PATHCONV=1\` at top (task #22 precedent — prevents Windows MSYS path-mangling on \`git show <rev>:<path>\`). Runs AC-1..AC-9 in order, exits 0 iff all pass.
- **`.ai-workspace/plans/2026-04-15-q1-ph01-us-06-ac-rewrite.md`** — this task's plan. Amended mid-PR to fix a planner-side regression (plan's reviewer one-liners referenced \`j.userStories\` but the JSON schema uses \`j.stories\`).

## Test plan

- [x] AC-1..AC-9 all PASS via \`bash scripts/q1-task21-acceptance.sh\` on the PR branch (local self-gate before push)
- [x] AC-5 (\`ac-lint\`): 52/52 pass
- [x] AC-6 (\`npm run build\`): exit 0
- [x] AC-7 (\`npm run lint\`): exit 0, zero errors
- [x] AC-8 (\`npm test\`): 719 passed / 4 skipped / 0 failed
- [x] AC-4 semantics-preserving: all 5 originals exited 0 on master, all 5 rewrites exit 0 on PR branch (baseline file)
- [ ] AC-10 (CI green on the PR) — pending this push

## Out-of-scope held

- No \`server/**\` edits
- No other user stories in \`forge-coordinate-phase-PH-01.json\` (US-01..US-05 are task #40's scope)
- No \`forge-generate-phase-PH-01.json\` edits
- No \`lintExempt\` block edits (task #22 already refreshed it under AFFIRM)
- No eslint config / CI workflow / tsconfig edits

---

index-check: none
plan-refresh: error: mcp-forge-plan-credit-balance-exceeded
plan-refresh-override: docs-only AC-command rewrite under PH01-US-06 (5 ACs rewritten to F-rule-safe patterns); zero semantic plan changes — no stories added/removed/renamed, no dependencies changed, no ACs added/removed, only hazardous command strings replaced with semantically-equivalent safe forms (baseline-verified exit-code preservation per .ai-workspace/audits/2026-04-15-task21-baseline.md); MCP forge_plan(update) credit-balance-exceeded at ship time