### PR TITLE
fix: scope dual-flag warning to retry-PASS branch only

### DIFF
--- a/server/lib/evaluator.test.ts
+++ b/server/lib/evaluator.test.ts
@@ -454,6 +454,43 @@ describe("evaluateStory", () => {
         ),
       ).toBe(true);
     });
+
+    // Q0.5/A3 — dual-flag both-FAIL: flaky+exempt but BOTH runs FAIL → "unverified", no dual-flag warning.
+    // Flake is a property of the PASS path; when both runs fail, the tag stays
+    // "unverified" (exemption fired) and no dual-flag warning is emitted.
+    it("dual-flag: flaky + fired exemption + both-FAIL → reliability=unverified, no dual-flag warning", async () => {
+      mockedExecute
+        .mockResolvedValueOnce(mockResult({ status: "FAIL", evidence: "first fail" }))
+        .mockResolvedValueOnce(mockResult({ status: "FAIL", evidence: "second fail" }));
+      const plan: ExecutionPlan = {
+        schemaVersion: "3.0.0",
+        stories: [
+          {
+            id: "US-01",
+            title: "Dual flag both FAIL",
+            acceptanceCriteria: [
+              {
+                id: "AC-01",
+                description: "flaky AND exempted, both runs fail",
+                command: "npx vitest run | grep -q 'passed'",
+                flaky: true,
+                lintExempt: { ruleId: "F55-passed-grep", rationale: "reviewed" },
+              },
+            ],
+          },
+        ],
+      };
+      const report = await evaluateStory(plan, "US-01", { flakyRetryGapMs: 1 });
+      expect(report.verdict).toBe("FAIL");
+      expect(report.criteria[0].status).toBe("FAIL");
+      // Exemption fired → unverified (not suspect); dual-flag warning must NOT appear.
+      expect(report.criteria[0].reliability).toBe("unverified");
+      expect(
+        (report.warnings ?? []).some((w) =>
+          /flaky.*lintExempt|lintExempt.*flaky/i.test(w),
+        ),
+      ).toBe(false);
+    });
   });
 
   // Q0.5/C2 — flaky field retry semantics.

--- a/server/lib/evaluator.ts
+++ b/server/lib/evaluator.ts
@@ -93,17 +93,6 @@ export async function evaluateStory(
     // (deferred to Q0.5/A3-bis).
     const exemptionFired = lint.findings.some((f) => f.exempt === true);
 
-    // Q0.5/A3 — dual-flag warning (T1510 blessed + T1545 clarified). A flaky
-    // AC whose exemption fired is reported as "suspect" (runtime signal
-    // outranks authoring override) — but the collision itself is a soft
-    // smell that deserves an explicit, per-AC warning so analytics can
-    // grep for it. Rolled warnings hide the signal.
-    if (ac.flaky === true && exemptionFired) {
-      dualFlagWarnings.push(
-        `AC '${ac.id}' has flaky: true AND a lintExempt entry whose exemption fired during this run — reporting as suspect (flake takes precedence). Override review recommended.`,
-      );
-    }
-
     const firstRun = await executeCommand(ac.command, execOptions);
 
     // Q0.5/C2 — flaky retry gate. Only fires when (a) the AC author opted in
@@ -128,6 +117,18 @@ export async function evaluateStory(
         // so the AC doesn't block the verdict, but surface the soft signal
         // via reliability="suspect" and an evidence prefix so callers can
         // audit the flake rate downstream.
+        // Q0.5/A3 — dual-flag warning (T1510 blessed + T1545 clarified). A flaky
+        // AC whose exemption fired is reported as "suspect" (runtime signal
+        // outranks authoring override) — but the collision itself is a soft
+        // smell that deserves an explicit, per-AC warning so analytics can
+        // grep for it. Scoped to the retry-PASS branch only: flake is a
+        // property of the PASS path; both-FAIL stays tagged "unverified"
+        // without a dual-flag warning (tag-vs-warning mismatch fixed).
+        if (exemptionFired) {
+          dualFlagWarnings.push(
+            `AC '${ac.id}' has flaky: true AND a lintExempt entry whose exemption fired during this run — reporting as suspect (flake takes precedence). Override review recommended.`,
+          );
+        }
         criteria.push({
           id: ac.id,
           status: "PASS",


### PR DESCRIPTION
Closes #192

Auto-fix by /housekeep Stage 4.

Moved the flaky+exempt dual-flag warning inside the retry-PASS branch so it only fires when flake semantics apply. Both-FAIL path now correctly tags as unverified with no conflicting suspect warning. Added test case for flaky+exempt+both-FAIL.