### PR TITLE
fix: derive RunRecord outcome from results.error

### DIFF
--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -703,8 +703,14 @@ async function handleCriticEval(input: EvaluateInput): Promise<McpResponse> {
       0,
     );
     const base = buildRunRecord(ctx, startTime, findingsTotal);
+    const outcome = results.every(r => r.error)
+      ? "failure"
+      : results.some(r => r.error)
+        ? "partial"
+        : "success";
     await writeRunRecord(input.projectPath, {
       ...base,
+      outcome,
       criticReport: report,
     });
   }


### PR DESCRIPTION
Closes #189

Auto-fix by /housekeep Stage 4.

Replaced hardcoded `outcome: "success"` in handleCriticEval with derived value: all errored -> failure, some errored -> partial, none -> success.