### PR TITLE
fix: handleCriticEval guard parsed !== null && typeof parsed === 'object'

### DIFF
--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -678,9 +678,12 @@ async function handleCriticEval(input: EvaluateInput): Promise<McpResponse> {
         jsonMode: true,
       });
 
-      const parsed = result.parsed as Record<string, unknown>;
-      const findings = Array.isArray(parsed.findings)
-        ? (parsed.findings as unknown[])
+      const parsed = result.parsed;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("critic response was not a JSON object");
+      }
+      const findings = Array.isArray((parsed as Record<string, unknown>).findings)
+        ? ((parsed as Record<string, unknown>).findings as unknown[])
         : [];
       results.push({ planPath, findings });
     } catch (err) {


### PR DESCRIPTION
Closes #184

Auto-fix by /housekeep Stage 4.

Added defensive guard to check parsed critic response is a non-null, non-array object before accessing .findings. Throws clear error message instead of opaque TypeError.