### PR TITLE
fix: aggregate unverified warning should include the offending AC ids

### DIFF
--- a/server/lib/evaluator.ts
+++ b/server/lib/evaluator.ts
@@ -166,12 +166,14 @@ export async function evaluateStory(
   }
 
   // Q0.5/A3 — aggregate unverified-count warning (per T1545 text).
-  const unverifiedCount = criteria.filter(
+  const unverifiedCriteria = criteria.filter(
     (c) => c.reliability === "unverified",
-  ).length;
+  );
+  const unverifiedCount = unverifiedCriteria.length;
   if (unverifiedCount > 0) {
+    const unverifiedIds = unverifiedCriteria.map((c) => c.id);
     warnings.push(
-      `${unverifiedCount} AC(s) ran with a fired lintExempt override — reliability is unverified`,
+      `${unverifiedCount} AC(s) ran with a fired lintExempt override — reliability is unverified (${unverifiedIds.join(", ")})`,
     );
   }
   // Q0.5/A3 — dual-flag per-AC warnings (flaky + fired exemption collision).


### PR DESCRIPTION
Closes #194

Auto-fix by /housekeep Stage 4.

Appended the offending AC id list to the unverified reliability warning string, giving downstream analytics a direct handle without re-walking criteria[].