### PR TITLE
fix: recursive walk for nested plan dirs in handleCriticEval

### DIFF
--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -644,7 +644,7 @@ async function handleCriticEval(input: EvaluateInput): Promise<McpResponse> {
     const root = input.projectPath ?? process.cwd();
     const plansDir = join(root, ".ai-workspace", "plans");
     try {
-      resolvedPaths = readdirSync(plansDir)
+      resolvedPaths = (readdirSync(plansDir, { recursive: true }) as string[])
         .filter((f) => f.endsWith(".json"))
         .map((f) => join(plansDir, f))
         .sort();


### PR DESCRIPTION
Closes #188

Auto-fix by /housekeep Stage 4.

Replaced `readdirSync(plansDir)` with `readdirSync(plansDir, { recursive: true })` in `handleCriticEval` so that plan JSON files in nested subdirectories (e.g. `.ai-workspace/plans/2026-Q2/foo.json`) are included in the critic sweep instead of being silently skipped.