### PR TITLE
refactor(plans): rewrite 6 F55-passed ACs in PH01-US-02 (#40 s03)

### DIFF
--- a/.ai-workspace/plans/forge-coordinate-phase-PH-01.json
+++ b/.ai-workspace/plans/forge-coordinate-phase-PH-01.json
@@ -211,32 +211,32 @@
         {
           "id": "PH01-US-02-AC04",
           "description": "topoSort([]) returns [] without throwing (empty-input guard)",
-          "command": "npx vitest run server/lib/topo-sort.test.ts -t 'empty' 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/lib/topo-sort.test.ts -t 'empty' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US-02-AC05",
           "description": "Given chained dependencies US-01 → US-02 → US-03, topoSort returns them in [US-01, US-02, US-03] order",
-          "command": "npx vitest run server/lib/topo-sort.test.ts -t 'chain' 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/lib/topo-sort.test.ts -t 'chain' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US-02-AC06",
           "description": "Given input order [US-03, US-01, US-02] with US-02 depending on US-01 and US-03 on US-02, topoSort returns [US-01, US-02, US-03]",
-          "command": "npx vitest run server/lib/topo-sort.test.ts -t 'reverse.*input|input.*order' 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/lib/topo-sort.test.ts -t 'reverse.*input|input.*order' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US-02-AC07",
           "description": "Stable lex tie-break: given two zero-in-degree stories US-Z and US-A with no dependencies, topoSort returns US-A before US-Z",
-          "command": "npx vitest run server/lib/topo-sort.test.ts -t 'lex|tie-break' 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/lib/topo-sort.test.ts -t 'lex|tie-break' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US-02-AC08",
           "description": "topoSort throws when given a plan containing a cycle",
-          "command": "npx vitest run server/lib/topo-sort.test.ts -t 'cycle' 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/lib/topo-sort.test.ts -t 'cycle' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US-02-AC09",
           "description": "Existing execution-plan validation tests still pass after detectCycles signature change",
-          "command": "npx vitest run server/validation/execution-plan.test.ts 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/validation/execution-plan.test.ts --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         }
       ],
       "affectedPaths": [

--- a/scripts/q1-t40-03-acceptance.sh
+++ b/scripts/q1-t40-03-acceptance.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Task #40 slice 3 — PH01-US-02 AC rewrite acceptance wrapper.
+# Runs AC-1, AC-2, AC-4, AC-6 from the task #40 plan.
+# Exits 0 iff all pass.
+#
+# MSYS_NO_PATHCONV=1 prevents Windows MSYS bash from silently mangling
+# /<path> arguments passed to git — task #22 learning #2.
+export MSYS_NO_PATHCONV=1
+
+set -u
+FAIL=0
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+PHASE_JSON=".ai-workspace/plans/forge-coordinate-phase-PH-01.json"
+STORY="PH01-US-02"
+F55_COUNT=6
+
+header () { printf '\n=== %s ===\n' "$1"; }
+pass   () { printf 'PASS %s\n' "$1"; }
+fail   () { printf 'FAIL %s — %s\n' "$1" "$2"; FAIL=1; }
+
+# ---------------- AC-1 ----------------
+# Every AC in PH01-US-02 passes ac-lint without lintExempt (F55 only).
+header "AC-1 — zero F55-passed-grep findings in $STORY after stripping lintExempt"
+node -e "
+const { lintPlan } = require('./dist/validation/ac-lint.js');
+const fs = require('fs');
+const plan = JSON.parse(fs.readFileSync('$PHASE_JSON', 'utf8'));
+const stripped = { ...plan, lintExempt: [] };
+const report = lintPlan(stripped);
+const f55InBlock = report.findings.filter(f => f.storyId === '$STORY' && f.ruleId === 'F55-passed-grep');
+if (f55InBlock.length > 0) {
+  console.error('F55 findings in $STORY:', JSON.stringify(f55InBlock, null, 2));
+  process.exit(1);
+}
+console.log('  Zero F55-passed-grep findings in $STORY after stripping lintExempt');
+"
+if [ $? -eq 0 ]; then pass "AC-1"; else fail "AC-1" "ac-lint findings in $STORY"; fi
+
+# ---------------- AC-2 ----------------
+# ac-lint test suite passes.
+header "AC-2 — ac-lint test suite"
+npx vitest run server/validation/ac-lint.test.ts > /tmp/q1t40-s03-aclint.log 2>&1
+if [ $? -eq 0 ]; then pass "AC-2"; else fail "AC-2" "see /tmp/q1t40-s03-aclint.log"; fi
+
+# ---------------- AC-3 ----------------
+# Every rewritten AC command is mechanically executable.
+header "AC-3 — rewritten AC commands are executable"
+AC3_FAIL=0
+for ACID in PH01-US-02-AC04 PH01-US-02-AC05 PH01-US-02-AC06 PH01-US-02-AC07 PH01-US-02-AC08 PH01-US-02-AC09; do
+  SCRIPT=$(mktemp --suffix=.sh)
+  node -e "
+    const fs = require('fs');
+    const plan = JSON.parse(fs.readFileSync('$PHASE_JSON', 'utf8'));
+    const story = plan.stories.find(s => s.id === '$STORY');
+    const ac = story.acceptanceCriteria.find(a => a.id === process.argv[1]);
+    process.stdout.write(ac.command);
+  " "$ACID" > "$SCRIPT"
+  # Unset MSYS_NO_PATHCONV for the AC command subshell — it interferes
+  # with mktemp/vitest --outputFile path translation on Windows MSYS.
+  # Empty string is not enough; MSYS checks presence, not value.
+  (unset MSYS_NO_PATHCONV; bash "$SCRIPT")
+  RC=$?
+  rm -f "$SCRIPT"
+  if [ $RC -eq 0 ]; then
+    printf '  %s: exit 0 (PASS)\n' "$ACID"
+  else
+    printf '  %s: exit %d (FAIL)\n' "$ACID" "$RC"
+    AC3_FAIL=1
+  fi
+done
+if [ $AC3_FAIL -eq 0 ]; then pass "AC-3"; else fail "AC-3" "one or more rewritten ACs failed"; fi
+
+# ---------------- AC-4 ----------------
+# Exactly 2*F55_COUNT command-line changes in the diff.
+header "AC-4 — exactly $((F55_COUNT * 2)) command-line changes"
+COUNT=$(git diff origin/master -- "$PHASE_JSON" | grep -cE '^\+\s*"command"|^-\s*"command"' || true)
+EXPECTED=$((F55_COUNT * 2))
+if [ "$COUNT" -eq "$EXPECTED" ]; then
+  pass "AC-4 (command-line changes: $COUNT)"
+else
+  fail "AC-4" "command-line changes: $COUNT (expected $EXPECTED)"
+fi
+
+# ---------------- AC-5 ----------------
+# Diff confined to phase JSON + acceptance wrapper only.
+header "AC-5 — diff confined to allowlist"
+DIFF_FILES=$(git diff origin/master...HEAD --name-only)
+BAD_FILES=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    .ai-workspace/plans/forge-coordinate-phase-PH-01.json) ;;
+    scripts/q1-t40-03-acceptance.sh) ;;
+    *) BAD_FILES="$BAD_FILES $f" ;;
+  esac
+done <<< "$DIFF_FILES"
+if [ -z "$BAD_FILES" ]; then
+  pass "AC-5"
+else
+  fail "AC-5" "unexpected files:$BAD_FILES"
+fi
+
+# ---------------- AC-6 ----------------
+# lintExempt block is byte-identical to master.
+header "AC-6 — lintExempt identical to master"
+node -e "
+const fs = require('fs');
+const { execSync } = require('child_process');
+const branchPlan = JSON.parse(fs.readFileSync('$PHASE_JSON', 'utf8'));
+const masterJson = execSync('git show origin/master:$PHASE_JSON', { encoding: 'utf8' });
+const masterPlan = JSON.parse(masterJson);
+const branchExempt = JSON.stringify(branchPlan.lintExempt);
+const masterExempt = JSON.stringify(masterPlan.lintExempt);
+if (branchExempt === masterExempt) {
+  console.log('  lintExempt identical');
+  process.exit(0);
+} else {
+  console.error('  lintExempt DIFFERS');
+  process.exit(1);
+}
+"
+if [ $? -eq 0 ]; then pass "AC-6"; else fail "AC-6" "lintExempt differs from master"; fi
+
+# ---------------- Summary ----------------
+header "SUMMARY"
+if [ "$FAIL" -eq 0 ]; then
+  echo "ALL GREEN"
+  exit 0
+else
+  echo "FAILURES PRESENT"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Rewrites 6 F55-passed-grep hazardous AC commands in the PH01-US-02 story block (forge-coordinate-phase-PH-01.json)
- Uses the subprocess-safe vitest JSON reporter pattern established in task #21 (PR #209) and continued in slices 1-2 (PR #223, #227)
- Adds acceptance wrapper `scripts/q1-t40-03-acceptance.sh` verifying all local ACs

## Test plan
- [x] Acceptance wrapper passes all checks (AC-1 through AC-6)
- [x] `npm run build` exits 0
- [x] `npm run lint` exits 0
- [x] `npm test` passes (721 passed, 0 failed)
- [x] `npx vitest run server/validation/ac-lint.test.ts` exits 0
- [x] Diff confined to phase JSON + acceptance wrapper only

---
plan-refresh: no-op