### PR TITLE
fix: retroactive-critique hook de-dup + 401 fallback

### DIFF
--- a/scripts/retroactive-critique-hook.sh
+++ b/scripts/retroactive-critique-hook.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 # PostToolUse hook: when a prompt-rule source file is edited, direct Claude to
 # re-run forge_evaluate in critic mode against every plan file before its next
 # response. Fast path: exit silently if the touched path is not in the allowlist.
+#
+# De-dup: hashes matched allowlist files and skips if unchanged since last fire
+# in this session (tracked via /tmp/forge-critique-<session>-last-hash).
+#
+# 401 fallback: if MCP auth fails, the directive tells Claude to produce
+# {findings: [...]} in-session rather than fail-closed. The contract is the
+# JSON output schema, not the MCP call site.
 
 input="$(cat)"
 
@@ -49,11 +56,32 @@ if [[ "$matched" -eq 0 ]]; then
   exit 0
 fi
 
+# --- De-dup: skip if allowlist file contents are unchanged since last fire ---
+# Resolve the repo root so we hash absolute paths regardless of cwd.
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+content_hash=""
+for f in "${allowlist[@]}"; do
+  abs="${repo_root}/${f}"
+  if [[ -f "$abs" ]]; then
+    content_hash+="$(md5sum "$abs" 2>/dev/null | cut -d' ' -f1)"
+  fi
+done
+content_hash="$(printf '%s' "$content_hash" | md5sum | cut -d' ' -f1)"
+
+session_id="${CLAUDE_SESSION_ID:-${MAILBOX_SESSION_ID:-default}}"
+hash_file="/tmp/forge-critique-${session_id}-last-hash"
+
+if [[ -f "$hash_file" ]] && [[ "$(cat "$hash_file")" == "$content_hash" ]]; then
+  # Allowlist files unchanged since last fire — skip to avoid duplicate findings
+  exit 0
+fi
+printf '%s' "$content_hash" > "$hash_file"
+
 cat <<'JSON'
 {
   "hookSpecificOutput": {
     "hookEventName": "PostToolUse",
-    "additionalContext": "A prompt-rule source file was just edited. Before producing your next response, you MUST invoke mcp__forge__forge_evaluate in critic mode against every .ai-workspace/plans/*.json file in this repo to detect drift between the updated rule set and existing plans. Surface all findings inline. Do not defer this to a later turn."
+    "additionalContext": "A prompt-rule source file was just edited. Before producing your next response, you MUST invoke mcp__forge__forge_evaluate in critic mode against every .ai-workspace/plans/*.json file in this repo to detect drift between the updated rule set and existing plans. Surface all findings inline. Do not defer this to a later turn.\n\nIMPORTANT — 401/auth fallback: if the mcp__forge__forge_evaluate call fails with HTTP 401, OAuth error, or any authentication failure, DO NOT retry or abort. Instead, perform the critique in-session: read each .ai-workspace/plans/*.json file, apply the updated prompt-rule set manually, and produce a well-formed JSON object matching the MCP output schema: {\"findings\": [{\"acId\": \"...\", \"severity\": \"error|warning|info\", \"message\": \"...\", \"file\": \"...\", \"line\": null}]}. The contract is the output schema, not the call site."
   }
 }
 JSON


### PR DESCRIPTION
Closes #205

## Summary
- **De-dup (Ask 1):** Hashes all allowlist file contents into a single digest, stores it in `/tmp/forge-critique-<session>-last-hash`. If the digest matches the previous fire, exits silently — no duplicate findings across successive critique rounds on unchanged files.
- **401 fallback (Ask 2):** Appends a fallback directive to the hook output telling Claude to produce a well-formed `{findings: [...]}` JSON array in-session when the MCP evaluator call fails with 401/OAuth. The contract is the output schema, not the call site.

## Test plan
- [ ] Edit an allowlist file twice without changing content between edits — second fire should be a no-op (check `/tmp/forge-critique-*-last-hash` file exists)
- [ ] Edit an allowlist file, then change it again — both fires should emit the directive
- [ ] Verify the `additionalContext` string includes the 401 fallback instruction with the `{findings: [...]}` schema

---
plan-refresh: no-op