### PR TITLE
refactor(plans): rewrite 3 F55-passed ACs in PH01-US01 (#40)

### DIFF
--- a/.ai-workspace/plans/forge-generate-phase-PH-01.json
+++ b/.ai-workspace/plans/forge-generate-phase-PH-01.json
@@ -33,17 +33,17 @@
         {
           "id": "PH01-US01-AC03",
           "description": "Validation accepts plans with baselineCheck field without errors",
-          "command": "npx vitest run server/validation/execution-plan.test.ts -t 'baselineCheck' 2>&1 | grep -qE '(passed|Tests.*[1-9])'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/validation/execution-plan.test.ts -t 'baselineCheck' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US01-AC04",
           "description": "Validation accepts stories with lineage field without errors",
-          "command": "npx vitest run server/validation/execution-plan.test.ts -t 'lineage' 2>&1 | grep -qE '(passed|Tests.*[1-9])'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/validation/execution-plan.test.ts -t 'lineage' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US01-AC05",
           "description": "Existing validation tests still pass (backward compatibility)",
-          "command": "npx vitest run server/validation/execution-plan.test.ts 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/validation/execution-plan.test.ts --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US01-AC06",

--- a/scripts/q1-t40-07-acceptance.sh
+++ b/scripts/q1-t40-07-acceptance.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Acceptance wrapper for task #40 slice 7 — PH01-US01 AC rewrite
+set -euo pipefail
+
+FAIL=0
+JSON=".ai-workspace/plans/forge-generate-phase-PH-01.json"
+
+echo "=== AC1: JSON is valid ==="
+if node -e "JSON.parse(require('fs').readFileSync('$JSON','utf8'))"; then
+  echo "PASS"
+else
+  echo "FAIL: $JSON is not valid JSON"
+  FAIL=1
+fi
+
+echo ""
+echo "=== AC2: Each rewritten AC contains --reporter=json ==="
+for AC in PH01-US01-AC03 PH01-US01-AC04 PH01-US01-AC05; do
+  CMD=$(node -e "
+    const p=JSON.parse(require('fs').readFileSync('$JSON','utf8'));
+    const s=p.stories.find(s=>s.id==='PH01-US01');
+    const ac=s.acceptanceCriteria.find(a=>a.id==='$AC');
+    process.stdout.write(ac.command);
+  ")
+  if echo "$CMD" | grep -q -- '--reporter=json'; then
+    echo "PASS: $AC contains --reporter=json"
+  else
+    echo "FAIL: $AC missing --reporter=json"
+    FAIL=1
+  fi
+done
+
+echo ""
+echo "=== AC3: git diff shows exactly 3 added, 3 removed ==="
+ADDED=$(git diff --numstat -- "$JSON" | awk '{print $1}')
+REMOVED=$(git diff --numstat -- "$JSON" | awk '{print $2}')
+if [[ "$ADDED" == "3" && "$REMOVED" == "3" ]]; then
+  echo "PASS: 3 added, 3 removed"
+else
+  echo "FAIL: expected 3/3, got $ADDED/$REMOVED"
+  FAIL=1
+fi
+
+echo ""
+echo "=== AC4: diff confined to generate phase JSON only ==="
+CHANGED=$(git diff --name-only)
+if [[ "$CHANGED" == "$JSON" ]]; then
+  echo "PASS: only $JSON changed"
+else
+  echo "FAIL: unexpected files changed: $CHANGED"
+  FAIL=1
+fi
+
+echo ""
+if [[ $FAIL -eq 0 ]]; then
+  echo "ALL CHECKS PASSED"
+else
+  echo "SOME CHECKS FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Rewrite 3 hazardous `grep -q 'passed'` AC commands in PH01-US01 (generate phase, execution-plan story) to use vitest `--reporter=json --outputFile` for subprocess-safe verification
- Part of task #40 slice 7 (37/66 F55 ACs done after this PR)

## Test plan
- [ ] Acceptance wrapper `scripts/q1-t40-07-acceptance.sh` passes all checks
- [ ] No remaining F55 patterns in US01 ACs (AC01/AC02 are F36, correctly untouched)
- [ ] JSON is valid and lint-clean

---
plan-refresh: no-op