### PR TITLE
refactor(plans): rewrite 2 F55-passed ACs in PH01-US03 (#40)

### DIFF
--- a/.ai-workspace/plans/forge-generate-phase-PH-01.json
+++ b/.ai-workspace/plans/forge-generate-phase-PH-01.json
@@ -128,12 +128,12 @@
         {
           "id": "PH01-US03-AC03",
           "description": "loadPlan handles planJson precedence over planPath",
-          "command": "npx vitest run server/lib/plan-loader.test.ts -t 'precedence' 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/lib/plan-loader.test.ts -t 'precedence' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US03-AC04",
           "description": "Existing evaluate tests still pass after extraction",
-          "command": "npx vitest run server/tools/evaluate.test.ts 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/tools/evaluate.test.ts --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US03-AC05",

--- a/scripts/q1-t40-08-acceptance.sh
+++ b/scripts/q1-t40-08-acceptance.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+PASS=0; FAIL=0
+report() {
+  local label=$1; local rc=$2
+  if [[ $rc -eq 0 ]]; then echo "PASS: $label"; ((PASS++)); else echo "FAIL: $label"; ((FAIL++)); fi
+}
+
+JSON=".ai-workspace/plans/forge-generate-phase-PH-01.json"
+
+# 1. Valid JSON
+node -e "JSON.parse(require('fs').readFileSync('$JSON','utf8'))" 2>/dev/null; report "JSON is valid" $?
+
+# 2. AC03 contains --reporter=json
+node -e "const j=JSON.parse(require('fs').readFileSync('$JSON','utf8')); const s=j.stories.find(s=>s.id==='PH01-US03'); const ac=s.acceptanceCriteria.find(a=>a.id==='PH01-US03-AC03'); process.exit(ac.command.includes('--reporter=json') ? 0 : 1)"; report "AC03 contains --reporter=json" $?
+
+# 3. AC04 contains --reporter=json
+node -e "const j=JSON.parse(require('fs').readFileSync('$JSON','utf8')); const s=j.stories.find(s=>s.id==='PH01-US03'); const ac=s.acceptanceCriteria.find(a=>a.id==='PH01-US03-AC04'); process.exit(ac.command.includes('--reporter=json') ? 0 : 1)"; report "AC04 contains --reporter=json" $?
+
+# 4. git diff shows exactly 2 insertions and 2 deletions
+STATS=$(git diff --numstat "$JSON")
+ADDS=$(echo "$STATS" | awk '{print $1}')
+DELS=$(echo "$STATS" | awk '{print $2}')
+[[ "$ADDS" == "2" && "$DELS" == "2" ]]; report "git diff shows exactly 2+/2-" $?
+
+# 5. diff confined to generate phase JSON only
+FILES=$(git diff --name-only)
+[[ "$FILES" == "$JSON" ]]; report "diff confined to generate phase JSON only" $?
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- Rewrite 2 hazardous `grep -q 'passed'` AC commands in PH01-US03 (generate phase) to use vitest `--reporter=json --outputFile` for subprocess-safe verification
- Part of task #40 slice 8 (39/66 F55 ACs done after this PR)

## Test plan
- [ ] Acceptance wrapper `scripts/q1-t40-08-acceptance.sh` passes all checks
- [ ] JSON is valid and lint-clean

---
plan-refresh: no-op