### PR TITLE
fix: acceptance wrapper header comment understates checked ACs

### DIFF
--- a/scripts/q1-t40-02-acceptance.sh
+++ b/scripts/q1-t40-02-acceptance.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Task #40 slice 2 — PH01-US-00b AC rewrite acceptance wrapper.
-# Runs AC-1, AC-2, AC-4, AC-6 from the task #40 plan.
+# Runs AC-1 through AC-6 from the task #40 plan.
 # Exits 0 iff all pass.
 #
 # MSYS_NO_PATHCONV=1 prevents Windows MSYS bash from silently mangling


### PR DESCRIPTION
Closes #228

Auto-fix by /housekeep Stage 4.

Line 3 header comment said "Runs AC-1, AC-2, AC-4, AC-6" but the script runs AC-1 through AC-6. Updated to "Runs AC-1 through AC-6" to match reality.