### PR TITLE
refactor(plans): rewrite 5 F55-passed ACs in PH01-US04 (#40)

### DIFF
--- a/.ai-workspace/plans/forge-generate-phase-PH-01.json
+++ b/.ai-workspace/plans/forge-generate-phase-PH-01.json
@@ -157,27 +157,27 @@
         {
           "id": "PH01-US04-AC01",
           "description": "buildBrief returns GenerationBrief with story object from plan matching storyId",
-          "command": "npx vitest run server/lib/generator.test.ts -t 'buildBrief.*story' 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*story' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US04-AC02",
           "description": "buildBrief returns codebaseContext string from scanCodebase",
-          "command": "npx vitest run server/lib/generator.test.ts -t 'buildBrief.*codebaseContext' 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*codebaseContext' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US04-AC03",
           "description": "buildBrief returns gitBranch as feat/{storyId} (e.g. feat/US-01 for storyId US-01)",
-          "command": "npx vitest run server/lib/generator.test.ts -t 'buildBrief.*gitBranch' 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*gitBranch' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US04-AC04",
           "description": "buildBrief returns baselineCheck from plan or defaults to 'npm run build && npm test'",
-          "command": "npx vitest run server/lib/generator.test.ts -t 'buildBrief.*baselineCheck' 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*baselineCheck' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US04-AC05",
           "description": "buildBrief throws or returns error for non-existent storyId",
-          "command": "npx vitest run server/lib/generator.test.ts -t 'buildBrief.*not found\\|buildBrief.*invalid' 2>&1 | grep -q 'passed'"
+          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*not found\\|buildBrief.*invalid' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         }
       ],
       "affectedPaths": [

--- a/scripts/q1-t40-05-acceptance.sh
+++ b/scripts/q1-t40-05-acceptance.sh
@@ -23,7 +23,6 @@ if npx vitest run server/smoke/ac-lint.test.ts >/dev/null 2>&1; then pass; else 
 
 # AC-3: each rewritten command is executable (all 8 use valid syntax)
 step 3 "all $F55_COUNT rewritten commands parse as valid JSON+bash"
-CMD_PASS=0
 # Extract the 8 rewritten commands from the phase JSON and check each is syntactically valid bash
 COMMANDS=$(node -e "
 const fs = require('fs');

--- a/scripts/q1-t40-09-acceptance.sh
+++ b/scripts/q1-t40-09-acceptance.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Acceptance wrapper for task #40 slice 9 (gen US04, 5 F55 ACs)
+set -euo pipefail
+export MSYS_NO_PATHCONV=1
+PASS=0; FAIL=0
+check() { if eval "$2"; then echo "  PASS: $1"; ((PASS++)); else echo "  FAIL: $1"; ((FAIL++)); fi; }
+
+echo "=== AC-1: eslint clean ==="
+check "eslint" "npx eslint .ai-workspace/plans/forge-generate-phase-PH-01.json >/dev/null 2>&1"
+
+echo "=== AC-2: all 5 ACs contain --reporter=json ==="
+COUNT=$(node -e "const j=JSON.parse(require('fs').readFileSync('.ai-workspace/plans/forge-generate-phase-PH-01.json','utf8')); const us=j.stories.find(s=>s.id==='PH01-US04'); const n=us.acceptanceCriteria.filter(ac=>ac.command.includes('--reporter=json')).length; console.log(n)")
+check "reporter-json-count" "[ '$COUNT' = '5' ]"
+
+echo "=== AC-3: zero grep -q in US04 vitest commands ==="
+GREPQ=$(node -e "const j=JSON.parse(require('fs').readFileSync('.ai-workspace/plans/forge-generate-phase-PH-01.json','utf8')); const us=j.stories.find(s=>s.id==='PH01-US04'); const n=us.acceptanceCriteria.filter(ac=>/vitest/.test(ac.command) && /grep -q/.test(ac.command)).length; console.log(n)")
+check "zero-grep-q" "[ '$GREPQ' = '0' ]"
+
+echo "=== AC-4: diff is 5+/5- ==="
+ADDED=$(git diff --numstat .ai-workspace/plans/forge-generate-phase-PH-01.json | awk '{print $1}')
+REMOVED=$(git diff --numstat .ai-workspace/plans/forge-generate-phase-PH-01.json | awk '{print $2}')
+check "diff-lines" "[ '$ADDED' = '5' ] && [ '$REMOVED' = '5' ]"
+
+echo "=== AC-5: diff confined to generate phase JSON ==="
+FILES=$(git diff --name-only)
+check "diff-scope" "[ '$FILES' = '.ai-workspace/plans/forge-generate-phase-PH-01.json' ]"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- Rewrite 5 hazardous `grep -q 'passed'` AC commands in PH01-US04 (generate phase, generator buildBrief) to use vitest `--reporter=json --outputFile` for subprocess-safe verification
- Part of task #40 slice 9 (44/66 F55 ACs done after this PR)

## Test plan
- [ ] Acceptance wrapper `scripts/q1-t40-09-acceptance.sh` passes all checks
- [ ] JSON is valid and lint-clean

---
plan-refresh: no-op