### PR TITLE
fix: remove unused CMD_PASS variable in q1-t40-05 acceptance wrapper

### DIFF
--- a/scripts/q1-t40-05-acceptance.sh
+++ b/scripts/q1-t40-05-acceptance.sh
@@ -23,7 +23,6 @@ if npx vitest run server/smoke/ac-lint.test.ts >/dev/null 2>&1; then pass; else 
 
 # AC-3: each rewritten command is executable (all 8 use valid syntax)
 step 3 "all $F55_COUNT rewritten commands parse as valid JSON+bash"
-CMD_PASS=0
 # Extract the 8 rewritten commands from the phase JSON and check each is syntactically valid bash
 COMMANDS=$(node -e "
 const fs = require('fs');


### PR DESCRIPTION
Closes #232

Auto-fix by /housekeep Stage 4.

`CMD_PASS=0` on line 26 of scripts/q1-t40-05-acceptance.sh was declared but never referenced — leftover from an earlier draft. Confirmed via grep that only this file had the pattern in the acceptance wrapper set.

Note: this commit also appears on `refactor/q1-t40-s09-gen-us04` due to a concurrent housekeep run — GitHub will dedupe on squash merge.