### PR TITLE
fix: note AC-4/AC-5 assume unstaged diff context

### DIFF
--- a/scripts/q1-t40-06-acceptance.sh
+++ b/scripts/q1-t40-06-acceptance.sh
@@ -48,6 +48,10 @@ run "AC-3 all 8 use reporter=json" bash -c '
   "
 '
 
+# AC-4 and AC-5 note: these checks rely on `git diff` (unstaged changes) and
+# assume a pre-commit self-check workflow — run them before staging/committing
+# the phase JSON, otherwise the diff will be empty and they will report FAIL.
+
 # AC-4: git diff --stat shows exactly 16 line changes (8 ins + 8 del) in the JSON
 run "AC-4 diff is 8+8=16" bash -c '
   STAT=$(git diff --numstat .ai-workspace/plans/forge-coordinate-phase-PH-01.json)


### PR DESCRIPTION
Closes #240

Auto-fix by /housekeep Stage 4 (stranded backlog).

Added a 3-line comment above the AC-4 block noting AC-4/AC-5 use `git diff` on unstaged changes and assume a pre-commit self-check workflow. Comment-only change; no logic modified.