### PR TITLE
fix: add dist/ build prerequisite guard to q1-t40-01 wrapper

### DIFF
--- a/scripts/q1-t40-01-acceptance.sh
+++ b/scripts/q1-t40-01-acceptance.sh
@@ -12,6 +12,14 @@ FAIL=0
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+# ---------------- dist/ build prerequisite guard ----------------
+# Wrapper runs compiled JS from dist/. If dist/ is missing or older than
+# server/ (TS sources), tests run against stale output. Issue #226.
+if [ ! -d "dist" ] || [ -n "$(find server -type f -newer dist 2>/dev/null | head -n 1)" ]; then
+  echo "ERROR: dist/ missing or stale. Run 'npm run build' first." >&2
+  exit 1
+fi
+
 PHASE_JSON=".ai-workspace/plans/forge-coordinate-phase-PH-01.json"
 STORY="PH01-US-00a"
 


### PR DESCRIPTION
Closes #226

Auto-fix by /housekeep Stage 4 (stranded backlog).

Added an 8-line guard after set -u/cd ROOT that exits 1 with 'Run npm run build first' message if dist/ is missing or any server/ file is newer than dist/. Catches the case where tests run against stale compiled output.