### PR TITLE
fix: extract emit_additional_context into shared hook-helpers.sh

### DIFF
--- a/scripts/ac-lint-hook.sh
+++ b/scripts/ac-lint-hook.sh
@@ -10,24 +10,12 @@ set -euo pipefail
 # M1 (explicit parse-failure diagnostic), M2 (linter-crashed additionalContext).
 # E3 (single-file lint passthrough) is deferred pending scripts/run-ac-lint.mjs
 # single-file support — see follow-up PR.
-
-emit_additional_context() {
-  # Emit a Claude Code PostToolUse additionalContext JSON to stdout.
-  # Reads the context body from stdin so bodies with special chars are
-  # JSON-escaped safely via node.
-  node -e '
-    let s = "";
-    process.stdin.on("data", d => s += d);
-    process.stdin.on("end", () => {
-      process.stdout.write(JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "PostToolUse",
-          additionalContext: s,
-        }
-      }));
-    });
-  '
-}
+#
+# emit_additional_context is now sourced from scripts/lib/hook-helpers.sh
+# (issue #186) so the JSON-safe emission path is shared with
+# retroactive-critique-hook.sh.
+# shellcheck source=lib/hook-helpers.sh
+source "$(dirname "$0")/lib/hook-helpers.sh"
 
 input="$(cat)"
 

--- a/scripts/lib/hook-helpers.sh
+++ b/scripts/lib/hook-helpers.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# scripts/lib/hook-helpers.sh
+#
+# Shared helpers for Claude Code PostToolUse hook scripts.
+#
+# Sourced (not executed) from scripts/*-hook.sh. Do NOT add `set -euo pipefail`
+# here — callers own their own error-handling mode. Do NOT rely on this file
+# being invoked directly; it exists purely to expose helper functions to the
+# caller's shell.
+#
+# Primary function: emit_additional_context
+#   - Reads the additionalContext body from stdin.
+#   - Emits a Claude Code PostToolUse hookSpecificOutput JSON object to stdout,
+#     with the body safely JSON-escaped via node's JSON.stringify.
+#   - Extracted from ac-lint-hook.sh to share the JSON-safe emission path with
+#     retroactive-critique-hook.sh, whose prior literal heredoc would silently
+#     produce malformed JSON if the directive ever interpolated a path or rule
+#     name. See issue #186.
+
+emit_additional_context() {
+  # Emit a Claude Code PostToolUse additionalContext JSON to stdout.
+  # Reads the context body from stdin so bodies with special chars are
+  # JSON-escaped safely via node.
+  node -e '
+    let s = "";
+    process.stdin.on("data", d => s += d);
+    process.stdin.on("end", () => {
+      process.stdout.write(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext: s,
+        }
+      }));
+    });
+  '
+}

--- a/scripts/retroactive-critique-hook.sh
+++ b/scripts/retroactive-critique-hook.sh
@@ -11,6 +11,13 @@ set -euo pipefail
 # 401 fallback: if MCP auth fails, the directive tells Claude to produce
 # {findings: [...]} in-session rather than fail-closed. The contract is the
 # JSON output schema, not the MCP call site.
+#
+# JSON emission is delegated to emit_additional_context from
+# scripts/lib/hook-helpers.sh (issue #186) so future edits to the directive
+# text can safely interpolate paths / rule names without producing malformed
+# JSON.
+# shellcheck source=lib/hook-helpers.sh
+source "$(dirname "$0")/lib/hook-helpers.sh"
 
 input="$(cat)"
 
@@ -77,12 +84,7 @@ if [[ -f "$hash_file" ]] && [[ "$(cat "$hash_file")" == "$content_hash" ]]; then
 fi
 printf '%s' "$content_hash" > "$hash_file"
 
-cat <<'JSON'
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PostToolUse",
-    "additionalContext": "A prompt-rule source file was just edited. Before producing your next response, you MUST invoke mcp__forge__forge_evaluate in critic mode against every .ai-workspace/plans/*.json file in this repo to detect drift between the updated rule set and existing plans. Surface all findings inline. Do not defer this to a later turn.\n\nIMPORTANT — 401/auth fallback: if the mcp__forge__forge_evaluate call fails with HTTP 401, OAuth error, or any authentication failure, DO NOT retry or abort. Instead, perform the critique in-session: read each .ai-workspace/plans/*.json file, apply the updated prompt-rule set manually, and produce a well-formed JSON object matching the MCP output schema: {\"findings\": [{\"acId\": \"...\", \"severity\": \"error|warning|info\", \"message\": \"...\", \"file\": \"...\", \"line\": null}]}. The contract is the output schema, not the call site."
-  }
-}
-JSON
+printf '%s' 'A prompt-rule source file was just edited. Before producing your next response, you MUST invoke mcp__forge__forge_evaluate in critic mode against every .ai-workspace/plans/*.json file in this repo to detect drift between the updated rule set and existing plans. Surface all findings inline. Do not defer this to a later turn.
+
+IMPORTANT — 401/auth fallback: if the mcp__forge__forge_evaluate call fails with HTTP 401, OAuth error, or any authentication failure, DO NOT retry or abort. Instead, perform the critique in-session: read each .ai-workspace/plans/*.json file, apply the updated prompt-rule set manually, and produce a well-formed JSON object matching the MCP output schema: {"findings": [{"acId": "...", "severity": "error|warning|info", "message": "...", "file": "...", "line": null}]}. The contract is the output schema, not the call site.' | emit_additional_context
 exit 0


### PR DESCRIPTION
Closes #186

Auto-fix by /housekeep Stage 4 (stranded backlog).

Created `scripts/lib/hook-helpers.sh` with a single `emit_additional_context` function. Both `retroactive-critique-hook.sh` and `ac-lint-hook.sh` now source it and emit context via the helper. JSON output is byte-semantically equivalent to the prior inline heredocs (newlines/quotes re-escaped via JSON.stringify).

Syntax check: `bash -n` passes for all three files.