### PR TITLE
fix: spec-vocabulary-check: use withFileTypes for directory detection

### DIFF
--- a/server/lib/spec-vocabulary-check.ts
+++ b/server/lib/spec-vocabulary-check.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -55,20 +56,19 @@ export async function parseTypeDefinitions(sourceDirs: ReadonlyArray<string>): P
 
 async function collectTsFiles(dir: string): Promise<string[]> {
   const results: string[] = [];
-  let entries: string[];
+  let entries: Dirent[];
   try {
-    entries = await readdir(dir);
+    entries = await readdir(dir, { withFileTypes: true });
   } catch {
     return results;
   }
 
-  for (const name of entries) {
-    const fullPath = join(dir, name);
-    if (name.endsWith(".ts") && !name.endsWith(".test.ts")) {
-      results.push(fullPath);
-    } else if (!name.includes(".")) {
-      // Likely a directory — recurse (readdir will fail gracefully if not)
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
       results.push(...(await collectTsFiles(fullPath)));
+    } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      results.push(fullPath);
     }
   }
 


### PR DESCRIPTION
Closes #144

Auto-fix by /housekeep Stage 4.

Refactor `collectTsFiles` in `server/lib/spec-vocabulary-check.ts` to use `readdir({withFileTypes: true})` + `dirent.isDirectory()/isFile()` instead of the fragile `!name.includes(".")` heuristic. External behavior preserved: same return type, same .ts files collected (excluding `*.test.ts`), same graceful failure on unreadable directories. tsc passes.