### PR TITLE
fix: spec-vocabulary-check: VOCAB gap IDs non-sequential

### DIFF
--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -300,9 +300,10 @@ async function handleCoherenceEval(
         ];
         const driftResults = await verifySpecVocabularyFromContent(input.prdContent, sourceDirs);
         const unknownFields = driftResults.filter((r) => r.kind === "unknown-field");
+        let vocabIdx = 1;
         for (const drift of unknownFields) {
           gaps.push({
-            id: `VOCAB-${gaps.length + 1}`,
+            id: `VOCAB-${vocabIdx++}`,
             severity: "MAJOR",
             sourceDocument: "prd",
             targetDocument: "phasePlan",


### PR DESCRIPTION
Closes #143

Auto-fix by /housekeep Stage 4.

Introduced a local `vocabIdx` counter initialized to 1 before the VOCAB gap loop and replaced `VOCAB-${gaps.length + 1}` with `VOCAB-${vocabIdx++}`. Produces sequential VOCAB-1, VOCAB-2, VOCAB-3 IDs regardless of any LLM-generated gaps already in the array.

HK-SAFE-8 scope: `server/tools/evaluate.ts` only.