### PR TITLE
fix: q1 task #62 + #63 — acceptance-script diff scope + generate-phase mktemp trap cleanup

### DIFF
--- a/.ai-workspace/plans/2026-04-17-q1-t62-63-acceptance-and-mktemp-polish.md
+++ b/.ai-workspace/plans/2026-04-17-q1-t62-63-acceptance-and-mktemp-polish.md
@@ -1,0 +1,99 @@
+# q1 task #62 + #63 — acceptance-script git-diff scope + generate-phase mktemp trap cleanup
+
+## Context
+
+Two independent defects discovered while verifying #62 and #63 via rule #9 (read target governance before accepting premise). Both are real; bundled in one PR because they touch adjacent areas (the q1 task-40 acceptance harness) and neither warrants a standalone slice.
+
+**Defect A — issue #240 only partially fixed.** Issue #240 was closed by PR #225 (trap cleanup + git-diff scope fixes), but the fix landed only in scripts `q1-t40-02..04-acceptance.sh`. Scripts `q1-t40-06..09-acceptance.sh` still invoke `git diff --numstat` without a base-branch ref. Post-commit, raw `git diff --numstat` compares the working tree to the index (not the feature branch to master), so the computed add/remove counts are wrong — typically zero when the tree is clean, which means any AC that reads those counts silently passes against fake data. Current offending lines:
+
+- `scripts/q1-t40-06-acceptance.sh:57` — `STAT=$(git diff --numstat .ai-workspace/plans/forge-coordinate-phase-PH-01.json)`
+- `scripts/q1-t40-07-acceptance.sh:35,36` — `$(git diff --numstat -- "$JSON" | awk ...)`
+- `scripts/q1-t40-08-acceptance.sh:22` — `STATS=$(git diff --numstat "$JSON")`
+- `scripts/q1-t40-09-acceptance.sh:20,21` — `$(git diff --numstat .ai-workspace/plans/forge-generate-phase-PH-01.json | awk ...)`
+
+Scripts `01` and `05` don't use `git diff --numstat` — a different shape — and are out of scope.
+
+**Defect B — issue #239 only partially fixed.** Issue #239's trap-cleanup sweep landed `trap 'rm -f "$TMP"' EXIT` in the *coord-phase* PH-01 JSON (34 of 34 mktemp AC commands, confirmed). The *generate-phase* PH-01 JSON was authored on a separate track and never received the sweep — current parity is 32 mktemp / 0 trap. On MSYS/Windows bash, un-trapped mktemp files accumulate in `$TMPDIR` indefinitely because the OS never GCs them on process exit. CI re-runs of the generate-phase phase harness therefore leak a new temp file per AC per run.
+
+**Why now.** Both fixes are small, mechanical, and unblock the task-40 harness's measurement integrity. #62 is load-bearing for any future AC that reads numstat counts (PR-body reporting, divergence measurement). #63 is cleanliness/hygiene but will leak indefinitely until fixed.
+
+**Rule #9 evidence.** Both defects were visible only by opening the target artefacts — closed-issue memory said "fixed," the files said otherwise. Issue status is a routing hint, not governance.
+
+## Goal
+
+1. Every script in `scripts/q1-t40-06..09-acceptance.sh` measures git diffs against `origin/master...HEAD` (or a semantically-equivalent base-branch ref) such that `git diff --numstat` reports the feature-branch's divergence from master, not working-tree-vs-index.
+2. `forge-generate-phase-PH-01.json` AC commands that use `mktemp` also trap-clean their temp file on EXIT, reaching parity with the coord-phase JSON (32 mktemp → 32 trap coverage).
+3. No existing AC behavior changes semantically except for the git-diff scope and the trap addition. No story restructuring, no AC renaming, no unrelated JSON edits.
+
+## Binary AC
+
+1. **AC-1 — all four scripts reference a base-branch-scoped diff**. `grep -c "origin/master\.\.\.HEAD\|master\.\.\.HEAD" scripts/q1-t40-06-acceptance.sh scripts/q1-t40-07-acceptance.sh scripts/q1-t40-08-acceptance.sh scripts/q1-t40-09-acceptance.sh` reports a non-zero match count for each file (each script has at least one match). Reviewer command: `MSYS_NO_PATHCONV=1 for f in scripts/q1-t40-0{6,7,8,9}-acceptance.sh; do c=$(grep -c "master\.\.\.HEAD" "$f"); echo "$f $c"; [ "$c" -ge 1 ] || exit 1; done`.
+
+2. **AC-2 — no raw, unscoped `git diff --numstat` remains in those scripts**. `grep -E "git diff --numstat( |$)[^o]" scripts/q1-t40-0{6,7,8,9}-acceptance.sh` returns zero matches (every `git diff --numstat` invocation is followed by an `origin/master...HEAD` or `master...HEAD` ref or a `--` separator preceded by the ref). Reviewer command: `grep -En "git diff --numstat" scripts/q1-t40-0{6,7,8,9}-acceptance.sh | grep -vE "master\.\.\.HEAD" | wc -l` returns `0`.
+
+3. **AC-3 — generate-phase mktemp/trap parity is 32/32**. `node -e` script walks `forge-generate-phase-PH-01.json`, counts occurrences of `mktemp` and `trap ['\"]?rm -f` across all AC `command` strings, asserts `mktemp >= 1 && mktemp === trap`. Reviewer command (see Verification Procedure for the full node script). On master at plan time: `mktemp=32, trap=0` (fail). After fix: `mktemp=32, trap=32` (pass).
+
+4. **AC-4 — per-AC mktemp/trap co-location**. Every `command` string in `forge-generate-phase-PH-01.json` that contains `mktemp` also contains a matching `trap` targeting the same variable. Reviewer runs the parity script which emits `MKTEMP-NO-TRAP @ <path>` for any offender; zero offenders required.
+
+5. **AC-5 — acceptance wrapper green**. `bash scripts/q1-t62-63-acceptance.sh` exits 0. The wrapper runs AC-1 through AC-4 in order and halts on first failure.
+
+6. **AC-6 — no drive-by edits**. `git diff --name-only origin/master...HEAD` returns only files matching the allowlist: `scripts/q1-t40-06-acceptance.sh`, `scripts/q1-t40-07-acceptance.sh`, `scripts/q1-t40-08-acceptance.sh`, `scripts/q1-t40-09-acceptance.sh`, `.ai-workspace/plans/forge-generate-phase-PH-01.json`, `.ai-workspace/plans/2026-04-17-q1-t62-63-acceptance-and-mktemp-polish.md`, `scripts/q1-t62-63-acceptance.sh`. Reviewer command: `MSYS_NO_PATHCONV=1 git diff --name-only origin/master...HEAD | grep -vE '^(scripts/q1-t40-0[6-9]-acceptance\.sh|\.ai-workspace/plans/forge-generate-phase-PH-01\.json|\.ai-workspace/plans/2026-04-17-q1-t62-63-acceptance-and-mktemp-polish\.md|scripts/q1-t62-63-acceptance\.sh)$' | wc -l` returns `0`.
+
+## Out of scope
+
+- Scripts `q1-t40-01-acceptance.sh`, `q1-t40-02-acceptance.sh`, `q1-t40-03-acceptance.sh`, `q1-t40-04-acceptance.sh`, `q1-t40-05-acceptance.sh` — do not touch. 02/03/04 already have the correct base-branch-scoped diff (PR #225); 01/05 use a different measurement shape.
+- `.ai-workspace/plans/forge-coordinate-phase-PH-01.json` — already 34/34 trap coverage; do not touch.
+- Any story/AC restructuring or renaming in the generate-phase JSON — only add `trap` lines, do not edit AC semantics or titles.
+- Re-opening or re-closing issues #239 / #240 — post-merge follow-up, not this PR's concern.
+- CHANGELOG / release bookkeeping — this is a content fix, not a release.
+- Fixing any lint / test / build / pack failure that pre-existed on master.
+
+## Verification procedure
+
+The reviewer runs each AC command in order and halts on first failure. Each command is copy-pasteable from the Binary AC section. For AC-3 and AC-4, the full parity script is:
+
+```bash
+MSYS_NO_PATHCONV=1 node -e "
+const fs = require('fs');
+const j = JSON.parse(fs.readFileSync('.ai-workspace/plans/forge-generate-phase-PH-01.json','utf8'));
+let mk=0, tr=0, offenders=[];
+const visit = (n,p='root') => {
+  if (typeof n === 'string') {
+    const m = (n.match(/mktemp/g)||[]).length;
+    const t = (n.match(/trap ['\"]?rm -f/g)||[]).length;
+    mk += m; tr += t;
+    if (m > 0 && t === 0) offenders.push(p);
+  } else if (Array.isArray(n)) n.forEach((v,i) => visit(v,p+'['+i+']'));
+  else if (n && typeof n === 'object') for (const k of Object.keys(n)) visit(n[k],p+'.'+k);
+};
+visit(j);
+console.log('mktemp='+mk+' trap='+tr+' offenders='+offenders.length);
+if (mk < 1 || mk !== tr || offenders.length > 0) { console.error('FAIL', offenders); process.exit(1); }
+"
+```
+
+After all 6 AC pass, reviewer returns PASS.
+
+## Critical files
+
+- `scripts/q1-t40-06-acceptance.sh` — audit-scope acceptance wrapper for story S0 / AC group; line 57 uses raw numstat on coord-phase JSON.
+- `scripts/q1-t40-07-acceptance.sh` — per-AC numstat on a parameterised `$JSON` target; lines 35-36.
+- `scripts/q1-t40-08-acceptance.sh` — single numstat on `$JSON`; line 22.
+- `scripts/q1-t40-09-acceptance.sh` — numstat on the generate-phase JSON specifically; lines 20-21.
+- `.ai-workspace/plans/forge-generate-phase-PH-01.json` — target for trap insertion; 32 mktemp AC commands need `trap 'rm -f "$TMP"' EXIT` inserted *after* `export TMP=$(mktemp)` and *before* the subsequent `&&`. Executor picks the exact line shape; the AC verifies co-location, not syntax.
+- `scripts/q1-t62-63-acceptance.sh` — new wrapper the executor authors per the brief's hard-rule; runs all 6 AC in order.
+- `.ai-workspace/plans/2026-04-17-q1-t62-63-acceptance-and-mktemp-polish.md` — this plan file.
+
+## Checkpoint
+
+- [x] Plan drafted — 2026-04-17
+- [x] Baseline measured on master: scripts 06-09 have 0 `master...HEAD` matches; generate-phase JSON has 32 mktemp / 0 trap
+- [ ] `/delegate` handoff to subagent
+- [ ] Executor ack received (status --porcelain, HEAD sha, tool manifest check)
+- [ ] Executor ships branch + wrapper green
+- [ ] Stateless reviewer PASS on all 6 AC
+- [ ] `/ship` merges PR
+- [ ] Tasks #62 and #63 marked completed
+- [ ] Post-merge: re-read generate-phase JSON from master to confirm 32/32 landed
+
+Last updated: 2026-04-17

--- a/.ai-workspace/plans/forge-generate-phase-PH-01.json
+++ b/.ai-workspace/plans/forge-generate-phase-PH-01.json
@@ -33,17 +33,17 @@
         {
           "id": "PH01-US01-AC03",
           "description": "Validation accepts plans with baselineCheck field without errors",
-          "command": "export TMP=$(mktemp) && npx vitest run server/validation/execution-plan.test.ts -t 'baselineCheck' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/validation/execution-plan.test.ts -t 'baselineCheck' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US01-AC04",
           "description": "Validation accepts stories with lineage field without errors",
-          "command": "export TMP=$(mktemp) && npx vitest run server/validation/execution-plan.test.ts -t 'lineage' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/validation/execution-plan.test.ts -t 'lineage' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US01-AC05",
           "description": "Existing validation tests still pass (backward compatibility)",
-          "command": "export TMP=$(mktemp) && npx vitest run server/validation/execution-plan.test.ts --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/validation/execution-plan.test.ts --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US01-AC06",
@@ -128,12 +128,12 @@
         {
           "id": "PH01-US03-AC03",
           "description": "loadPlan handles planJson precedence over planPath",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/plan-loader.test.ts -t 'precedence' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/plan-loader.test.ts -t 'precedence' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US03-AC04",
           "description": "Existing evaluate tests still pass after extraction",
-          "command": "export TMP=$(mktemp) && npx vitest run server/tools/evaluate.test.ts --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/tools/evaluate.test.ts --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US03-AC05",
@@ -157,27 +157,27 @@
         {
           "id": "PH01-US04-AC01",
           "description": "buildBrief returns GenerationBrief with story object from plan matching storyId",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*story' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*story' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US04-AC02",
           "description": "buildBrief returns codebaseContext string from scanCodebase",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*codebaseContext' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*codebaseContext' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US04-AC03",
           "description": "buildBrief returns gitBranch as feat/{storyId} (e.g. feat/US-01 for storyId US-01)",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*gitBranch' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*gitBranch' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US04-AC04",
           "description": "buildBrief returns baselineCheck from plan or defaults to 'npm run build && npm test'",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*baselineCheck' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*baselineCheck' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US04-AC05",
           "description": "buildBrief throws or returns error for non-existent storyId",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*not found\\|buildBrief.*invalid' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'buildBrief.*not found\\|buildBrief.*invalid' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         }
       ],
       "affectedPaths": [
@@ -194,32 +194,32 @@
         {
           "id": "PH01-US05-AC01",
           "description": "buildFixBrief extracts only FAIL criteria from eval report (skips PASS and SKIPPED)",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildFixBrief.*failedCriteria' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'buildFixBrief.*failedCriteria' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US05-AC02",
           "description": "computeScore returns PASS/non-SKIPPED ratio (e.g. 2 PASS, 1 FAIL, 1 SKIPPED = 0.667)",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'computeScore' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'computeScore' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US05-AC03",
           "description": "fixBrief.evalHint.failFastIds lists AC IDs ordered by priority (functionality first)",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'evalHint\\|failFast' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'evalHint\\|failFast' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US05-AC04",
           "description": "buildDiffManifest computes changed/unchanged/new arrays from current vs previous fileHashes",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'diffManifest\\|DiffManifest' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'diffManifest\\|DiffManifest' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US05-AC05",
           "description": "diffManifest is omitted when iteration is 0 (init call)",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'diffManifest.*init\\|init.*diffManifest\\|omitted.*iteration.0' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'diffManifest.*init\\|init.*diffManifest\\|omitted.*iteration.0' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US05-AC06",
           "description": "Each failed criterion includes id, description, and evidence fields",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'buildFixBrief.*evidence\\|failed.*evidence' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'buildFixBrief.*evidence\\|failed.*evidence' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         }
       ],
       "affectedPaths": [
@@ -236,42 +236,42 @@
         {
           "id": "PH01-US06-AC01",
           "description": "Plateau detection: previousScores [0.5, 0.5, 0.5] triggers escalation with reason 'plateau'",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'plateau' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'plateau' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US06-AC02",
           "description": "No-op detection: matching fileHashes triggers escalation with reason 'no-op'",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'no-op' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'no-op' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US06-AC03",
           "description": "Max iterations: iteration >= maxIterations triggers escalation with reason 'max-iterations'",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'max-iterations' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'max-iterations' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US06-AC04",
           "description": "INCONCLUSIVE: verdict INCONCLUSIVE triggers immediate escalation regardless of other conditions",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'inconclusive' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'inconclusive' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US06-AC05",
           "description": "Baseline-failed: escalation includes diagnostics with exitCode, stderr (truncated to 2000 chars), and failingTests",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'baseline-failed\\|baseline.*diagnostics' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'baseline-failed\\|baseline.*diagnostics' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US06-AC06",
           "description": "Continue when improving: previousScores [0.3, 0.5] does NOT trigger any stopping condition",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'continue when improving\\|continue.*improving' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'continue when improving\\|continue.*improving' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US06-AC07",
           "description": "INCONCLUSIVE takes precedence over all other stopping conditions",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'INCONCLUSIVE.*precedence\\|precedence.*INCONCLUSIVE' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'INCONCLUSIVE.*precedence\\|precedence.*INCONCLUSIVE' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US06-AC08",
           "description": "Plateau boundary case: previousScores [0.3, 0.5, 0.5] triggers plateau (improving then stuck)",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'plateau.*boundary\\|improving.*plateau\\|0.3.*0.5.*0.5' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'plateau.*boundary\\|improving.*plateau\\|0.3.*0.5.*0.5' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         }
       ],
       "affectedPaths": [
@@ -288,17 +288,17 @@
         {
           "id": "PH01-US07-AC01",
           "description": "Every escalation contains reason, description, hypothesis, lastEvalVerdict, and scoreHistory",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'escalation.*report\\|structured.*escalation' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'escalation.*report\\|structured.*escalation' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US07-AC02",
           "description": "Escalation description is specific to the failure reason (not generic)",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'escalation.*description\\|description.*specific' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'escalation.*description\\|description.*specific' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US07-AC03",
           "description": "Baseline-failed escalation has diagnostics; other reasons do not",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'diagnostics.*only.*baseline\\|baseline.*only.*diagnostics' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'diagnostics.*only.*baseline\\|baseline.*only.*diagnostics' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         }
       ],
       "affectedPaths": [
@@ -318,27 +318,27 @@
         {
           "id": "PH01-US08-AC01",
           "description": "assembleGenerateResult with no evalReport returns action 'implement' with GenerationBrief",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'assembleGenerateResult.*implement\\|orchestrator.*implement' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'assembleGenerateResult.*implement\\|orchestrator.*implement' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US08-AC02",
           "description": "assembleGenerateResult with FAIL evalReport returns action 'fix' with FixBrief when no stopping conditions met",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'assembleGenerateResult.*fix\\|orchestrator.*fix' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'assembleGenerateResult.*fix\\|orchestrator.*fix' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US08-AC03",
           "description": "assembleGenerateResult with PASS evalReport returns action 'pass'",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'assembleGenerateResult.*pass\\|orchestrator.*pass' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'assembleGenerateResult.*pass\\|orchestrator.*pass' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US08-AC04",
           "description": "assembleGenerateResult with stopping condition returns action 'escalate' with Escalation",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts -t 'assembleGenerateResult.*escalate\\|orchestrator.*escalate' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts -t 'assembleGenerateResult.*escalate\\|orchestrator.*escalate' --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US08-AC05",
           "description": "All PH-01 unit tests pass together",
-          "command": "export TMP=$(mktemp) && npx vitest run server/lib/generator.test.ts --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
+          "command": "export TMP=$(mktemp) && trap 'rm -f \"$TMP\"' EXIT && npx vitest run server/lib/generator.test.ts --reporter=json --outputFile=\"$TMP\" >/dev/null 2>&1; node -e \"const r=JSON.parse(require('fs').readFileSync(process.env.TMP,'utf8')); process.exit(r.success && r.numFailedTests===0 ? 0 : 1)\""
         },
         {
           "id": "PH01-US08-AC06",

--- a/scripts/q1-t40-06-acceptance.sh
+++ b/scripts/q1-t40-06-acceptance.sh
@@ -48,13 +48,13 @@ run "AC-3 all 8 use reporter=json" bash -c '
   "
 '
 
-# AC-4 and AC-5 note: these checks rely on `git diff` (unstaged changes) and
-# assume a pre-commit self-check workflow — run them before staging/committing
-# the phase JSON, otherwise the diff will be empty and they will report FAIL.
+# AC-4 and AC-5 measure branch divergence from master using `origin/master...HEAD`,
+# so they work post-commit (comparing feature branch to master) rather than
+# measuring working-tree-vs-index (which is empty post-commit).
 
 # AC-4: git diff --stat shows exactly 16 line changes (8 ins + 8 del) in the JSON
 run "AC-4 diff is 8+8=16" bash -c '
-  STAT=$(git diff --numstat .ai-workspace/plans/forge-coordinate-phase-PH-01.json)
+  STAT=$(git diff --numstat origin/master...HEAD -- .ai-workspace/plans/forge-coordinate-phase-PH-01.json)
   ADDED=$(echo "$STAT" | awk "{print \$1}")
   REMOVED=$(echo "$STAT" | awk "{print \$2}")
   if [ "$ADDED" = "8" ] && [ "$REMOVED" = "8" ]; then
@@ -67,7 +67,7 @@ run "AC-4 diff is 8+8=16" bash -c '
 
 # AC-5: diff confined to the phase JSON only
 run "AC-5 diff confined to phase JSON" bash -c '
-  FILES=$(git diff --name-only)
+  FILES=$(git diff --name-only origin/master...HEAD)
   if [ "$FILES" = ".ai-workspace/plans/forge-coordinate-phase-PH-01.json" ]; then
     echo "OK: only phase JSON changed"
   else

--- a/scripts/q1-t40-07-acceptance.sh
+++ b/scripts/q1-t40-07-acceptance.sh
@@ -32,8 +32,8 @@ done
 
 echo ""
 echo "=== AC3: git diff shows exactly 3 added, 3 removed ==="
-ADDED=$(git diff --numstat -- "$JSON" | awk '{print $1}')
-REMOVED=$(git diff --numstat -- "$JSON" | awk '{print $2}')
+ADDED=$(git diff --numstat origin/master...HEAD -- "$JSON" | awk '{print $1}')
+REMOVED=$(git diff --numstat origin/master...HEAD -- "$JSON" | awk '{print $2}')
 if [[ "$ADDED" == "3" && "$REMOVED" == "3" ]]; then
   echo "PASS: 3 added, 3 removed"
 else
@@ -43,7 +43,7 @@ fi
 
 echo ""
 echo "=== AC4: diff confined to generate phase JSON only ==="
-CHANGED=$(git diff --name-only)
+CHANGED=$(git diff --name-only origin/master...HEAD)
 if [[ "$CHANGED" == "$JSON" ]]; then
   echo "PASS: only $JSON changed"
 else

--- a/scripts/q1-t40-08-acceptance.sh
+++ b/scripts/q1-t40-08-acceptance.sh
@@ -19,13 +19,13 @@ node -e "const j=JSON.parse(require('fs').readFileSync('$JSON','utf8')); const s
 node -e "const j=JSON.parse(require('fs').readFileSync('$JSON','utf8')); const s=j.stories.find(s=>s.id==='PH01-US03'); const ac=s.acceptanceCriteria.find(a=>a.id==='PH01-US03-AC04'); process.exit(ac.command.includes('--reporter=json') ? 0 : 1)"; report "AC04 contains --reporter=json" $?
 
 # 4. git diff shows exactly 2 insertions and 2 deletions
-STATS=$(git diff --numstat "$JSON")
+STATS=$(git diff --numstat origin/master...HEAD -- "$JSON")
 ADDS=$(echo "$STATS" | awk '{print $1}')
 DELS=$(echo "$STATS" | awk '{print $2}')
 [[ "$ADDS" == "2" && "$DELS" == "2" ]]; report "git diff shows exactly 2+/2-" $?
 
 # 5. diff confined to generate phase JSON only
-FILES=$(git diff --name-only)
+FILES=$(git diff --name-only origin/master...HEAD)
 [[ "$FILES" == "$JSON" ]]; report "diff confined to generate phase JSON only" $?
 
 echo ""

--- a/scripts/q1-t40-09-acceptance.sh
+++ b/scripts/q1-t40-09-acceptance.sh
@@ -17,12 +17,12 @@ GREPQ=$(node -e "const j=JSON.parse(require('fs').readFileSync('.ai-workspace/pl
 check "zero-grep-q" "[ '$GREPQ' = '0' ]"
 
 echo "=== AC-4: diff is 5+/5- ==="
-ADDED=$(git diff --numstat .ai-workspace/plans/forge-generate-phase-PH-01.json | awk '{print $1}')
-REMOVED=$(git diff --numstat .ai-workspace/plans/forge-generate-phase-PH-01.json | awk '{print $2}')
+ADDED=$(git diff --numstat origin/master...HEAD -- .ai-workspace/plans/forge-generate-phase-PH-01.json | awk '{print $1}')
+REMOVED=$(git diff --numstat origin/master...HEAD -- .ai-workspace/plans/forge-generate-phase-PH-01.json | awk '{print $2}')
 check "diff-lines" "[ '$ADDED' = '5' ] && [ '$REMOVED' = '5' ]"
 
 echo "=== AC-5: diff confined to generate phase JSON ==="
-FILES=$(git diff --name-only)
+FILES=$(git diff --name-only origin/master...HEAD)
 check "diff-scope" "[ '$FILES' = '.ai-workspace/plans/forge-generate-phase-PH-01.json' ]"
 
 echo ""

--- a/scripts/q1-t62-63-acceptance.sh
+++ b/scripts/q1-t62-63-acceptance.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Acceptance wrapper for q1 tasks #62 + #63 — runs AC-1 through AC-6 in order,
+# halts on first failure, and exits 0 only if every AC passes.
+#
+# AC list:
+#   AC-1: scripts 06-09 reference a base-branch-scoped diff (master...HEAD)
+#   AC-2: no raw unscoped `git diff --numstat` remains in scripts 06-09
+#   AC-3: generate-phase JSON mktemp/trap parity is 32/32 globally
+#   AC-4: every mktemp command in generate-phase JSON has a matching trap
+#         (AC-3 parity script also emits offenders for AC-4)
+#   AC-5: this wrapper itself exits 0 (self-referential — AC-5 passes iff
+#         AC-1..AC-4 + AC-6 all pass)
+#   AC-6: no drive-by edits — only files in the allowlist are modified
+#         relative to origin/master...HEAD
+
+set -euo pipefail
+export MSYS_NO_PATHCONV=1
+
+PASS=0; FAIL=0
+
+check() {
+  local label="$1"; shift
+  if "$@"; then
+    echo "  PASS  $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $label"
+    FAIL=$((FAIL + 1))
+    return 1
+  fi
+}
+
+ac1_base_branch_scoped() {
+  for f in scripts/q1-t40-06-acceptance.sh scripts/q1-t40-07-acceptance.sh scripts/q1-t40-08-acceptance.sh scripts/q1-t40-09-acceptance.sh; do
+    local c
+    c=$(grep -c "master\.\.\.HEAD" "$f" || true)
+    if [ "$c" -lt 1 ]; then
+      echo "    $f has $c matches (need >= 1)"
+      return 1
+    fi
+  done
+  return 0
+}
+
+ac2_no_unscoped_numstat() {
+  local bad
+  bad=$(grep -En "git diff --numstat" \
+    scripts/q1-t40-06-acceptance.sh \
+    scripts/q1-t40-07-acceptance.sh \
+    scripts/q1-t40-08-acceptance.sh \
+    scripts/q1-t40-09-acceptance.sh \
+    | grep -vE "master\.\.\.HEAD" || true)
+  if [ -n "$bad" ]; then
+    echo "    Unscoped numstat calls found:"
+    echo "$bad" | sed 's/^/      /'
+    return 1
+  fi
+  return 0
+}
+
+ac3_ac4_parity_and_colocation() {
+  node -e '
+    const fs = require("fs");
+    const j = JSON.parse(fs.readFileSync(".ai-workspace/plans/forge-generate-phase-PH-01.json","utf8"));
+    let mk=0, tr=0, offenders=[];
+    const visit = (n,p="root") => {
+      if (typeof n === "string") {
+        const m = (n.match(/mktemp/g)||[]).length;
+        const t = (n.match(/trap [\x27"]?rm -f/g)||[]).length;
+        mk += m; tr += t;
+        if (m > 0 && t === 0) offenders.push(p);
+      } else if (Array.isArray(n)) n.forEach((v,i) => visit(v,p+"["+i+"]"));
+      else if (n && typeof n === "object") for (const k of Object.keys(n)) visit(n[k],p+"."+k);
+    };
+    visit(j);
+    console.log("    mktemp="+mk+" trap="+tr+" offenders="+offenders.length);
+    if (mk < 1 || mk !== tr || offenders.length > 0) {
+      console.error("    FAIL offenders:", offenders);
+      process.exit(1);
+    }
+  '
+}
+
+ac6_no_drive_by_edits() {
+  local allowed_regex='^(scripts/q1-t40-0[6-9]-acceptance\.sh|\.ai-workspace/plans/forge-generate-phase-PH-01\.json|\.ai-workspace/plans/2026-04-17-q1-t62-63-acceptance-and-mktemp-polish\.md|scripts/q1-t62-63-acceptance\.sh)$'
+  local bad
+  bad=$(git diff --name-only origin/master...HEAD | grep -vE "$allowed_regex" || true)
+  if [ -n "$bad" ]; then
+    echo "    Unexpected files in diff:"
+    echo "$bad" | sed 's/^/      /'
+    return 1
+  fi
+  return 0
+}
+
+echo "=== q1 task #62 + #63 acceptance wrapper ==="
+echo ""
+
+echo "AC-1: scripts 06-09 reference a base-branch-scoped diff"
+check "AC-1 base-branch-scoped diff" ac1_base_branch_scoped || exit 1
+echo ""
+
+echo "AC-2: no raw unscoped numstat remains in scripts 06-09"
+check "AC-2 no unscoped numstat" ac2_no_unscoped_numstat || exit 1
+echo ""
+
+echo "AC-3 + AC-4: generate-phase JSON mktemp/trap parity and co-location"
+check "AC-3/AC-4 parity + co-location" ac3_ac4_parity_and_colocation || exit 1
+echo ""
+
+echo "AC-6: no drive-by edits (allowlist enforcement)"
+check "AC-6 no drive-by edits" ac6_no_drive_by_edits || exit 1
+echo ""
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -eq 0 ]; then
+  echo "AC-5 (wrapper green): PASS"
+  exit 0
+else
+  echo "AC-5 (wrapper green): FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- **#62 (issue #240, partial re-fix):** scope `git diff --numstat` to `origin/master...HEAD` in scripts `q1-t40-06..09-acceptance.sh`. PR #225 fixed scripts 01–04 only; 06–09 still used raw numstat, which measures working-tree-vs-index (typically zero post-commit), so downstream ACs reading those counts were passing against fake data.
- **#63 (issue #239, partial re-fix):** insert `trap 'rm -f "$TMP"' EXIT` in all 32 mktemp-using AC commands in `forge-generate-phase-PH-01.json`, reaching parity with the coord-phase JSON (34/34, already fixed by PR #225). Without the trap, Windows/MSYS temp files leak per CI run.
- **New acceptance wrapper** at `scripts/q1-t62-63-acceptance.sh` runs all 6 AC in order and exits 0 iff all pass. Stateless reviewer PASS on all 6.

Rule #9 evidence: both defects were visible only by reading the artefacts directly — closed-issue status said "fixed," the files said otherwise. The plan captures the before/after diff for future auditors.

## Test plan
- [x] `bash scripts/q1-t62-63-acceptance.sh` exits 0
- [x] All four scripts (06/07/08/09) grep-match `master...HEAD` at least once (counts: 3/3/2/3)
- [x] No raw unscoped `git diff --numstat` remains in scripts 06–09 (count: 0)
- [x] `forge-generate-phase-PH-01.json` parity: mktemp=32, trap=32, offenders=0
- [x] Diff scope matches allowlist (7 files: 4 scripts + 1 JSON + 1 plan + 1 wrapper)
- [x] Stateless reviewer PASS on all 6 AC

---
plan-refresh: no-op