### PR TITLE
fix: add typeof guard for oauth.expiresAt in readOAuthToken

### DIFF
--- a/server/lib/anthropic.ts
+++ b/server/lib/anthropic.ts
@@ -18,8 +18,8 @@ function readOAuthToken(): { accessToken: string; expiresAt: number } | null {
   try {
     const credPath = join(homedir(), ".claude", ".credentials.json");
     const creds = JSON.parse(readFileSync(credPath, "utf-8"));
-    const oauth = creds.claudeAiOauth as { accessToken?: string; expiresAt?: number } | undefined;
-    if (!oauth?.accessToken || !oauth?.expiresAt) return null;
+    const oauth = creds.claudeAiOauth as { accessToken?: unknown; expiresAt?: unknown } | undefined;
+    if (typeof oauth?.accessToken !== "string" || typeof oauth?.expiresAt !== "number") return null;
 
     // Check expiry — reject if less than 5 minutes remaining
     const remainingMs = oauth.expiresAt - Date.now();


### PR DESCRIPTION
Closes #19

Auto-fix by /housekeep Stage 4.

The previous cast assumed `accessToken: string` and `expiresAt: number`
without runtime validation. If `.credentials.json` stored `expiresAt` as
an ISO string (e.g. from an older or different tool), the subsequent
`oauth.expiresAt - Date.now()` arithmetic would produce NaN and silently
return null via the `< 5 * 60 * 1000` comparison — hiding the schema drift.

Typed the raw oauth object as `unknown` fields and replaced the
truthy-only check with `typeof` guards so mismatched types are rejected
up front instead of silently coerced.