### PR TITLE
feat(dashboard): env-gated browser auto-open + fix AC-07 fixture drift

### DIFF
--- a/scripts/s8-kanban-dashboard-acceptance.sh
+++ b/scripts/s8-kanban-dashboard-acceptance.sh
@@ -76,9 +76,24 @@ JSON
 
 # RunRecords marking US-01 through US-04 PASS. Cost per run = $2.15/4 so
 # the aggregated budget.usedUsd is $2.15 total (matching AC-07).
+#
+# Timestamps are generated relative to NOW (60s ago + 1..4s offset) so they
+# fall inside the driver's `currentPlanStartTimeMs = Date.now() - 5min`
+# window at server/lib/coordinator.ts:314. Previously the fixture used
+# hardcoded absolute timestamps which drifted outside the window, causing
+# assessPhase to silently skip them and AC-07 to fail.
+TS_LIST=($(node -e '
+  const base = Date.now() - 60000;
+  const parts = [];
+  for (let i = 1; i <= 4; i++) parts.push(new Date(base + i * 1000).toISOString());
+  process.stdout.write(parts.join(" "));
+'))
 for n in 01 02 03 04; do
-  ts="2026-04-18T10:00:0${n:1}.000Z"
-  safe_ts="2026-04-18T10-00-0${n:1}-000Z"
+  idx=$((10#$n - 1))
+  ts="${TS_LIST[$idx]}"
+  # filesystem-safe variant: replace ':' and '.' with '-'
+  safe_ts="${ts//:/-}"
+  safe_ts="${safe_ts//./-}"
   # $2.15 / 4 = $0.5375 per record. Four records sum to exactly $2.15.
   cat > "$FIXTURE_DIR/.forge/runs/forge_evaluate-${safe_ts}-00${n}.json" <<JSON_INNER
 {

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -28,7 +28,8 @@
  *     (exposed for unit tests that supply known inputs directly).
  */
 
-import { writeFile, rename, mkdir, readFile } from "node:fs/promises";
+import { writeFile, rename, mkdir, readFile, stat } from "node:fs/promises";
+import { spawn } from "node:child_process";
 import { join, basename } from "node:path";
 import type {
   PhaseTransitionBrief,
@@ -599,11 +600,64 @@ export async function writeDashboardHtml(
 }
 
 /**
+ * Open the dashboard in the user's default browser — env-gated, one-shot.
+ *
+ * Gates (both must hold):
+ *   1. `FORGE_DASHBOARD_AUTO_OPEN=1` in the environment (opt-in; default off
+ *      so `npm test`, CI, and MCP servers launched without the flag never
+ *      spawn a browser).
+ *   2. Marker `.forge/.dashboard-opened` must be absent. First successful
+ *      open writes the marker; subsequent renders are no-ops. Delete the
+ *      marker to re-open the tab (e.g. after closing it accidentally).
+ *
+ * Uses spawn with an argv array (no shell interpolation) to avoid any
+ * command-injection surface on user-controlled projectPath values. The
+ * child is detached + unreffed so the MCP process exits independently.
+ *
+ * Failure-swallowed per the parent renderer's error policy.
+ */
+async function maybeAutoOpenBrowser(projectPath: string): Promise<void> {
+  if (process.env.FORGE_DASHBOARD_AUTO_OPEN !== "1") return;
+
+  const markerPath = join(projectPath, ".forge", ".dashboard-opened");
+  try {
+    await stat(markerPath);
+    return;
+  } catch {
+    /* marker absent — proceed to open */
+  }
+
+  try {
+    const dashboardPath = join(projectPath, ".forge", "dashboard.html");
+    const child =
+      process.platform === "win32"
+        ? spawn("cmd", ["/c", "start", "", dashboardPath], { detached: true, stdio: "ignore" })
+        : process.platform === "darwin"
+          ? spawn("open", [dashboardPath], { detached: true, stdio: "ignore" })
+          : spawn("xdg-open", [dashboardPath], { detached: true, stdio: "ignore" });
+    child.on("error", (err) => {
+      console.error("forge: dashboard auto-open spawn failed (continuing):", err.message);
+    });
+    child.unref();
+    await writeFile(markerPath, new Date().toISOString(), "utf-8");
+  } catch (err) {
+    console.error(
+      "forge: dashboard auto-open failed (continuing):",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+/**
  * Render the dashboard and write it to `.forge/dashboard.html`.
  *
  * Error policy: all I/O wrapped in a single try/catch. Any failure is
  * logged to stderr and swallowed — the parent tool's invocation is never
  * affected by a dashboard problem.
+ *
+ * Optional auto-open: if the environment variable FORGE_DASHBOARD_AUTO_OPEN
+ * is "1", the first successful render also spawns the OS-native browser
+ * against the rendered file. See maybeAutoOpenBrowser() for full gating.
  *
  * The `io` parameter is a test seam only; production callers omit it.
  */
@@ -624,6 +678,7 @@ export async function renderDashboard(
       renderedAt: new Date().toISOString(),
     });
     await writeDashboardHtml(projectPath, html, io);
+    await maybeAutoOpenBrowser(projectPath);
   } catch (err) {
     console.error(
       "forge: failed to render dashboard (continuing):",


### PR DESCRIPTION
## Summary

Two cohesive dashboard improvements uncovered while verifying the S8 Kanban dashboard is ready/live for an adjacent Claude Code session running monday-bot work through forge-harness.

- **Auto-open (opt-in):** `renderDashboard()` now spawns the OS-native browser on the first render when `FORGE_DASHBOARD_AUTO_OPEN=1`. Gated by both the env var and a `.forge/.dashboard-opened` marker so it opens exactly once per project session. `spawn` + argv array (no shell interpolation) and `detached`+`unref` (MCP process stays independent).
- **Wrapper fix (AC-07):** `scripts/s8-kanban-dashboard-acceptance.sh` built its fixture with hardcoded past timestamps, but the driver passes `currentPlanStartTimeMs = Date.now() - 5min`. Under assessPhase's time-window filter (`coordinator.ts:314`) those records were silently dropped, so the rendered header read `0/9` and AC-07 failed on every post-merge run. CI never caught it because no workflow invokes this wrapper. Fix: generate timestamps relative to `Date.now() - 60s`.

## Why now

The monday-bot session will drive `forge_coordinate` calls against forge-harness's MCP server. Two concrete wins from this PR:

1. Users can set `FORGE_DASHBOARD_AUTO_OPEN=1` in `.mcp.json`'s env block so the dashboard appears automatically on the first coordinate call — no manual `start .forge/dashboard.html` needed.
2. The acceptance wrapper becomes trustworthy again, so the next dashboard refactor has a working green baseline.

## Test plan

- [x] `npm run build` — exits 0
- [x] `npm test` — 744 pass / 4 skipped / 0 fail (no regressions from the new spawn path, which is env-gated off in tests)
- [x] `npx vitest run server/smoke/mcp-surface.test.ts` — 6 pass
- [x] `bash scripts/s8-kanban-dashboard-acceptance.sh` — 15 pass / 0 fail (was 14/1 on master)
- [ ] Manual: set `FORGE_DASHBOARD_AUTO_OPEN=1`, invoke `forge_coordinate`, verify browser opens exactly once and meta-refresh updates the view

## Follow-up worth considering (not in this PR)

CI has no job that runs the S8 acceptance wrapper. Worth adding a workflow gate so fixture drift can't silently regress AC-07 again. Deferred — not blocking.

index-check: none

plan-refresh: no-op