### PR TITLE
ci(workflows): wire S8 Kanban dashboard acceptance wrapper into CI (closes #284)

### DIFF
--- a/.ai-workspace/plans/2026-04-19-ci-s8-acceptance-wrapper.md
+++ b/.ai-workspace/plans/2026-04-19-ci-s8-acceptance-wrapper.md
@@ -1,0 +1,62 @@
+# Plan: CI wrapper workflow for S8 Kanban dashboard acceptance
+
+## ELI5
+
+The S8 dashboard has a long acceptance test (`scripts/s8-kanban-dashboard-acceptance.sh`) that verifies the Kanban view renders correctly. Today, nobody runs it automatically — it's a manual-only artifact. That's how a fixture bug slipped past the original merge in #269 and had to be caught by PR #280 a day later. This plan adds a GitHub Actions workflow that runs the wrapper on any PR touching the dashboard stack, so the same class of drift can't hide again.
+
+## Context
+
+- Closes forge-harness issue #284 (filed during PR #280 ship-review as an enhancement).
+- The wrapper already exists and exits 0 with 15/15 AC PASS on current master (verified at shipping of PR #280).
+- PR #280's post-ship summary explicitly flagged this gap as "Follow-up worth considering (not in this PR)".
+- Existing workflows follow a standard pattern: `actions/checkout@v4` → `actions/setup-node@v4` (node 20, npm cache) → `npm ci --ignore-scripts` → job-specific step. Build step uses `npm run build`.
+- The wrapper internally runs `npm run build` + `npm test` + `npx vitest run server/smoke/mcp-surface.test.ts` as AC-17, then drives `handleCoordinate` against a fixture and greps the rendered HTML. Self-contained; no additional setup needed beyond `npm ci`.
+
+## Goal
+
+Invariants when this ships:
+1. Any PR touching the dashboard stack (`server/lib/{dashboard-renderer,coordinator,progress,run-record,activity}.ts` or `scripts/s8-kanban-dashboard-acceptance.sh` or the new workflow file itself) runs the acceptance wrapper as a PR check.
+2. The check passes on current master and on PR #280's merge commit — no false red.
+3. The check is visible in `gh pr checks <pr-number>` output for gated PRs.
+
+## Binary AC
+
+1. **File exists:** `.github/workflows/s8-kanban-dashboard-acceptance.yml` present after merge. Check: `test -f .github/workflows/s8-kanban-dashboard-acceptance.yml`.
+2. **Path filter applied:** the workflow's `on.pull_request.paths` array contains all 7 gated paths as literal strings. Check: `grep -c 'server/lib/dashboard-renderer.ts\|server/lib/coordinator.ts\|server/lib/progress.ts\|server/lib/run-record.ts\|server/lib/activity.ts\|scripts/s8-kanban-dashboard-acceptance.sh\|.github/workflows/s8-kanban-dashboard-acceptance.yml' .github/workflows/s8-kanban-dashboard-acceptance.yml` returns ≥ 7.
+3. **Wrapper invocation:** workflow contains a step that runs `bash scripts/s8-kanban-dashboard-acceptance.sh`. Check: `grep -F 'bash scripts/s8-kanban-dashboard-acceptance.sh' .github/workflows/s8-kanban-dashboard-acceptance.yml` returns non-empty.
+4. **Live PR run succeeds:** `gh pr checks <plan-pr-number>` includes a line whose check name matches the new workflow with `conclusion: SUCCESS`.
+5. **No CI regression:** all pre-existing checks (`build (ubuntu-latest, 20)`, `build (windows-latest, 20)`, `smoke-gate (report-only)`) still appear with `conclusion: SUCCESS` on the PR.
+
+## Out of scope
+
+- Making the new workflow a required check under branch protection (that's an admin action, not a code change).
+- Refactoring the wrapper (e.g., skipping AC-17 redundant with ci.yml) — stays self-contained.
+- Cross-platform matrix (ubuntu-only is sufficient; the wrapper's bash-ism + bash-specific node-e patterns would complicate Windows setup and ci.yml already covers Windows build health).
+- Speeding up the wrapper; the full run is ~90s on ubuntu which is acceptable for a path-filtered gate.
+- Adjacent issues #281/#282/#283 — they each get their own PR later.
+
+## Ordering constraints
+
+None. This is a single-file workflow add; no dependencies on other in-flight work.
+
+## Verification procedure
+
+1. `test -f .github/workflows/s8-kanban-dashboard-acceptance.yml` — exit 0.
+2. `grep -c 'server/lib/dashboard-renderer.ts' .github/workflows/s8-kanban-dashboard-acceptance.yml` ≥ 1 (and repeat for the other 6 gated paths).
+3. After PR opens, `gh pr checks <pr-number>` shows the new check name with `pass` conclusion. Wait up to 10 min; the wrapper runs `npm test` which takes ~25s plus build + wrapper ACs.
+4. Spot-check the workflow run log via `gh run view <run-id> --log` to confirm the wrapper's own 15/15 PASS summary appears.
+
+## Critical files
+
+- `.github/workflows/s8-kanban-dashboard-acceptance.yml` — new workflow. Single-file change.
+
+## Checkpoint
+
+- [ ] Plan written + critiqued
+- [ ] Workflow file authored
+- [ ] Local YAML syntax sanity-check (file parses as valid YAML)
+- [ ] Ship via /ship — PR opened, CI runs on the PR (the workflow runs on itself because the workflow path is self-gated)
+- [ ] New check passes on the PR
+- [ ] Merge + close issue #284
+
+Last updated: 2026-04-19T13:30:00+08:00 — plan draft, queued for critique.

--- a/.github/workflows/s8-kanban-dashboard-acceptance.yml
+++ b/.github/workflows/s8-kanban-dashboard-acceptance.yml
@@ -1,0 +1,32 @@
+name: s8-kanban-dashboard-acceptance
+
+on:
+  pull_request:
+    paths:
+      - 'server/lib/dashboard-renderer.ts'
+      - 'server/lib/coordinator.ts'
+      - 'server/lib/progress.ts'
+      - 'server/lib/run-record.ts'
+      - 'server/lib/activity.ts'
+      - 'scripts/s8-kanban-dashboard-acceptance.sh'
+      - '.github/workflows/s8-kanban-dashboard-acceptance.yml'
+
+jobs:
+  acceptance:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run S8 Kanban dashboard acceptance wrapper
+        shell: bash
+        run: bash scripts/s8-kanban-dashboard-acceptance.sh


### PR DESCRIPTION
## Summary

Adds a path-filtered GH Actions workflow that runs `scripts/s8-kanban-dashboard-acceptance.sh` on any PR touching the S8 dashboard stack. Prevents the exact class of fixture drift that regressed AC-07 between PR #269 (original S8 merge) and PR #280 (the fix).

- **Trigger paths:** `server/lib/{dashboard-renderer,coordinator,progress,run-record,activity}.ts`, `scripts/s8-kanban-dashboard-acceptance.sh`, `.github/workflows/s8-kanban-dashboard-acceptance.yml`
- **Runner:** ubuntu-latest only (ci.yml already covers Windows build health)
- **Invocation:** full wrapper via `bash scripts/s8-kanban-dashboard-acceptance.sh` — keeps the wrapper self-contained and adds ~90s to gated PRs
- **Closes #284**

## Test plan

- [x] Plan written at `.ai-workspace/plans/2026-04-19-ci-s8-acceptance-wrapper.md`
- [x] AC-1 — `.github/workflows/s8-kanban-dashboard-acceptance.yml` exists
- [x] AC-2 — all 7 gated paths appear as literal strings in `on.pull_request.paths`
- [x] AC-3 — workflow contains `bash scripts/s8-kanban-dashboard-acceptance.sh`
- [ ] AC-4 — new workflow check passes on this PR (the workflow is self-gated — it runs on itself because `.github/workflows/s8-kanban-dashboard-acceptance.yml` is in its own path filter)
- [ ] AC-5 — no regression in pre-existing checks (`build (ubuntu-latest, 20)`, `build (windows-latest, 20)`, `smoke-gate (report-only)`)

## Out of scope

- Making the new workflow a required check under branch protection (separate admin action).
- Refactoring the wrapper to skip AC-17's build+test duplication with ci.yml.
- Cross-platform matrix (ubuntu-only; ci.yml already covers Windows).
- Follow-up issues #281/#282/#283 — each gets its own PR.

---

plan-refresh: no-op

index-check: none