### PR TITLE
fix(dashboard): harden auto-open path per ship-review findings (closes #281 #282 #283)

### DIFF
--- a/.ai-workspace/plans/2026-04-19-dashboard-auto-open-hardening.md
+++ b/.ai-workspace/plans/2026-04-19-dashboard-auto-open-hardening.md
@@ -1,0 +1,70 @@
+# Plan: dashboard auto-open hardening (bundled #281/#282/#283)
+
+## ELI5
+
+PR #280's env-gated browser auto-open shipped with three small holes the ship-review flagged:
+- **#281** — the "already opened" marker is written immediately after `spawn()` returns, not after the child actually launched. If `xdg-open` is missing, the marker still lands and permanently disables auto-open.
+- **#282** — the auto-open helper bypasses the module's `DashboardIo` test seam, so its behavior is effectively untestable without filesystem side effects.
+- **#283** — the `stat(markerPath)` catch is a bare `catch {}` that treats any stat failure as "marker absent", so EPERM/EIO would re-open a tab on every render.
+
+All three live in `maybeAutoOpenBrowser()` in `server/lib/dashboard-renderer.ts`. Bundling as one PR because they're one function.
+
+## Context
+
+- Opened by ship-review on PR #280 as enhancement issues #281, #282, #283.
+- None are blocking. The env-gate (`FORGE_DASHBOARD_AUTO_OPEN=1`) means production impact is scoped to users who opted in; the failure modes are "auto-open quietly stops working" or "auto-open re-fires on every render when the underlying marker file is unreadable" — both self-recoverable by deleting `.forge/.dashboard-opened`.
+- The new CI gate shipped in PR #285 (`.github/workflows/s8-kanban-dashboard-acceptance.yml`) will run the S8 acceptance wrapper on this PR automatically because `server/lib/dashboard-renderer.ts` is in its path filter. Meta-validation: this PR proves the CI gate works.
+
+## Goal
+
+Invariants when this ships:
+1. The marker file is written only after the child process has confirmed-spawned (emitted its `"spawn"` event). If spawn fails (`"error"` event), no marker lands and the next render re-attempts.
+2. The auto-open code path is unit-testable — there is an injectable I/O seam covering `stat`, `openExternal`, and `writeFile` for the marker.
+3. The `stat` catch inside `maybeAutoOpenBrowser` distinguishes ENOENT (marker absent → open it) from other errors (EPERM/EIO/etc → log + skip, do NOT re-open every render).
+
+## Binary AC
+
+1. **Marker-on-spawn fix (#281) — behavior:** exercised via the new unit test, when `openExternal` rejects, `writeFile` is never called. Check: new test `maybeAutoOpenBrowser — marker not written when openExternal rejects` passes.
+2. **DashboardIo seam (#282) — interface:** `maybeAutoOpenBrowser` is exported and accepts an `AutoOpenIo` parameter with signature including `stat`, `openExternal`, and `writeFile`. Check: `grep -E "export (async )?function maybeAutoOpenBrowser" server/lib/dashboard-renderer.ts` returns exactly one match; `grep -E "export interface AutoOpenIo" server/lib/dashboard-renderer.ts` returns exactly one match.
+3. **Stat-catch narrowing (#283) — behavior:** when `stat` throws a non-ENOENT error, the outer catch logs it AND the function does NOT call `openExternal` or `writeFile`. Check: new test `maybeAutoOpenBrowser — non-ENOENT stat error rethrows` passes.
+4. **No regression:** `npm test` exits 0 (744 → 746+ tests, all green).
+5. **No regression:** `bash scripts/s8-kanban-dashboard-acceptance.sh` exits 0 with 15/15 PASS.
+6. **Live CI proof:** the new `acceptance` workflow (from PR #285) runs on this PR and reports pass.
+7. **No regression:** existing renderer tests pass unchanged — the bundled fix MUST NOT modify the `DashboardIo` interface or break the current atomic-write seam. (Separate interface `AutoOpenIo` keeps the seams decoupled.)
+
+## Out of scope
+
+- Changing the env-gate contract (`FORGE_DASHBOARD_AUTO_OPEN=1` stays the opt-in).
+- Expanding auto-open to non-first renders or cross-session behavior.
+- Adding a CLI flag to re-open without deleting the marker.
+- Closing enhancement issues #286/#287/#288/#289 from PR #285's ship-review (those are CI workflow concerns, separate area).
+
+## Ordering constraints
+
+None — single-file implementation change plus two new unit tests, committed together.
+
+## Verification procedure
+
+1. `npm run build` — exits 0.
+2. `npm test` — exits 0.
+3. `bash scripts/s8-kanban-dashboard-acceptance.sh` — exits 0 with 15/15 PASS.
+4. `grep -E "export (async )?function maybeAutoOpenBrowser" server/lib/dashboard-renderer.ts` — exactly one match.
+5. `grep -E "export interface AutoOpenIo" server/lib/dashboard-renderer.ts` — exactly one match.
+6. After merge: `gh pr checks <pr>` shows `acceptance` check with `pass` conclusion.
+
+## Critical files
+
+- `server/lib/dashboard-renderer.ts` — `maybeAutoOpenBrowser` is promoted to `export`, a new `AutoOpenIo` interface + `DEFAULT_AUTO_OPEN_IO` are introduced, and the three fixes land inside the helper.
+- `server/lib/dashboard-renderer.test.ts` — two new tests targeting the new seam.
+
+## Checkpoint
+
+- [ ] Plan written + pushed
+- [ ] Implementation done (all 3 fixes in one diff)
+- [ ] Two new unit tests passing
+- [ ] Full test suite + smoke + acceptance wrapper green locally
+- [ ] Ship via /ship — PR opened, CI runs
+- [ ] New `acceptance` check (PR #285's gate) passes on this PR — meta-validation
+- [ ] Merge + close issues #281, #282, #283
+
+Last updated: 2026-04-19T13:50:00+08:00 — plan draft.

--- a/server/lib/dashboard-renderer.test.ts
+++ b/server/lib/dashboard-renderer.test.ts
@@ -23,7 +23,9 @@ import {
   classifyStaleness,
   renderDashboardHtml,
   renderDashboard,
+  maybeAutoOpenBrowser,
   COLUMN_IDS,
+  type AutoOpenIo,
   type DashboardRenderInput,
   type AuditFeedEntry,
 } from "./dashboard-renderer.js";
@@ -463,5 +465,108 @@ describe("renderDashboard — failure isolation (AC-18)", () => {
     // hooks run in the background and swallow errors internally.
     expect(() => reporter.begin("stage-a")).not.toThrow();
     expect(() => reporter.complete("stage-a")).not.toThrow();
+  });
+});
+
+describe("maybeAutoOpenBrowser — marker-on-spawn (#281)", () => {
+  const PROJECT_ROOT = process.platform === "win32"
+    ? "Z:\\forge-auto-open-fixture"
+    : "/tmp/forge-auto-open-nonexistent-xyz";
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.FORGE_DASHBOARD_AUTO_OPEN = "1";
+  });
+
+  afterEach(() => {
+    delete process.env.FORGE_DASHBOARD_AUTO_OPEN;
+    vi.restoreAllMocks();
+  });
+
+  it("does NOT write the marker when openExternal rejects (spawn failure)", async () => {
+    const calls: Array<{ op: string; args: unknown[] }> = [];
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    const io: AutoOpenIo = {
+      stat: async (p) => {
+        calls.push({ op: "stat", args: [p] });
+        throw enoent; // marker absent → proceed
+      },
+      openExternal: async (target) => {
+        calls.push({ op: "openExternal", args: [target] });
+        throw new Error("xdg-open missing");
+      },
+      writeFile: async (p, d, e) => {
+        calls.push({ op: "writeFile", args: [p, d, e] });
+      },
+    };
+
+    await maybeAutoOpenBrowser(PROJECT_ROOT, io);
+
+    // openExternal was attempted but writeFile must NEVER have been called.
+    expect(calls.some((c) => c.op === "openExternal")).toBe(true);
+    expect(calls.some((c) => c.op === "writeFile")).toBe(false);
+  });
+
+  it("writes the marker exactly once when openExternal resolves", async () => {
+    const calls: Array<{ op: string; args: unknown[] }> = [];
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    const io: AutoOpenIo = {
+      stat: async () => { throw enoent; },
+      openExternal: async (target) => { calls.push({ op: "openExternal", args: [target] }); },
+      writeFile: async (p, d, e) => { calls.push({ op: "writeFile", args: [p, d, e] }); },
+    };
+
+    await maybeAutoOpenBrowser(PROJECT_ROOT, io);
+
+    const opOrder = calls.map((c) => c.op);
+    expect(opOrder).toEqual(["openExternal", "writeFile"]);
+    const writeArgs = calls.find((c) => c.op === "writeFile")!.args;
+    expect(String(writeArgs[0])).toMatch(/\.dashboard-opened$/);
+  });
+});
+
+describe("maybeAutoOpenBrowser — stat catch narrowing (#283)", () => {
+  const PROJECT_ROOT = process.platform === "win32"
+    ? "Z:\\forge-auto-open-stat-fixture"
+    : "/tmp/forge-auto-open-stat-nonexistent-xyz";
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.FORGE_DASHBOARD_AUTO_OPEN = "1";
+  });
+
+  afterEach(() => {
+    delete process.env.FORGE_DASHBOARD_AUTO_OPEN;
+    vi.restoreAllMocks();
+  });
+
+  it("non-ENOENT stat error skips open and does NOT call openExternal or writeFile", async () => {
+    const calls: Array<{ op: string }> = [];
+    const eperm = Object.assign(new Error("EPERM"), { code: "EPERM" });
+    const io: AutoOpenIo = {
+      stat: async () => { throw eperm; },
+      openExternal: async () => { calls.push({ op: "openExternal" }); },
+      writeFile: async () => { calls.push({ op: "writeFile" }); },
+    };
+
+    await maybeAutoOpenBrowser(PROJECT_ROOT, io);
+
+    // Non-ENOENT must neither re-open nor re-write the marker —
+    // otherwise every render would re-spawn a browser tab.
+    expect(calls.length).toBe(0);
+  });
+
+  it("env var unset → no io calls at all", async () => {
+    delete process.env.FORGE_DASHBOARD_AUTO_OPEN;
+    const calls: Array<{ op: string }> = [];
+    const io: AutoOpenIo = {
+      stat: async () => { calls.push({ op: "stat" }); },
+      openExternal: async () => { calls.push({ op: "openExternal" }); },
+      writeFile: async () => { calls.push({ op: "writeFile" }); },
+    };
+
+    await maybeAutoOpenBrowser(PROJECT_ROOT, io);
+
+    expect(calls.length).toBe(0);
   });
 });

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -600,6 +600,36 @@ export async function writeDashboardHtml(
 }
 
 /**
+ * Injectable I/O seam for the auto-open path — separate from `DashboardIo`
+ * so tests that mock the atomic-write contract don't have to stub the
+ * auto-open-only fields. Production callers use `DEFAULT_AUTO_OPEN_IO`.
+ */
+export interface AutoOpenIo {
+  stat: (path: string) => Promise<void>;
+  openExternal: (target: string) => Promise<void>;
+  writeFile: (path: string, data: string, encoding: "utf-8") => Promise<void>;
+}
+
+const DEFAULT_AUTO_OPEN_IO: AutoOpenIo = {
+  stat: (p) => stat(p).then(() => undefined),
+  openExternal: (target) =>
+    new Promise<void>((resolve, reject) => {
+      const child =
+        process.platform === "win32"
+          ? spawn("cmd", ["/c", "start", "", target], { detached: true, stdio: "ignore" })
+          : process.platform === "darwin"
+            ? spawn("open", [target], { detached: true, stdio: "ignore" })
+            : spawn("xdg-open", [target], { detached: true, stdio: "ignore" });
+      child.once("spawn", () => {
+        child.unref();
+        resolve();
+      });
+      child.once("error", (err) => reject(err));
+    }),
+  writeFile: (p, d, e) => writeFile(p, d, e),
+};
+
+/**
  * Open the dashboard in the user's default browser — env-gated, one-shot.
  *
  * Gates (both must hold):
@@ -610,36 +640,50 @@ export async function writeDashboardHtml(
  *      open writes the marker; subsequent renders are no-ops. Delete the
  *      marker to re-open the tab (e.g. after closing it accidentally).
  *
+ * The marker is only written AFTER the child process emits its `"spawn"`
+ * event — if the spawn fails (e.g. `xdg-open` missing on a headless box),
+ * no marker lands and the next render re-attempts. Issue #281.
+ *
+ * The `stat` catch narrows to ENOENT only; other errors (EPERM, EIO, etc)
+ * are re-thrown to the outer catch so they are logged rather than silently
+ * treated as "marker absent" (which would re-open a tab on every render).
+ * Issue #283.
+ *
+ * Exported + accepts an injectable `AutoOpenIo` so the env-gated behavior
+ * can be unit-tested without real filesystem side effects. Issue #282.
+ *
  * Uses spawn with an argv array (no shell interpolation) to avoid any
- * command-injection surface on user-controlled projectPath values. The
- * child is detached + unreffed so the MCP process exits independently.
+ * command-injection surface on user-controlled paths. The child is
+ * detached + unreffed so the MCP process exits independently.
  *
  * Failure-swallowed per the parent renderer's error policy.
  */
-async function maybeAutoOpenBrowser(projectPath: string): Promise<void> {
+export async function maybeAutoOpenBrowser(
+  projectPath: string,
+  io: AutoOpenIo = DEFAULT_AUTO_OPEN_IO,
+): Promise<void> {
   if (process.env.FORGE_DASHBOARD_AUTO_OPEN !== "1") return;
 
   const markerPath = join(projectPath, ".forge", ".dashboard-opened");
   try {
-    await stat(markerPath);
+    await io.stat(markerPath);
     return;
-  } catch {
-    /* marker absent — proceed to open */
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code && code !== "ENOENT") {
+      console.error(
+        "forge: dashboard auto-open stat failed (continuing):",
+        err instanceof Error ? err.message : String(err),
+      );
+      return;
+    }
+    /* ENOENT or unknown — marker absent, proceed to open */
   }
 
   try {
     const dashboardPath = join(projectPath, ".forge", "dashboard.html");
-    const child =
-      process.platform === "win32"
-        ? spawn("cmd", ["/c", "start", "", dashboardPath], { detached: true, stdio: "ignore" })
-        : process.platform === "darwin"
-          ? spawn("open", [dashboardPath], { detached: true, stdio: "ignore" })
-          : spawn("xdg-open", [dashboardPath], { detached: true, stdio: "ignore" });
-    child.on("error", (err) => {
-      console.error("forge: dashboard auto-open spawn failed (continuing):", err.message);
-    });
-    child.unref();
-    await writeFile(markerPath, new Date().toISOString(), "utf-8");
+    await io.openExternal(dashboardPath);
+    await io.writeFile(markerPath, new Date().toISOString(), "utf-8");
   } catch (err) {
     console.error(
       "forge: dashboard auto-open failed (continuing):",


### PR DESCRIPTION
## Summary

Bundled fix for the three auto-open issues filed during PR #280's ship-review. All touch `maybeAutoOpenBrowser()` in `server/lib/dashboard-renderer.ts`.

- **#281 — marker-on-spawn:** marker now written only after the child emits its `spawn` event. If spawn fails (e.g., `xdg-open` missing), no marker lands and the next render re-attempts.
- **#282 — DashboardIo seam:** new `AutoOpenIo` interface + exported `maybeAutoOpenBrowser` make the env-gated behavior unit-testable. Kept separate from the existing `DashboardIo` so atomic-write tests don't need auto-open stubs.
- **#283 — stat-catch narrowing:** ENOENT proceeds to open; EPERM/EIO/etc log and skip. Prevents re-opening a new tab on every render when the marker dir is unreadable.

Meta-validation: the CI gate shipped in PR #285 (v0.32.1) runs the S8 acceptance wrapper on this PR automatically because the renderer path is in its filter. First practical proof the new gate works.

## Test plan

- [x] `npm run build` — exits 0
- [x] `npm test` — 748 pass (was 744; +4 from the 2 new test blocks)
- [x] `npx vitest run server/lib/dashboard-renderer.test.ts` — 22 pass (was 18)
- [x] `bash scripts/s8-kanban-dashboard-acceptance.sh` — 15/15 PASS
- [ ] Live CI: `acceptance` check passes on this PR (meta-validation of PR #285's gate)
- [ ] Live CI: pre-existing checks (build ubuntu/windows, smoke-gate) still pass

## Out of scope

- Changing the `FORGE_DASHBOARD_AUTO_OPEN=1` opt-in contract
- CI workflow enhancements #286/#287/#288/#289 from PR #285's ship-review — separate area

---

plan-refresh: no-op

index-check: none