### PR TITLE
chore(ci): S8 Kanban dashboard workflow polish (closes #286 #287 #288 #289)

### DIFF
--- a/.github/workflows/s8-kanban-dashboard-acceptance.yml
+++ b/.github/workflows/s8-kanban-dashboard-acceptance.yml
@@ -1,4 +1,4 @@
-name: s8-kanban-dashboard-acceptance
+name: S8 Kanban Dashboard Acceptance
 
 on:
   pull_request:
@@ -10,6 +10,13 @@ on:
       - 'server/lib/activity.ts'
       - 'scripts/s8-kanban-dashboard-acceptance.sh'
       - '.github/workflows/s8-kanban-dashboard-acceptance.yml'
+  workflow_dispatch: {}
+
+# Cancel superseded runs on rapid branch pushes — the wrapper is ~35s but
+# stacking runs against the same ref wastes CI minutes.
+concurrency:
+  group: s8-dashboard-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   acceptance:
@@ -24,6 +31,10 @@ jobs:
           node-version: 20
           cache: npm
 
+      # `--ignore-scripts` matches ci.yml. The acceptance wrapper runs
+      # `npm run build` internally as part of AC-17, so any postinstall
+      # build hook would be redundant; skipping scripts also narrows the
+      # supply-chain surface to packages we explicitly build ourselves.
       - name: Install dependencies
         run: npm ci --ignore-scripts
 


### PR DESCRIPTION
## Summary

Four CI ergonomics fixes from PR #285's ship-review, bundled into one edit of `.github/workflows/s8-kanban-dashboard-acceptance.yml`.

- **#286 — workflow_dispatch:** maintainers can now manually re-run the workflow from the Actions tab (useful for dependency-bump validation against master without opening a dummy PR).
- **#287 — friendly name:** `name:` changed to `S8 Kanban Dashboard Acceptance` so the checks panel reads as human text instead of a slug.
- **#288 — `--ignore-scripts` rationale:** pinned as an inline comment. The wrapper runs `npm run build` as AC-17, so postinstall build hooks would be redundant; comment also explains supply-chain surface narrowing.
- **#289 — concurrency block:** `group: s8-dashboard-${{ github.ref }}` + `cancel-in-progress: true` so stacked pushes cancel in-flight runs instead of queuing.

Zero behavior change on the happy path. The workflow still runs on the same path filter, still invokes the same wrapper, still exits 0 with 15/15 AC PASS.

## Test plan

- [x] YAML syntax sanity: all 4 fixes verified via regex grep (`workflow_dispatch`, `name: S8 Kanban`, `--ignore-scripts.*matches ci\.yml`, `concurrency:` block)
- [ ] Live: `acceptance` check passes on this PR (self-gates because the workflow file is in its own path filter)
- [ ] Live: pre-existing checks (build ubuntu/windows, smoke-gate) pass
- [ ] Manual: after merge, trigger `workflow_dispatch` from the Actions UI and confirm a green run on master

## Out of scope

- Further CI refactoring (e.g., consolidating ci.yml + acceptance workflow into a reusable workflow) — that would be a larger architectural decision, not a polish pass.
- Dashboard-renderer follow-ups #291-#295 (separate bundle, tracked as task #94).

---

plan-refresh: no-op

index-check: none