### PR TITLE
refactor(dashboard): auto-open polish bundle (closes #291 #293 #294 #295)

### DIFF
--- a/server/lib/dashboard-renderer.test.ts
+++ b/server/lib/dashboard-renderer.test.ts
@@ -468,11 +468,18 @@ describe("renderDashboard — failure isolation (AC-18)", () => {
   });
 });
 
-describe("maybeAutoOpenBrowser — marker-on-spawn (#281)", () => {
-  const PROJECT_ROOT = process.platform === "win32"
-    ? "Z:\\forge-auto-open-fixture"
-    : "/tmp/forge-auto-open-nonexistent-xyz";
+// ── maybeAutoOpenBrowser — shared test helpers ─────────────────────────────
+// Neutral fixture path: tests fully inject AutoOpenIo and never touch disk,
+// so the label is "this is the fake project root" rather than "a nonexistent
+// real path". Renamed from the previous `/tmp/forge-auto-open-nonexistent-xyz`
+// per #293.
+const FIXTURE_PROJECT_ROOT =
+  process.platform === "win32" ? "Z:\\project-fixture" : "/project-fixture";
 
+// Factored shared setup/teardown for auto-open describes per #294. Returns
+// nothing — the afterEach hook restores mocks globally. Call from the top of
+// each describe that exercises the env-gated auto-open path.
+function useAutoOpenEnvGate(): void {
   beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     process.env.FORGE_DASHBOARD_AUTO_OPEN = "1";
@@ -482,6 +489,10 @@ describe("maybeAutoOpenBrowser — marker-on-spawn (#281)", () => {
     delete process.env.FORGE_DASHBOARD_AUTO_OPEN;
     vi.restoreAllMocks();
   });
+}
+
+describe("maybeAutoOpenBrowser — marker-on-spawn (#281)", () => {
+  useAutoOpenEnvGate();
 
   it("does NOT write the marker when openExternal rejects (spawn failure)", async () => {
     const calls: Array<{ op: string; args: unknown[] }> = [];
@@ -500,7 +511,7 @@ describe("maybeAutoOpenBrowser — marker-on-spawn (#281)", () => {
       },
     };
 
-    await maybeAutoOpenBrowser(PROJECT_ROOT, io);
+    await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
 
     // openExternal was attempted but writeFile must NEVER have been called.
     expect(calls.some((c) => c.op === "openExternal")).toBe(true);
@@ -516,7 +527,7 @@ describe("maybeAutoOpenBrowser — marker-on-spawn (#281)", () => {
       writeFile: async (p, d, e) => { calls.push({ op: "writeFile", args: [p, d, e] }); },
     };
 
-    await maybeAutoOpenBrowser(PROJECT_ROOT, io);
+    await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
 
     const opOrder = calls.map((c) => c.op);
     expect(opOrder).toEqual(["openExternal", "writeFile"]);
@@ -525,22 +536,10 @@ describe("maybeAutoOpenBrowser — marker-on-spawn (#281)", () => {
   });
 });
 
-describe("maybeAutoOpenBrowser — stat catch narrowing (#283)", () => {
-  const PROJECT_ROOT = process.platform === "win32"
-    ? "Z:\\forge-auto-open-stat-fixture"
-    : "/tmp/forge-auto-open-stat-nonexistent-xyz";
+describe("maybeAutoOpenBrowser — stat catch narrowing (#283 + #291)", () => {
+  useAutoOpenEnvGate();
 
-  beforeEach(() => {
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    process.env.FORGE_DASHBOARD_AUTO_OPEN = "1";
-  });
-
-  afterEach(() => {
-    delete process.env.FORGE_DASHBOARD_AUTO_OPEN;
-    vi.restoreAllMocks();
-  });
-
-  it("non-ENOENT stat error skips open and does NOT call openExternal or writeFile", async () => {
+  it("non-ENOENT stat error (e.g. EPERM) skips open and does NOT call openExternal or writeFile", async () => {
     const calls: Array<{ op: string }> = [];
     const eperm = Object.assign(new Error("EPERM"), { code: "EPERM" });
     const io: AutoOpenIo = {
@@ -549,15 +548,47 @@ describe("maybeAutoOpenBrowser — stat catch narrowing (#283)", () => {
       writeFile: async () => { calls.push({ op: "writeFile" }); },
     };
 
-    await maybeAutoOpenBrowser(PROJECT_ROOT, io);
+    await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
 
     // Non-ENOENT must neither re-open nor re-write the marker —
     // otherwise every render would re-spawn a browser tab.
     expect(calls.length).toBe(0);
   });
 
-  it("env var unset → no io calls at all", async () => {
+  it("plain Error with no code (undefined) is treated as 'skip', NOT 'marker absent' (#291)", async () => {
+    const calls: Array<{ op: string }> = [];
+    // Plain Error has no `.code` property — previous guard
+    // `if (code && code !== "ENOENT")` fell through to open.
+    // After the #291 widening (`if (code !== "ENOENT")`), undefined
+    // also skips because undefined !== "ENOENT".
+    const io: AutoOpenIo = {
+      stat: async () => { throw new Error("mystery stat failure"); },
+      openExternal: async () => { calls.push({ op: "openExternal" }); },
+      writeFile: async () => { calls.push({ op: "writeFile" }); },
+    };
+
+    await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
+
+    // No io other than stat must have been touched.
+    expect(calls.length).toBe(0);
+  });
+});
+
+describe("maybeAutoOpenBrowser — env gate (#295)", () => {
+  // Env-gate suppression is a distinct concern from stat-narrowing, so it
+  // lives in its own describe per #295. useAutoOpenEnvGate() is deliberately
+  // NOT used here — the whole point is that the env var is unset.
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
     delete process.env.FORGE_DASHBOARD_AUTO_OPEN;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("env var unset → no io calls at all (early return)", async () => {
     const calls: Array<{ op: string }> = [];
     const io: AutoOpenIo = {
       stat: async () => { calls.push({ op: "stat" }); },
@@ -565,7 +596,7 @@ describe("maybeAutoOpenBrowser — stat catch narrowing (#283)", () => {
       writeFile: async () => { calls.push({ op: "writeFile" }); },
     };
 
-    await maybeAutoOpenBrowser(PROJECT_ROOT, io);
+    await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
 
     expect(calls.length).toBe(0);
   });

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -644,10 +644,12 @@ const DEFAULT_AUTO_OPEN_IO: AutoOpenIo = {
  * event — if the spawn fails (e.g. `xdg-open` missing on a headless box),
  * no marker lands and the next render re-attempts. Issue #281.
  *
- * The `stat` catch narrows to ENOENT only; other errors (EPERM, EIO, etc)
- * are re-thrown to the outer catch so they are logged rather than silently
- * treated as "marker absent" (which would re-open a tab on every render).
- * Issue #283.
+ * The `stat` catch treats **only** `ENOENT` as "marker absent, proceed to
+ * open". Any other error — including errors without a `code` property —
+ * is logged and the render skips auto-open for this tick. This prevents
+ * EPERM/EIO (or a non-Node-FS rejection) from being silently re-interpreted
+ * as "no marker yet" and re-opening a tab on every render. Issue #283 +
+ * #291 widening.
  *
  * Exported + accepts an injectable `AutoOpenIo` so the env-gated behavior
  * can be unit-tested without real filesystem side effects. Issue #282.
@@ -670,14 +672,17 @@ export async function maybeAutoOpenBrowser(
     return;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code && code !== "ENOENT") {
+    if (code !== "ENOENT") {
+      // Any non-ENOENT condition — including undefined code from a plain
+      // Error — is treated as "cannot determine marker state safely; skip
+      // open". This matches the spirit of #283 (#291 widening).
       console.error(
         "forge: dashboard auto-open stat failed (continuing):",
         err instanceof Error ? err.message : String(err),
       );
       return;
     }
-    /* ENOENT or unknown — marker absent, proceed to open */
+    /* ENOENT — marker absent, proceed to open */
   }
 
   try {


### PR DESCRIPTION
## Summary

Four polish fixes from PR #290's ship-review, bundled into edits of `server/lib/dashboard-renderer.ts` + `server/lib/dashboard-renderer.test.ts`. #292 closed separately as premature-without-consumer.

- **#291 — stat-catch widening + docstring.** Guard changed from `if (code && code !== "ENOENT")` to `if (code !== "ENOENT")` so an error with undefined code (plain `Error`, non-Node-FS rejection) also skips the open rather than falling through. Strictly safer; matches the spirit of #283. Docstring reworded to describe the actual "log + skip" flow.
- **#293 — fixture naming.** `PROJECT_ROOT = "/tmp/forge-auto-open-nonexistent-xyz"` → `FIXTURE_PROJECT_ROOT = "/project-fixture"` (Windows variant: `Z:\project-fixture`). Tests inject `AutoOpenIo` fully and never touch disk; the old naming implied filesystem interaction that never happened.
- **#294 — shared test plumbing.** Extracted `useAutoOpenEnvGate()` helper for the env-var + console-spy setup/teardown. Two describes call it instead of duplicating the 6 lines.
- **#295 — env-gate test extracted.** The "env var unset → no io calls" test is now in its own `describe("maybeAutoOpenBrowser — env gate")` block instead of colocated under the stat-narrowing describe.

One new unit test (#291 undefined-code case) brings the renderer test file from 22 → 23 tests; full suite from 748 → 749. Zero behavior change on the happy path.

## Test plan

- [x] `npm run build` — exits 0
- [x] `npx vitest run server/lib/dashboard-renderer.test.ts` — 23 pass
- [x] `npm test` — 749 / 4 skipped / 0 fail
- [x] `bash scripts/s8-kanban-dashboard-acceptance.sh` — 15/15 PASS
- [ ] CI `acceptance` check passes (meta-validation continues — this PR touches `server/lib/dashboard-renderer.ts` which is in the acceptance workflow's path filter)

## Out of scope

- Issue #292 (widen `AutoOpenIo.stat` return type) — closed as premature; reopen when a consumer needs `Stats` branching.
- Further refactoring of `maybeAutoOpenBrowser` — this PR is strictly polish, not restructure.

---

plan-refresh: no-op

index-check: none