### PR TITLE
fix(setup): register forge MCP server to canonical user-scope path

### DIFF
--- a/.ai-workspace/plans/2026-04-19-setup-config-mcp-registration-fix.md
+++ b/.ai-workspace/plans/2026-04-19-setup-config-mcp-registration-fix.md
@@ -1,0 +1,149 @@
+---
+task: v0.32.5 — fix setup-config.cjs MCP registration path
+status: drafting
+owner: forge-plan
+created: 2026-04-19
+supersedes: none
+---
+
+## ELI5
+
+When you run `./setup.sh` in forge-harness, it's supposed to tell Claude Code "hey, there's a tool called `forge` — please load it so the user can use it." It does this by writing a config file.
+
+The problem: it's writing to the **wrong config file**. It writes to `~/.claude/settings.json`, but Claude Code never reads MCP server entries from there — it reads them from `~/.claude.json` (a different file, same-ish name). So every user who ran `./setup.sh` and then tried to use `forge` tools from a directory that isn't forge-harness itself got silently broken: Claude Code starts, reads the real config, sees no forge, and doesn't load the tools.
+
+Monday ran into this today while building monday-bot. Her session's working directory is `monday-bot`, so she gets none of the forge tools despite having run `./setup.sh` cleanly.
+
+The fix: rewrite `scripts/setup-config.cjs` to use the official CLI — `claude mcp add forge node -s user -e FORGE_DASHBOARD_AUTO_OPEN=1 -- <absolute-path-to-dist/index.js>` — which writes to the correct file (`~/.claude.json`). We also add a warning (not a delete) for the old stale entries so users know they can clean them up.
+
+## Context
+
+**Root cause verified on-disk** (see `~/.claude/agent-working-memory/tier-b/topics/infra-bugs/2026-04-19-forge-setup-sh-wrong-mcp-path.md` for the full blocker card and mailbox trail):
+
+- Current `scripts/setup-config.cjs:50-56` writes `mcpServers.forge` to `~/.claude/settings.json`.
+- Claude Code does NOT read `mcpServers` from that path (dead-letter). Confirmed: on the reporting machine, `~/.claude/settings.json` contains a `context7` MCP entry but `claude mcp list` also doesn't surface `context7`.
+- Canonical user-scope MCP path is `~/.claude.json` top-level `mcpServers` key, written by `claude mcp add ... -s user`.
+- A stray `~/.claude/mcp.json` exists on this machine with a `forge` entry (also inert — Claude Code doesn't read that path either). Authorship unclear; likely fallout from an older setup-config.cjs version.
+
+**Why monday hit it and I didn't notice sooner:**
+
+- Monday's session cwd is `monday-bot` → no project-scope `.mcp.json` → falls back to user-scope → user-scope is empty (`~/.claude.json.mcpServers = {}`) → forge tools silently missing.
+- My session cwd is forge-harness itself → project-scope `.mcp.json` (TOFU) registers forge → I had access all along without realizing user-scope was broken.
+
+**Key CLI finding (v2.1.114 of `claude`):**
+
+- `claude mcp add` does NOT have a `--cwd` flag. The JSON it writes contains `{type, command, args, env}` only — no `cwd` field.
+- Consequence: passing a relative arg like `dist/index.js` means Claude Code spawns `node dist/index.js` with some default cwd that is NOT the repo root. For users whose session cwd ≠ forge-harness, `dist/index.js` fails to resolve.
+- **Fix: pass the absolute path** to `dist/index.js` as the positional arg. This sidesteps cwd entirely.
+- Correction to prior sanctioned workaround: the `--cwd "..."` flag I mailed to monday on 2026-04-19T14:21Z is silently ignored by the current CLI. The follow-up mail must correct this.
+
+**Idempotency:**
+
+- `claude mcp add` errors "already exists" on re-add. Setup-config must `claude mcp remove forge -s user` first (ignoring "not found"), then `add`.
+
+**Migration — the two stale surfaces, handled with warnings only, no auto-delete:**
+
+- `~/.claude/settings.json.mcpServers.forge` — may exist on any machine that ran an older setup.sh. Inert. Warn user.
+- `~/.claude/mcp.json` — may exist from some earlier attempt. Inert. Warn user.
+- Rationale for no auto-delete: both files may contain user-authored entries we don't own (`context7`, etc.). Leave them alone; surface awareness, let the user decide.
+
+**Fallback path — when `claude` CLI is not on PATH:**
+
+- `claude` is a hard dep of running Claude Code, so PATH availability is near-guaranteed.
+- Edge case: user installed claude via a method that didn't add the npm bin dir to PATH. For this case, fall back to direct atomic write of `~/.claude.json` top-level `mcpServers.forge` (write to temp, rename).
+- Direct write is the second choice because it risks corrupting unrelated keys in `~/.claude.json` (~40 user-config keys); we mitigate by always read-parse-mutate-atomic-rename, never blind overwrite.
+
+## Goal
+
+After `./setup.sh` completes on a machine where monday-bot (or any non-forge-harness cwd) runs Claude Code:
+1. `claude mcp list` shows `forge: node <abs-path>/dist/index.js - ✓ Connected`
+2. The registered entry carries `FORGE_DASHBOARD_AUTO_OPEN=1` in its env block
+3. A second run of `./setup.sh` succeeds (idempotent)
+4. Any stale `~/.claude/settings.json.mcpServers.forge` or `~/.claude/mcp.json` triggers a visible migration warning to stderr but is **not** auto-deleted
+
+## Binary AC
+
+All ACs below are checkable by the wrapper at `scripts/setup-config-acceptance.sh` unless otherwise noted. The wrapper drives setup-config.cjs against an isolated scratch HOME (via `HOME=<tmp>` + `USERPROFILE=<tmp>`, both claude CLI v2.1.114 and node respect this — confirmed on 2026-04-19 during planning) so the reviewer's real `~/.claude.json` is never touched.
+
+- **AC-1** — Running `node scripts/setup-config.cjs <repo-root>` against a scratch HOME with `claude` on PATH produces `<scratch>/.claude.json` containing `mcpServers.forge` with:
+  - `command === "node"`
+  - `args` is a one-element array whose value ends in `/dist/index.js` (absolute path)
+  - `env.FORGE_DASHBOARD_AUTO_OPEN === "1"`
+  - `type === "stdio"`
+- **AC-2** — `args[0]` points to a file that exists on disk (the absolute path resolves).
+- **AC-3** — Running setup-config twice in succession against the same scratch HOME both exit 0, and the resulting `mcpServers.forge` entry is identical to the single-run result (no duplication, no stale state).
+- **AC-4** — Fallback path: running setup-config with `PATH` stripped of `claude` (simulated via `PATH=/nonexistent`) against a scratch HOME still produces a valid `<scratch>/.claude.json.mcpServers.forge` entry matching the AC-1 shape. Stderr contains the substring `claude CLI` acknowledging the fallback.
+- **AC-5** — With `<scratch>/.claude/settings.json` pre-seeded containing `{"mcpServers":{"forge":{...}}}`, setup-config stderr contains the substring `inert` (case-insensitive) referring to settings.json.
+- **AC-6** — With `<scratch>/.claude/mcp.json` pre-seeded, setup-config stderr contains the substring `inert` (case-insensitive) referring to mcp.json.
+- **AC-7** — After AC-5 and AC-6 conditions both trigger, both pre-seeded files still exist on disk unchanged (no auto-delete).
+- **AC-8** — If `<repo-root>/dist/index.js` does not exist, setup-config exits non-zero within 2 seconds and stderr contains the word `build` (hint to run `npm run build`).
+- **AC-9** — `scripts/setup-config-acceptance.sh` exists, exits 0 when AC-1..AC-8 all pass, and leaves no files outside its scratch dir.
+- **AC-10** — No changes to `setup.sh` itself — `diff origin/master -- setup.sh` is empty.
+
+## Out of scope
+
+- Refactoring `setup.sh` driver (only setup-config.cjs + new wrapper)
+- Auto-deleting stale config files (`~/.claude/settings.json.mcpServers.forge` or `~/.claude/mcp.json`) — warnings only
+- Modifying the existing project-scope `.mcp.json` file (forge-harness's local one already works)
+- Tracking or generating the `.claude/worktrees/` / `.claude/settings.local.json` working-tree artifacts
+- Changing the `claude` CLI version constraint (accept whatever is on PATH at v2.0+)
+- Documenting non-Claude-Code MCP clients (Cursor, etc. — each has its own registration path, not our concern)
+- Retroactive cleanup of polluted installs in the wild — that's a post-ship mail to monday, not a code change
+
+## Ordering constraints
+
+- AC-1..AC-3 before AC-4: primary path must be proven before the fallback can be meaningfully tested (the fallback shares the migration-warning code path).
+- AC-9 (wrapper existence + green) must be the last AC, since it depends on AC-1..AC-8 passing.
+
+## Verification procedure
+
+The reviewer runs these exact commands from the repo root on master's HEAD (i.e., the PR's merge-base simulation) with the PR branch checked out:
+
+```bash
+# 1. Dist must be built.
+npm ci --ignore-scripts
+npm run build
+
+# 2. Wrapper must exist.
+test -x scripts/setup-config-acceptance.sh || chmod +x scripts/setup-config-acceptance.sh
+
+# 3. Run the wrapper. It must exit 0 and print a PASS summary.
+bash scripts/setup-config-acceptance.sh
+
+# 4. Spot-check setup.sh is unchanged vs master.
+git diff origin/master -- setup.sh
+# Expected: empty.
+
+# 5. Manual sanity — the reviewer MAY optionally run the real thing against their own ~/.claude.json
+#    (clean up via `claude mcp remove forge -s user` afterwards). Skip if the reviewer doesn't want
+#    to touch their real config. AC-1..AC-9 passing in scratch already proves correctness.
+```
+
+## Critical files
+
+- `scripts/setup-config.cjs` — primary target. Rewrite the body from "write to settings.json" to "shell out to `claude mcp add` (with claude-remove first for idempotency); fall back to atomic direct-write of `~/.claude.json` on CLI absence; emit migration warnings for the two known stale surfaces."
+- `scripts/setup-config-acceptance.sh` — new plan-mandated wrapper; drives AC-1..AC-8, exits 0 iff all pass. Uses scratch HOME via `mktemp -d` + `cygpath -m` bridge for Windows compatibility.
+- `setup.sh` — unchanged (AC-10). Driver already invokes `node scripts/setup-config.cjs "$SCRIPT_DIR"` correctly; the fix is entirely inside the callee.
+- `package.json` — patch version bump 0.32.4 → 0.32.5 (done by `/ship` Stage 7).
+- `CHANGELOG.md` — new `### Bug Fixes` entry covering this commit (done by `/ship` Stage 7).
+- `README.md` — touch only if the setup-troubleshooting section needs an "if you previously ran a pre-v0.32.5 setup.sh" migration call-out. Check during implementation; add if absent, leave alone if already current.
+- `~/.claude/agent-working-memory/tier-b/topics/infra-bugs/2026-04-19-forge-setup-sh-wrong-mcp-path.md` — load-bearing context card (read-only for this task; mark card "resolved" only after v0.32.5 ships successfully).
+
+## Checkpoint
+
+- [x] Plan drafted
+- [x] Critiqued via `/coherent-plan` (or inline reasoning — this is a short plan with binary AC)
+- [x] Root cause re-verified on-disk via Rule #9 (measure before describing)
+- [x] `claude mcp add` behavior probed (no --cwd flag, idempotency, HOME-override support)
+- [x] `scripts/setup-config.cjs` rewritten
+- [x] `scripts/setup-config-acceptance.sh` written
+- [x] Wrapper runs clean locally (11/11 checks green, verified real ~/.claude.json untouched)
+- [x] `vitest run` passes (749 passed, 4 skipped, 40/41 test files)
+- [x] `npm run build` succeeds
+- [x] GitHub issue filed for the bug (#304)
+- [ ] `/ship` pipeline (branch, commit, PR, CI, review, merge, release tag v0.32.5)
+- [ ] README migration-note added if missing
+- [ ] Monday mailed with: v0.32.5 tag, migration instructions, correction that `--cwd` in my 14:21Z workaround was silently ignored (but her reboot worked anyway)
+- [ ] Tier-b card at `infra-bugs/2026-04-19-forge-setup-sh-wrong-mcp-path.md` updated to `status: resolved` post-ship
+
+Last updated: 2026-04-19T22:40:00+08:00 — implementation + wrapper green; ready for /ship.

--- a/scripts/setup-config-acceptance.sh
+++ b/scripts/setup-config-acceptance.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# Acceptance wrapper for the v0.32.5 setup-config MCP-registration fix.
+# Plan: .ai-workspace/plans/2026-04-19-setup-config-mcp-registration-fix.md
+# AC-1..AC-10 are checked against an isolated scratch HOME so the reviewer's
+# real ~/.claude.json is never touched.
+#
+# Exit 0 iff all AC pass. Designed for CI + local Git Bash / MSYS2.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+# ---------- Scratch HOME setup (bridges Git Bash / MSYS path mismatch) ----------
+# Git Bash's /tmp maps to $USERPROFILE/AppData/Local/Temp, which Node sees as
+# a Windows path. Use `cygpath -m` so HOME/USERPROFILE carry a form both
+# cmd.exe-invoked claude.cmd AND node can resolve consistently.
+
+SCRATCH_MSYS="$(mktemp -d -t forge-setup-config-XXXXXX)"
+if command -v cygpath >/dev/null 2>&1; then
+  SCRATCH_WIN="$(cygpath -m "$SCRATCH_MSYS")"
+else
+  SCRATCH_WIN="$SCRATCH_MSYS"
+fi
+
+cleanup() {
+  # Best-effort cleanup. Try to remove the user-scope forge registration from
+  # the scratch config too, in case the primary path wrote it there.
+  HOME="$SCRATCH_WIN" USERPROFILE="$SCRATCH_WIN" \
+    claude mcp remove forge -s user >/dev/null 2>&1 || true
+  rm -rf "$SCRATCH_MSYS"
+}
+trap cleanup EXIT
+
+FAIL=0
+PASS_COUNT=0
+
+ok() { echo "  ✓ $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "  ✗ $1"; FAIL=1; }
+
+ac() { echo; echo "=== $1 ==="; }
+
+# ---------- Pre-flight ----------
+ac "Pre-flight"
+if [ ! -f "$REPO_ROOT/dist/index.js" ]; then
+  echo "  ! dist/index.js not found — running npm run build..."
+  npm run build >/dev/null 2>&1
+fi
+[ -f "$REPO_ROOT/dist/index.js" ] && ok "dist/index.js exists" || fail "dist/index.js missing after build"
+
+# Expected absolute path for dist/index.js (forward-slash Windows form).
+EXPECTED_DIST="$(cygpath -m "$REPO_ROOT/dist/index.js" 2>/dev/null || echo "$REPO_ROOT/dist/index.js")"
+
+# ---------- AC-1 — primary path writes canonical shape ----------
+ac "AC-1 — primary path shape"
+rm -rf "$SCRATCH_MSYS"/.claude* 2>/dev/null || true
+# scratch HOME must exist, but .claude.json absent so setup-config's primary path runs clean
+mkdir -p "$SCRATCH_MSYS"
+
+HOME="$SCRATCH_WIN" USERPROFILE="$SCRATCH_WIN" \
+  node "$REPO_ROOT/scripts/setup-config.cjs" "$REPO_ROOT" >/dev/null 2>"$SCRATCH_MSYS/stderr-1.log" || {
+    echo "  ! setup-config.cjs exited non-zero"
+    cat "$SCRATCH_MSYS/stderr-1.log"
+    fail "AC-1 setup-config.cjs exited non-zero"
+  }
+
+AC1_JSON="$SCRATCH_MSYS/.claude.json"
+if [ ! -f "$AC1_JSON" ]; then
+  fail "AC-1 ~/.claude.json was not created"
+else
+  # Verify shape via node.
+  SHAPE_OK=$(node -e '
+    const fs = require("fs");
+    const d = JSON.parse(fs.readFileSync(process.argv[1], "utf-8"));
+    const e = d.mcpServers && d.mcpServers.forge;
+    if (!e) { console.log("no-forge-entry"); process.exit(0); }
+    const ok =
+      e.command === "node" &&
+      Array.isArray(e.args) && e.args.length === 1 &&
+      e.args[0].endsWith("/dist/index.js") &&
+      e.env && e.env.FORGE_DASHBOARD_AUTO_OPEN === "1" &&
+      e.type === "stdio";
+    console.log(ok ? "ok" : "bad-shape:" + JSON.stringify(e));
+  ' "$AC1_JSON")
+  [ "$SHAPE_OK" = "ok" ] && ok "AC-1 entry shape correct" || fail "AC-1 shape check: $SHAPE_OK"
+fi
+
+# ---------- AC-2 — args[0] resolves to a real file ----------
+ac "AC-2 — args[0] resolves"
+if [ -f "$AC1_JSON" ]; then
+  ARGS_PATH=$(node -e 'const d=JSON.parse(require("fs").readFileSync(process.argv[1],"utf-8"));console.log(d.mcpServers.forge.args[0]);' "$AC1_JSON")
+  if [ -f "$ARGS_PATH" ]; then
+    ok "AC-2 args[0] '$ARGS_PATH' exists"
+  else
+    fail "AC-2 args[0] '$ARGS_PATH' does not exist on disk"
+  fi
+fi
+
+# ---------- AC-3 — idempotent re-run ----------
+ac "AC-3 — idempotency"
+if [ -f "$AC1_JSON" ]; then
+  FIRST_HASH=$(node -e 'const d=JSON.parse(require("fs").readFileSync(process.argv[1],"utf-8"));console.log(JSON.stringify(d.mcpServers.forge));' "$AC1_JSON")
+  HOME="$SCRATCH_WIN" USERPROFILE="$SCRATCH_WIN" \
+    node "$REPO_ROOT/scripts/setup-config.cjs" "$REPO_ROOT" >/dev/null 2>"$SCRATCH_MSYS/stderr-3.log" || fail "AC-3 second run exited non-zero"
+  SECOND_HASH=$(node -e 'const d=JSON.parse(require("fs").readFileSync(process.argv[1],"utf-8"));console.log(JSON.stringify(d.mcpServers.forge));' "$AC1_JSON")
+  [ "$FIRST_HASH" = "$SECOND_HASH" ] && ok "AC-3 forge entry identical across runs" || fail "AC-3 entry drifted: first=$FIRST_HASH second=$SECOND_HASH"
+fi
+
+# ---------- AC-4 — fallback path when claude CLI missing ----------
+ac "AC-4 — fallback path (no claude CLI)"
+SCRATCH2_MSYS="$(mktemp -d -t forge-setup-config-fallback-XXXXXX)"
+SCRATCH2_WIN=$(cygpath -m "$SCRATCH2_MSYS" 2>/dev/null || echo "$SCRATCH2_MSYS")
+
+# Strip `claude` from PATH by keeping only the node dir (MSYS form) plus essential
+# Windows system dirs (System32 for cmd.exe — node's spawnSync(shell:true) uses it).
+# Use MSYS form (`/c/...`) so Git Bash's own command lookup resolves `node`; cmd.exe
+# spawned by node will see the env PATH string and resolve via its own logic.
+NODE_DIR="$(dirname "$(which node)")"
+SYS32_MSYS=/c/Windows/System32
+STRIPPED_PATH="$NODE_DIR:$SYS32_MSYS"
+
+HOME="$SCRATCH2_WIN" USERPROFILE="$SCRATCH2_WIN" PATH="$STRIPPED_PATH" \
+  node "$REPO_ROOT/scripts/setup-config.cjs" "$REPO_ROOT" >/dev/null 2>"$SCRATCH2_MSYS/stderr-4.log" || fail "AC-4 fallback exit non-zero"
+
+AC4_JSON="$SCRATCH2_MSYS/.claude.json"
+if [ -f "$AC4_JSON" ]; then
+  SHAPE_OK=$(node -e '
+    const fs = require("fs");
+    const d = JSON.parse(fs.readFileSync(process.argv[1], "utf-8"));
+    const e = d.mcpServers && d.mcpServers.forge;
+    if (!e) { console.log("no-forge-entry"); process.exit(0); }
+    const ok =
+      e.command === "node" &&
+      Array.isArray(e.args) && e.args.length === 1 &&
+      e.args[0].endsWith("/dist/index.js") &&
+      e.env && e.env.FORGE_DASHBOARD_AUTO_OPEN === "1";
+    console.log(ok ? "ok" : "bad-shape:" + JSON.stringify(e));
+  ' "$AC4_JSON")
+  [ "$SHAPE_OK" = "ok" ] && ok "AC-4 fallback wrote correct shape" || fail "AC-4 fallback shape: $SHAPE_OK"
+
+  if grep -q "claude CLI" "$SCRATCH2_MSYS/stderr-4.log"; then
+    ok "AC-4 stderr mentions 'claude CLI' (fallback acknowledged)"
+  else
+    fail "AC-4 stderr did not mention fallback"
+    echo "    stderr was:"; sed 's/^/      /' "$SCRATCH2_MSYS/stderr-4.log"
+  fi
+else
+  fail "AC-4 ~/.claude.json not created in fallback mode"
+fi
+rm -rf "$SCRATCH2_MSYS"
+
+# ---------- AC-5 + AC-6 + AC-7 — migration warnings (don't auto-delete) ----------
+ac "AC-5/6/7 — migration warnings + no auto-delete"
+SCRATCH3_MSYS="$(mktemp -d -t forge-setup-config-migrate-XXXXXX)"
+SCRATCH3_WIN=$(cygpath -m "$SCRATCH3_MSYS" 2>/dev/null || echo "$SCRATCH3_MSYS")
+
+# Pre-seed stale surfaces.
+mkdir -p "$SCRATCH3_MSYS/.claude"
+cat > "$SCRATCH3_MSYS/.claude/settings.json" <<'EOF'
+{
+  "mcpServers": {
+    "forge": { "command": "node", "args": ["dist/index.js"], "cwd": "/stale" }
+  },
+  "someUserKey": "preserve-me"
+}
+EOF
+cat > "$SCRATCH3_MSYS/.claude/mcp.json" <<'EOF'
+{
+  "mcpServers": {
+    "forge": { "command": "node", "args": ["dist/index.js"] }
+  }
+}
+EOF
+
+# Hash files BEFORE the run so we can verify no-auto-delete.
+SETTINGS_BEFORE=$(node -e 'console.log(require("crypto").createHash("sha256").update(require("fs").readFileSync(process.argv[1])).digest("hex"));' "$SCRATCH3_MSYS/.claude/settings.json")
+MCP_BEFORE=$(node -e 'console.log(require("crypto").createHash("sha256").update(require("fs").readFileSync(process.argv[1])).digest("hex"));' "$SCRATCH3_MSYS/.claude/mcp.json")
+
+HOME="$SCRATCH3_WIN" USERPROFILE="$SCRATCH3_WIN" \
+  node "$REPO_ROOT/scripts/setup-config.cjs" "$REPO_ROOT" >/dev/null 2>"$SCRATCH3_MSYS/stderr-migrate.log" || fail "AC-5/6/7 setup-config exit non-zero"
+
+# AC-5: stderr mentions inert + settings.json
+if grep -iq "inert" "$SCRATCH3_MSYS/stderr-migrate.log" && grep -q "settings.json" "$SCRATCH3_MSYS/stderr-migrate.log"; then
+  ok "AC-5 migration warning for settings.json emitted"
+else
+  fail "AC-5 no migration warning for settings.json"
+  echo "    stderr was:"; sed 's/^/      /' "$SCRATCH3_MSYS/stderr-migrate.log"
+fi
+
+# AC-6: stderr mentions inert + mcp.json
+if grep -iq "inert" "$SCRATCH3_MSYS/stderr-migrate.log" && grep -q "mcp.json" "$SCRATCH3_MSYS/stderr-migrate.log"; then
+  ok "AC-6 migration warning for mcp.json emitted"
+else
+  fail "AC-6 no migration warning for mcp.json"
+fi
+
+# AC-7: both stale files unchanged
+SETTINGS_AFTER=$(node -e 'console.log(require("crypto").createHash("sha256").update(require("fs").readFileSync(process.argv[1])).digest("hex"));' "$SCRATCH3_MSYS/.claude/settings.json" 2>/dev/null || echo "MISSING")
+MCP_AFTER=$(node -e 'console.log(require("crypto").createHash("sha256").update(require("fs").readFileSync(process.argv[1])).digest("hex"));' "$SCRATCH3_MSYS/.claude/mcp.json" 2>/dev/null || echo "MISSING")
+
+if [ "$SETTINGS_BEFORE" = "$SETTINGS_AFTER" ] && [ "$MCP_BEFORE" = "$MCP_AFTER" ]; then
+  ok "AC-7 stale files preserved unchanged"
+else
+  fail "AC-7 stale files mutated (settings: $SETTINGS_BEFORE -> $SETTINGS_AFTER, mcp: $MCP_BEFORE -> $MCP_AFTER)"
+fi
+rm -rf "$SCRATCH3_MSYS"
+
+# ---------- AC-8 — missing dist/index.js error ----------
+ac "AC-8 — missing dist/index.js error"
+SCRATCH4_MSYS="$(mktemp -d -t forge-setup-config-missing-dist-XXXXXX)"
+SCRATCH4_WIN=$(cygpath -m "$SCRATCH4_MSYS" 2>/dev/null || echo "$SCRATCH4_MSYS")
+# Use a fake repo root that has no dist/ dir.
+FAKE_ROOT_MSYS="$SCRATCH4_MSYS/fake-repo"
+mkdir -p "$FAKE_ROOT_MSYS"
+FAKE_ROOT_WIN=$(cygpath -m "$FAKE_ROOT_MSYS" 2>/dev/null || echo "$FAKE_ROOT_MSYS")
+
+set +e
+HOME="$SCRATCH4_WIN" USERPROFILE="$SCRATCH4_WIN" \
+  timeout 5 node "$REPO_ROOT/scripts/setup-config.cjs" "$FAKE_ROOT_WIN" >/dev/null 2>"$SCRATCH4_MSYS/stderr-8.log"
+EXIT_8=$?
+set -e
+
+if [ "$EXIT_8" -ne 0 ] && grep -iq "build" "$SCRATCH4_MSYS/stderr-8.log"; then
+  ok "AC-8 missing dist exits non-zero with build hint (exit=$EXIT_8)"
+else
+  fail "AC-8 expected non-zero exit + 'build' hint; got exit=$EXIT_8"
+  echo "    stderr was:"; sed 's/^/      /' "$SCRATCH4_MSYS/stderr-8.log"
+fi
+rm -rf "$SCRATCH4_MSYS"
+
+# ---------- AC-10 — setup.sh unchanged vs origin/master ----------
+ac "AC-10 — setup.sh unchanged"
+if git diff origin/master -- setup.sh 2>/dev/null | grep -q .; then
+  fail "AC-10 setup.sh has diff vs origin/master"
+  git diff origin/master -- setup.sh | sed 's/^/      /'
+else
+  ok "AC-10 setup.sh unchanged vs origin/master"
+fi
+
+# ---------- Summary ----------
+echo
+echo "=== Summary ==="
+echo "  Passed: $PASS_COUNT checks"
+if [ "$FAIL" -ne 0 ]; then
+  echo "  FAIL — one or more AC failed."
+  exit 1
+fi
+echo "  PASS — all AC green."

--- a/scripts/setup-config.cjs
+++ b/scripts/setup-config.cjs
@@ -1,10 +1,23 @@
 #!/usr/bin/env node
-// Merge forge MCP server config into ~/.claude/settings.json
+// Register forge MCP server for Claude Code.
+//
+// Primary path: shell out to `claude mcp add forge -s user ...`, which writes to
+// `~/.claude.json` (Claude Code's canonical user-scope MCP config path).
+//
+// Fallback path: when `claude` CLI is not on PATH, atomically write directly to
+// `~/.claude.json` top-level `mcpServers.forge`. Preserves all other keys.
+//
+// Migration warnings: emits (but does NOT delete) notices when pre-v0.32.5 stale
+// config surfaces are present:
+//   - `~/.claude/settings.json.mcpServers.forge` (dead-letter — Claude Code never read it)
+//   - `~/.claude/mcp.json` (inert — Claude Code reads `~/.claude.json` not `~/.claude/mcp.json`)
+//
 // Usage: node scripts/setup-config.cjs <repo-root-path>
 
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const { spawnSync } = require("child_process");
 
 const repoRoot = process.argv[2];
 if (!repoRoot) {
@@ -13,47 +26,132 @@ if (!repoRoot) {
   process.exit(1);
 }
 
-const claudeDir = path.join(os.homedir(), ".claude");
-const settingsPath = path.join(claudeDir, "settings.json");
-
-// Ensure ~/.claude/ exists
-if (!fs.existsSync(claudeDir)) {
-  fs.mkdirSync(claudeDir, { recursive: true });
-  console.error("setup-config: created ~/.claude/");
-}
-
-// Read existing settings or start fresh
-let settings;
-if (fs.existsSync(settingsPath)) {
-  const raw = fs.readFileSync(settingsPath, "utf-8");
-  try {
-    settings = JSON.parse(raw);
-  } catch {
-    console.error(
-      "ERROR: ~/.claude/settings.json contains invalid JSON. Please fix it manually or delete it and re-run setup.sh."
-    );
-    process.exit(1);
-  }
-} else {
-  settings = {};
-  console.error("setup-config: creating new ~/.claude/settings.json");
-}
-
-// Merge forge MCP server entry
-if (!settings.mcpServers) {
-  settings.mcpServers = {};
-}
-
-// Resolve to absolute path and normalize to forward slashes
 const normalizedRoot = path.resolve(repoRoot).replace(/\\/g, "/");
+const distIndex = normalizedRoot + "/dist/index.js";
 
-settings.mcpServers.forge = {
-  command: "node",
-  args: ["dist/index.js"],
-  cwd: normalizedRoot,
-};
+if (!fs.existsSync(distIndex)) {
+  console.error(`ERROR: ${distIndex} does not exist.`);
+  console.error("Did you forget to run `npm run build`? The MCP server entry point must exist before registration.");
+  process.exit(1);
+}
 
-fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
-console.error(
-  `setup-config: registered forge MCP server (cwd: ${normalizedRoot})`
-);
+emitMigrationWarnings();
+
+const primaryOk = tryClaudeMcpAdd(distIndex);
+if (primaryOk) {
+  console.error(`setup-config: registered forge via \`claude mcp add -s user\` ✓ (entry: ${distIndex})`);
+  process.exit(0);
+}
+
+// Fallback path — claude CLI not on PATH or failed.
+fallbackDirectWrite(distIndex);
+console.error(`setup-config: registered forge via direct ~/.claude.json write ✓ (entry: ${distIndex})`);
+console.error("setup-config: note — claude CLI was unavailable, so we wrote the config directly. If you later install the CLI, re-run setup.sh to let it manage the entry.");
+process.exit(0);
+
+function tryClaudeMcpAdd(distIndexAbs) {
+  const probeSpawn = spawnClaude(["--version"]);
+  if (!probeSpawn.available) {
+    return false;
+  }
+
+  // Idempotency: remove any existing user-scope entry first. Ignore "not found" errors.
+  spawnClaude(["mcp", "remove", "forge", "-s", "user"]);
+
+  const add = spawnClaude([
+    "mcp",
+    "add",
+    "forge",
+    "node",
+    "-s",
+    "user",
+    "-e",
+    "FORGE_DASHBOARD_AUTO_OPEN=1",
+    "--",
+    distIndexAbs,
+  ]);
+  if (!add.available || add.result.status !== 0) {
+    const stderr = add.result && add.result.stderr ? add.result.stderr.toString() : "(no stderr)";
+    console.error("setup-config: WARNING — `claude mcp add` failed. Falling back to direct write.");
+    console.error("setup-config: claude stderr:", stderr.trim());
+    return false;
+  }
+  return true;
+}
+
+// Spawn the claude CLI with args. Handles Windows `.cmd` shim via shell: true.
+// Returns { available: boolean, result: SpawnSyncResult | null }.
+// `available: false` means the binary was not found on PATH (ENOENT).
+function spawnClaude(args) {
+  const result = spawnSync("claude", args, {
+    encoding: "utf-8",
+    shell: process.platform === "win32",
+  });
+  if (result.error && result.error.code === "ENOENT") {
+    return { available: false, result };
+  }
+  // On Windows with shell:true, ENOENT surfaces differently — a non-zero exit
+  // and stderr like "'claude' is not recognized..." Treat that as unavailable too.
+  if (process.platform === "win32" && result.status !== 0 && result.stderr) {
+    const stderr = result.stderr.toString();
+    if (stderr.includes("not recognized") || stderr.includes("command not found")) {
+      return { available: false, result };
+    }
+  }
+  return { available: true, result };
+}
+
+function fallbackDirectWrite(distIndexAbs) {
+  const configPath = path.join(os.homedir(), ".claude.json");
+  let config = {};
+  if (fs.existsSync(configPath)) {
+    const raw = fs.readFileSync(configPath, "utf-8");
+    try {
+      config = JSON.parse(raw);
+    } catch {
+      console.error(`ERROR: ${configPath} contains invalid JSON. Fix or remove it and re-run setup.sh.`);
+      process.exit(1);
+    }
+  }
+  if (!config.mcpServers || typeof config.mcpServers !== "object") {
+    config.mcpServers = {};
+  }
+  config.mcpServers.forge = {
+    type: "stdio",
+    command: "node",
+    args: [distIndexAbs],
+    env: { FORGE_DASHBOARD_AUTO_OPEN: "1" },
+  };
+
+  // Atomic write: tempfile + rename. Rename on Windows replaces the target atomically
+  // when both paths are on the same filesystem (always true here — same dir).
+  const tmpPath = configPath + ".tmp-" + process.pid;
+  fs.writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
+  fs.renameSync(tmpPath, configPath);
+}
+
+function emitMigrationWarnings() {
+  const home = os.homedir();
+
+  const staleSettings = path.join(home, ".claude", "settings.json");
+  if (fs.existsSync(staleSettings)) {
+    try {
+      const raw = fs.readFileSync(staleSettings, "utf-8");
+      const data = JSON.parse(raw);
+      if (data && data.mcpServers && data.mcpServers.forge) {
+        console.error(
+          "setup-config: WARNING — ~/.claude/settings.json contains a `mcpServers.forge` entry from a pre-v0.32.5 setup. This path is INERT (Claude Code does not read mcpServers from settings.json). You can remove the `mcpServers` key manually; leave the rest of the file alone. Not auto-deleted."
+        );
+      }
+    } catch {
+      // settings.json is not valid JSON or unreadable; not our concern here, skip warning.
+    }
+  }
+
+  const strayMcp = path.join(home, ".claude", "mcp.json");
+  if (fs.existsSync(strayMcp)) {
+    console.error(
+      "setup-config: WARNING — ~/.claude/mcp.json exists. This path is INERT (Claude Code reads ~/.claude.json, not ~/.claude/mcp.json). If it only contains a forge entry, you can delete it manually; if it has other entries, verify whether your MCP client (not Claude Code) needs it. Not auto-deleted."
+    );
+  }
+}


### PR DESCRIPTION
## Summary

`scripts/setup-config.cjs` was writing the forge MCP server entry to `~/.claude/settings.json.mcpServers`, a path Claude Code does NOT read (dead-letter). Users who ran `./setup.sh` and then opened Claude Code from a non-forge-harness cwd saw no forge tools despite clean setup. Canonical user-scope path is `~/.claude.json` top-level `mcpServers`, written by `claude mcp add ... -s user`.

**What changes**

- **Primary path**: shell out to `claude mcp add forge node -s user -e FORGE_DASHBOARD_AUTO_OPEN=1 -- <absolute-path-to-dist/index.js>`. Absolute path sidesteps the missing `--cwd` flag in CLI v2.1.114 (so Claude Code's spawn cwd no longer matters).
- **Idempotency**: `claude mcp remove forge -s user` before each add, ignoring "not found."
- **Fallback**: when `claude` CLI is not on PATH, atomic direct-write to `~/.claude.json` top-level `mcpServers.forge` (tempfile + rename), preserving all other keys.
- **Migration warnings** (stderr, non-fatal, no auto-delete) for stale `~/.claude/settings.json.mcpServers.forge` and stray `~/.claude/mcp.json` on existing installs. Both may carry user-authored entries we don't own.
- **Acceptance wrapper** `scripts/setup-config-acceptance.sh` drives 10 AC against an isolated scratch HOME via `HOME=<tmp>` + `USERPROFILE=<tmp>` override (confirmed both node and `claude` CLI v2.1.114 respect it).

**Blast radius / migration**

Every user who previously ran `./setup.sh` is silently broken for non-forge-harness cwds. To pick up the fix:

```bash
# Optional: clean up the stale dead-letter entry
claude mcp remove forge -s user 2>/dev/null || true
# Re-run setup
./setup.sh
# Verify
claude mcp list  # should show: forge: node <abs-path>/dist/index.js - ✓ Connected
# Quit and relaunch Claude Code to pick up the new registration
```

Reported by monday during monday-bot bootstrap (2026-04-19 mailbox thread `forge-harness-monday-bot-support`).

## Test plan

- [x] `bash scripts/setup-config-acceptance.sh` — 11/11 checks pass (AC-1..AC-10, pre-flight)
- [x] `npm run build` — succeeds
- [x] `npx vitest run` — 749 pass, 4 skipped, no new failures
- [x] Verified real `~/.claude.json` untouched by wrapper run (scratch HOME override works)
- [x] `git diff origin/master -- setup.sh` — empty (AC-10)

Closes #304

---
plan-refresh: no-op