### PR TITLE
fix(anthropic): raise DEFAULT_MAX_TOKENS 8192 → 32000 (sweep all LLM call sites)

### DIFF
--- a/.ai-workspace/plans/2026-04-20-default-max-tokens-sweep.md
+++ b/.ai-workspace/plans/2026-04-20-default-max-tokens-sweep.md
@@ -1,0 +1,81 @@
+---
+task: v0.32.7 — bump DEFAULT_MAX_TOKENS 8192→32000 (sweep)
+status: in-flight
+owner: forge-plan
+created: 2026-04-20
+supersedes: none
+---
+
+## ELI5
+
+When Claude sends back a response, forge-harness tells it "stop after N words". v0.32.6 raised N to 32000 only for the corrector (one call site). Monday hit the same wall a few hours later on the PLANNER — another call site — which was still at the old 8192 ceiling (~27KB of JSON). She got a clean `LLMOutputTruncatedError` instead of silent corruption (that part of v0.32.6 worked), but the plan never got drafted.
+
+Instead of repeating the override at 10 different call sites and hoping we don't miss any future ones, raise the default itself. Single-line change, one place to audit, covers all current and future callers.
+
+## Context
+
+Monday blocker #3, mailbox thread `forge-harness-monday-bot-support`, 2026-04-20T03:05Z. Re-invoked `forge_plan` on the same 242-line PRD from blocker #2 after v0.32.6 shipped. Got:
+
+```
+LLMOutputTruncatedError: LLM output truncated: stop_reason=max_tokens hit at
+limit 8192. Received 27108 chars before cutoff.
+```
+
+`agentRole: planner`, not `corrector` — the planner hit the ceiling first, so the corrector never even ran.
+
+**Audit of all 10 `trackedCallClaude` call sites in `server/tools/plan.ts`:**
+- 2 corrector sites (lines 336, 476) — already bumped to `CORRECTOR_MAX_TOKENS = 32000` in v0.32.6 ✓
+- 8 planner/critic sites (lines 235, 251, 291, 384, 399, 440, 526, 541, 582, 597) — all still on default 8192 ❌
+
+Plus call sites in `server/tools/evaluate.ts` (not audited yet; same class of risk).
+
+## Goal
+
+1. Default max_tokens ceiling = 32000 for any LLM call whose caller omits `maxTokens`.
+2. Existing explicit `maxTokens` overrides continue to win (corrector's `32000` and any hypothetical smaller overrides).
+3. No cost impact — Anthropic bills per output-token-used, not per max_tokens-requested.
+4. No behavior change for callers that don't actually produce >8192 tokens of output.
+
+## Binary AC
+
+All checkable by `scripts/default-max-tokens-sweep-acceptance.sh`.
+
+- **AC-1** — `grep -n "const DEFAULT_MAX_TOKENS = 32000" server/lib/anthropic.ts | wc -l` returns `1`.
+- **AC-2** — `grep -n "const DEFAULT_MAX_TOKENS = 8192" server/lib/anthropic.ts | wc -l` returns `0`.
+- **AC-3** — New unit test: `npx vitest run server/lib/anthropic.test.ts -t "max_tokens=32000 to the SDK when caller does not pass maxTokens"` exits 0.
+- **AC-4** — Regression positive: `npx vitest run server/lib/anthropic.test.ts -t "explicit maxTokens override still wins"` exits 0.
+- **AC-5** — Full vitest suite: no test FAILURES (same log-grep gate as v0.32.6 wrapper).
+- **AC-6** — `npm run build` exits 0.
+- **AC-7** — `scripts/default-max-tokens-sweep-acceptance.sh` exists, is executable, exits 0.
+- **AC-8** — `setup.sh` unchanged vs origin/master.
+
+## Out of scope
+
+- Bumping to something higher than 32000 (e.g., full 64K Sonnet 4 ceiling). 32K is enough for every plan size observed and halves max-runaway-cost headroom.
+- Making the default environment-overridable (deferred — see #318 which proposes `FORGE_CORRECTOR_MAX_TOKENS` env var; same idea applies at the default level).
+- AC-pattern lint for vacuous bash pipelines (#312 follow-up; still deferred).
+- Auditing `server/tools/evaluate.ts` call sites for independent LLM-output-size risk (orthogonal; separate PR if needed).
+
+## Critical files
+
+- `server/lib/anthropic.ts` — line 7: `const DEFAULT_MAX_TOKENS = 8192` → `const DEFAULT_MAX_TOKENS = 32000`. Plus a comment explaining the bump rationale so future maintainers understand.
+- `server/lib/anthropic.test.ts` — 2 new tests (default-passed-through + override-wins-regression).
+- `scripts/default-max-tokens-sweep-acceptance.sh` — new acceptance wrapper.
+- `package.json` — version 0.32.6 → 0.32.7 (done by `/ship` Stage 7).
+- `CHANGELOG.md` — new bug-fix entry (done by `/ship` Stage 7).
+
+## Checkpoint
+
+- [x] Monday's mail read + archived
+- [x] ACK sent within 600s SLA (T+8min)
+- [x] Root cause verified via grep audit
+- [x] `server/lib/anthropic.ts` — bumped to 32000
+- [x] `server/lib/anthropic.test.ts` — 2 new tests added
+- [x] `npm run build` green
+- [x] `npx vitest run` — 759 pass, 0 regressions
+- [ ] `scripts/default-max-tokens-sweep-acceptance.sh` wrapper
+- [ ] GH issue filed
+- [ ] `/ship` pipeline
+- [ ] Mail monday with v0.32.7 tag
+
+Last updated: 2026-04-20T03:15:00Z — ready for wrapper + ship.

--- a/scripts/default-max-tokens-sweep-acceptance.sh
+++ b/scripts/default-max-tokens-sweep-acceptance.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Acceptance wrapper for v0.32.7 — bump DEFAULT_MAX_TOKENS 8192 → 32000 sweep.
+# Runs AC-1..AC-8 from .ai-workspace/plans/2026-04-20-default-max-tokens-sweep.md
+# Exits 0 iff all ACs pass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PASS=0
+FAIL=0
+declare -a FAILURES
+
+check() {
+  local name="$1"
+  local description="$2"
+  local exit_code="$3"
+  if [ "$exit_code" -eq 0 ]; then
+    echo "  PASS  $name — $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $name — $description"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: $description")
+  fi
+}
+
+echo "=== v0.32.7 default-max-tokens-sweep acceptance ==="
+echo
+
+# AC-1: DEFAULT_MAX_TOKENS is 32000
+grep -q "^const DEFAULT_MAX_TOKENS = 32000;$" server/lib/anthropic.ts && AC1=0 || AC1=1
+check "AC-1" "DEFAULT_MAX_TOKENS literal is 32000 in anthropic.ts" "$AC1"
+
+# AC-2: old 8192 literal is gone from anthropic.ts
+! grep -q "^const DEFAULT_MAX_TOKENS = 8192;$" server/lib/anthropic.ts && AC2=0 || AC2=1
+check "AC-2" "no stale DEFAULT_MAX_TOKENS = 8192 literal" "$AC2"
+
+# AC-3: default-passed-through unit test passes
+npx vitest run server/lib/anthropic.test.ts -t "max_tokens=32000 to the SDK when caller does not pass maxTokens" > /tmp/ac3.log 2>&1 && AC3=0 || AC3=1
+check "AC-3" "default-maxTokens-passed-through unit test passes" "$AC3"
+
+# AC-4: explicit override still wins
+npx vitest run server/lib/anthropic.test.ts -t "explicit maxTokens override still wins" > /tmp/ac4.log 2>&1 && AC4=0 || AC4=1
+check "AC-4" "explicit maxTokens override still wins (regression positive)" "$AC4"
+
+# AC-5: full suite clean — no test FAILURES (ignore vitest teardown-rpc flake)
+npx vitest run > /tmp/ac5.log 2>&1 || true
+if grep -qE "Tests  [0-9]+ failed" /tmp/ac5.log; then
+  AC5=1
+elif grep -qE "Tests  [0-9]+ passed" /tmp/ac5.log; then
+  AC5=0
+else
+  AC5=1
+fi
+check "AC-5" "full vitest suite passes (no test failures)" "$AC5"
+
+# AC-6: TypeScript build clean
+npm run build > /tmp/ac6.log 2>&1 && AC6=0 || AC6=1
+check "AC-6" "npm run build compiles cleanly" "$AC6"
+
+# AC-8: setup.sh unchanged vs master
+SETUP_DIFF=$(git diff origin/master -- setup.sh 2>/dev/null | wc -l || echo "0")
+[ "$SETUP_DIFF" -eq 0 ] && AC8=0 || AC8=1
+check "AC-8" "setup.sh unchanged vs origin/master (diff lines: $SETUP_DIFF)" "$AC8"
+
+echo
+echo "=== summary: $PASS pass / $FAIL fail ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "FAILURES:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  echo
+  echo "Inspect logs under /tmp/ac*.log for failing ACs."
+  exit 1
+fi
+
+echo "ALL GREEN"
+exit 0

--- a/server/lib/anthropic.test.ts
+++ b/server/lib/anthropic.test.ts
@@ -92,6 +92,44 @@ describe("callClaude — truncation handling (v0.32.6)", () => {
     expect(result.usage.outputTokens).toBe(5);
   });
 
+  it("sends max_tokens=32000 to the SDK when caller does not pass maxTokens (v0.32.7 sweep)", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 2 },
+    });
+
+    const { callClaude } = await import("./anthropic.js");
+
+    await callClaude({
+      system: "s",
+      messages: [{ role: "user", content: "u" }],
+    });
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const sdkArgs = mockCreate.mock.calls[0][0];
+    expect(sdkArgs.max_tokens).toBe(32000);
+  });
+
+  it("explicit maxTokens override still wins over the default (regression positive)", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 2 },
+    });
+
+    const { callClaude } = await import("./anthropic.js");
+
+    await callClaude({
+      system: "s",
+      messages: [{ role: "user", content: "u" }],
+      maxTokens: 1024,
+    });
+
+    const sdkArgs = mockCreate.mock.calls[0][0];
+    expect(sdkArgs.max_tokens).toBe(1024);
+  });
+
   it("does NOT throw when stop_reason is 'stop_sequence'", async () => {
     mockCreate.mockResolvedValueOnce({
       content: [{ type: "text", text: "done." }],

--- a/server/lib/anthropic.ts
+++ b/server/lib/anthropic.ts
@@ -4,7 +4,12 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
-const DEFAULT_MAX_TOKENS = 8192;
+// Raised from 8192 → 32000 in v0.32.7 after monday-bot hit truncation on the
+// planner call site (not just the corrector fixed in v0.32.6). Sonnet 4
+// supports 64K output tokens; 32000 covers every full-plan/findings payload
+// observed so far with headroom. Billing is per-token-used, so non-plan callers
+// pay nothing extra — the raised ceiling just stops clipping premature.
+const DEFAULT_MAX_TOKENS = 32000;
 
 let client: Anthropic | null = null;
 // Track the OAuth token's expiry so we can evict the cache before it goes stale.


### PR DESCRIPTION
## Summary

- Raises `DEFAULT_MAX_TOKENS` in `server/lib/anthropic.ts` from 8192 → 32000. Single-line sweep covering all 10 LLM call sites in `server/tools/plan.ts` (plus any future ones and any in `server/tools/evaluate.ts`). v0.32.6 had raised only the 2 corrector sites; the 8 planner/critic sites remained on the 8192 default and truncated for any plan >~27KB.
- Reported by monday at 2026-04-20T03:05Z (~10h after v0.32.6 shipped). Same 242-line PRD as blocker #2; this time `LLMOutputTruncatedError` fired cleanly (v0.32.6 fix #2 working) on the **planner** call — corrector never ran.
- Explicit `maxTokens: CORRECTOR_MAX_TOKENS` overrides stay in place as documentation of intent; they remain no-ops at the default level but future-proof if the default is ever lowered again.
- No cost or behavior impact on small callers — Anthropic bills per output-token-used, not per max_tokens-requested. Sonnet 4 supports 64K output, 32000 is halfway with headroom.
- Closes #319. Plan at `.ai-workspace/plans/2026-04-20-default-max-tokens-sweep.md` (8 binary AC). 2 new tests (default-passed-through + override-wins-regression). Full suite 759/4skipped/0fail.

## Test plan

- [x] `bash scripts/default-max-tokens-sweep-acceptance.sh` → 7/7 AC green
- [x] `npx vitest run server/lib/anthropic.test.ts` → 6/6 pass (includes 2 new)
- [x] `npx vitest run` full suite → 759 passed, 4 skipped, 0 failed
- [x] `npm run build` → TypeScript compiles clean
- [ ] Reviewer: confirm only one file under `server/` changed (anthropic.ts), to validate the "sweep at the default" principle
- [ ] Reviewer: confirm explicit `maxTokens: CORRECTOR_MAX_TOKENS` overrides are retained in plan.ts

---
plan-refresh: no-op