### PR TITLE
fix(anthropic): switch callClaude to messages.stream().finalMessage() unconditionally

### DIFF
--- a/.ai-workspace/plans/2026-04-20-unconditional-streaming-callclaude.md
+++ b/.ai-workspace/plans/2026-04-20-unconditional-streaming-callclaude.md
@@ -1,0 +1,101 @@
+# v0.32.8 — unconditional streaming in callClaude
+
+## Context
+
+Monday blocker #4 (2026-04-20T03:35Z). v0.32.7's 32000 max_tokens default works (no more
+`stop_reason=max_tokens` truncation), but the Anthropic TypeScript SDK now refuses the
+planner request synchronously:
+
+```
+Streaming is required for operations that may take longer than 10 minutes.
+See https://github.com/anthropics/anthropic-sdk-typescript#long-requests
+```
+
+The SDK predicts runtime from `model + input size + max_tokens` and throws before any
+network call when the prediction exceeds 600s. Same thread (`forge-harness-monday-bot-support`),
+same class-of-bug arc:
+- v0.32.6 — corrector max_tokens truncation detection
+- v0.32.7 — default max_tokens ceiling (8192 → 32000)
+- v0.32.8 — streaming for long calls (THIS)
+
+After this ship, `callClaude` is the single seam handling `{max_tokens, streaming,
+stop_reason, retries, timeouts}` correctly.
+
+## Goal
+
+1. `callClaude` no longer throws "Streaming is required …" when a call's predicted runtime
+   exceeds 10 min.
+2. The return shape (`{text, parsed?, usage}`) of `callClaude` is unchanged — no caller
+   modification required.
+3. `LLMOutputTruncatedError` on `stop_reason: "max_tokens"` still fires through the
+   streaming path (v0.32.6 coverage preserved).
+4. No extra LLM cost — Anthropic bills per token used, streaming adds zero per-call
+   overhead.
+
+## Binary AC
+
+- **AC-1** — `grep -nE "messages\.create\(" server/lib/anthropic.ts | wc -l` prints `0`.
+  (All callClaude message sends go through the streaming helper.)
+- **AC-2** — code-only (strip JSDoc comment lines with leading `*`) count of `anthropic.messages.stream(` call sites in `server/lib/anthropic.ts` equals `1`. JSDoc references don't count.
+- **AC-3** — code-only (strip JSDoc comment lines) count of `.finalMessage()` call sites in `server/lib/anthropic.ts` equals `1`.
+- **AC-4** — `npx tsc --noEmit` exits 0.
+- **AC-5** — `npx vitest run server/lib/anthropic.test.ts 2>&1 | tee /tmp/anthropic.log` completes,
+  and `grep -qE "Tests [0-9]+ passed" /tmp/anthropic.log` AND `! grep -qE "Tests [0-9]+ failed" /tmp/anthropic.log`.
+  Tests cover: (a) uses `messages.stream().finalMessage()` — not `messages.create()`;
+  (b) `LLMOutputTruncatedError` still fires on `stop_reason: "max_tokens"` through the streaming path;
+  (c) default max_tokens=32000 still passed to stream params; (d) explicit maxTokens override wins.
+- **AC-6** — `npx vitest run 2>&1 | tee /tmp/fullsuite.log` completes, and
+  `grep -qE "Tests [0-9]+ passed" /tmp/fullsuite.log` AND `! grep -qE "Tests [0-9]+ failed" /tmp/fullsuite.log`.
+  (The `dashboard-renderer.test.ts` Vitest 4.x teardown-rpc flake may set non-zero exit code
+  even with zero test failures — v0.32.6 acceptance wrapper already encoded this; reuse the same
+  grep-the-log pattern.)
+- **AC-7** — `git grep -nE "messages\.create\(" -- 'server/**/*.ts' ':!server/**/*.test.ts'` returns zero
+  matches. (Sanity: no residual non-streaming call site in production code. Test files are allowed
+  to reference `messages.create` in comments / test-names as intentional tripwires.)
+- **AC-8** — `package.json` version field bumps to `0.32.8`.
+
+## Out of scope
+
+- No changes to caller signatures (plan.ts, coordinator.ts, etc.).
+- No max_tokens heuristics / conditional streaming — per monday's recommendation,
+  unconditional streaming is explicitly safe for short calls.
+- No `requestOptions.timeout` tweaks.
+- No retry policy changes. (Flagged as a future hardening target in the v0.32.8 CHANGELOG note,
+  not in this patch.)
+- No OAuth/auth changes — `getClient()` untouched.
+- No dashboard-renderer teardown-rpc flake fix (known Vitest 4.x issue, encoded in AC-6 workaround).
+
+## Ordering constraints
+
+None — single file plus its test file.
+
+## Verification procedure
+
+Run `scripts/unconditional-streaming-acceptance.sh` (new, mandatory wrapper that runs AC-1
+through AC-8 in order). The wrapper must exit 0 iff every AC passes.
+
+## Critical files
+
+- `server/lib/anthropic.ts` — swap `messages.create(...)` → `messages.stream(...).finalMessage()`
+  inside `callClaude`. Single-file change. Keep `LLMOutputTruncatedError` logic (it reads
+  `response.stop_reason`, which is populated on the final `Message`).
+- `server/lib/anthropic.test.ts` — update mock shape: stub `messages.stream` to return a
+  fake stream-handle whose `finalMessage()` resolves to the Message-shaped value the
+  tests previously handed to `messages.create`. Add two new tests (streaming call path,
+  truncation through streaming).
+- `scripts/unconditional-streaming-acceptance.sh` — NEW. Plan-mandated wrapper.
+- `package.json` — version bump 0.32.7 → 0.32.8.
+- `CHANGELOG.md` — prepend v0.32.8 entry summarizing streaming + class-of-bug closure.
+
+## Checkpoint
+
+- [x] Plan file created
+- [x] `server/lib/anthropic.ts` updated with streaming call
+- [x] `server/lib/anthropic.test.ts` mock + tests updated (7 tests, all green)
+- [x] Acceptance wrapper script created
+- [x] `package.json` bumped to 0.32.8
+- [x] `CHANGELOG.md` prepended
+- [x] Acceptance wrapper green locally (AC-1..8 pass; 760 tests pass in full suite)
+- [ ] `/ship` → PR → CI → stateless review → merge → release → mail monday
+
+Last updated: 2026-04-20T04:00Z — implementation + local AC green, ready for `/ship`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.32.8](https://github.com/ziyilam3999/forge-harness/compare/v0.32.7...v0.32.8) (2026-04-20)
+
+### Bug Fixes
+- **anthropic:** `callClaude` now uses `messages.stream(...).finalMessage()` unconditionally instead of `messages.create(...)`. After v0.32.7 raised `DEFAULT_MAX_TOKENS` to 32000, the Anthropic SDK's synchronous pre-flight check began refusing planner calls with `"Streaming is required for operations that may take longer than 10 minutes"` — the SDK predicts runtime from model + input size + max_tokens and rejects non-streaming requests projected beyond the 600s cap. `messages.stream().finalMessage()` is the SDK-recommended path, returns the same `Message` object (same `content`, `stop_reason`, `usage`), so callers and `LLMOutputTruncatedError` detection are unchanged. Streaming is explicitly safe for short calls per Anthropic docs — zero per-call overhead — so this is flipped at the helper level rather than via a fragile heuristic. Closes the class-of-bug arc v0.32.6 → v0.32.7 → v0.32.8: `callClaude` is now the single seam handling max_tokens, stop_reason, and streaming correctly. 5 retrofitted tests (existing truncation + max_tokens coverage reused via streaming mock) + 1 new transport regression test (`messages.stream` invoked, `messages.create` never invoked). Reported by monday during monday-bot bootstrap (mailbox thread `forge-harness-monday-bot-support`, 2026-04-20T03:35Z). (closes #325)
+
 ## [0.32.7](https://github.com/ziyilam3999/forge-harness/compare/v0.32.6...v0.32.7) (2026-04-20)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-harness",
-  "version": "0.32.7",
+  "version": "0.32.8",
   "type": "module",
   "description": "Composable AI primitives — plan, evaluate, generate, coordinate — as a local MCP server",
   "scripts": {

--- a/scripts/unconditional-streaming-acceptance.sh
+++ b/scripts/unconditional-streaming-acceptance.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Acceptance wrapper for v0.32.8 — unconditional streaming in callClaude.
+# Plan: .ai-workspace/plans/2026-04-20-unconditional-streaming-callclaude.md
+# Exits 0 iff every AC passes, non-zero with a labelled failure otherwise.
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+LOG_DIR="$(mktemp -d)"
+trap 'rm -rf "$LOG_DIR"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+echo "--- AC-1: no messages.create( calls remain in anthropic.ts ---"
+CREATE_COUNT=$(grep -cE 'messages\.create\(' server/lib/anthropic.ts || true)
+[ "$CREATE_COUNT" = "0" ] || fail "AC-1: found $CREATE_COUNT messages.create() call(s) in anthropic.ts"
+echo "PASS: 0 messages.create() calls"
+
+echo "--- AC-2: exactly 1 anthropic.messages.stream( call site in anthropic.ts (excluding JSDoc) ---"
+# Strip JSDoc comment lines (leading `*`) before counting, so the docstring reference doesn't count.
+STREAM_COUNT=$(grep -vE '^\s*\*' server/lib/anthropic.ts | grep -cE 'anthropic\.messages\.stream\(' || true)
+[ "$STREAM_COUNT" = "1" ] || fail "AC-2: expected 1 anthropic.messages.stream() call site, found $STREAM_COUNT"
+echo "PASS: 1 anthropic.messages.stream() call site"
+
+echo "--- AC-3: exactly 1 .finalMessage() call site in anthropic.ts (excluding JSDoc) ---"
+FINAL_COUNT=$(grep -vE '^\s*\*' server/lib/anthropic.ts | grep -cE '\.finalMessage\(\)' || true)
+[ "$FINAL_COUNT" = "1" ] || fail "AC-3: expected 1 .finalMessage() call site, found $FINAL_COUNT"
+echo "PASS: 1 .finalMessage() call site"
+
+echo "--- AC-4: tsc --noEmit clean ---"
+npx tsc --noEmit >"$LOG_DIR/tsc.log" 2>&1 || { cat "$LOG_DIR/tsc.log"; fail "AC-4: tsc failed"; }
+echo "PASS: tsc clean"
+
+echo "--- AC-5: anthropic.test.ts passes (grep log, not exit code) ---"
+npx vitest run server/lib/anthropic.test.ts >"$LOG_DIR/anthropic.log" 2>&1 || true
+grep -qE "Tests[[:space:]]+[0-9]+[[:space:]]+passed" "$LOG_DIR/anthropic.log" || { cat "$LOG_DIR/anthropic.log"; fail "AC-5: no 'Tests N passed' line in vitest output"; }
+if grep -qE "Tests[[:space:]]+[0-9]+[[:space:]]+failed" "$LOG_DIR/anthropic.log"; then
+  cat "$LOG_DIR/anthropic.log"
+  fail "AC-5: found 'Tests N failed' line in vitest output"
+fi
+PASSED_ANTHROPIC=$(grep -oE "Tests[[:space:]]+[0-9]+[[:space:]]+passed" "$LOG_DIR/anthropic.log" | head -1)
+echo "PASS: anthropic.test.ts — $PASSED_ANTHROPIC"
+
+echo "--- AC-6: full vitest suite passes (grep log, tolerate teardown-rpc exit flake) ---"
+npx vitest run >"$LOG_DIR/fullsuite.log" 2>&1 || true
+grep -qE "Tests[[:space:]]+[0-9]+[[:space:]]+passed" "$LOG_DIR/fullsuite.log" || { tail -100 "$LOG_DIR/fullsuite.log"; fail "AC-6: no 'Tests N passed' line in full-suite output"; }
+if grep -qE "Tests[[:space:]]+[0-9]+[[:space:]]+failed" "$LOG_DIR/fullsuite.log"; then
+  tail -100 "$LOG_DIR/fullsuite.log"
+  fail "AC-6: found 'Tests N failed' line in full-suite output"
+fi
+PASSED_FULL=$(grep -oE "Tests[[:space:]]+[0-9]+[[:space:]]+passed" "$LOG_DIR/fullsuite.log" | head -1)
+echo "PASS: full suite — $PASSED_FULL"
+
+echo "--- AC-7: no residual messages.create( in production code under server/ (excluding *.test.ts) ---"
+# Test files may reference the old API name in comments/test-names as intentional tripwires.
+# Production code must not invoke messages.create().
+RESIDUAL=$(git grep -nE 'messages\.create\(' -- 'server/**/*.ts' ':!server/**/*.test.ts' || true)
+[ -z "$RESIDUAL" ] || fail "AC-7: residual messages.create() in production code:\n$RESIDUAL"
+echo "PASS: no residual messages.create() in production code under server/"
+
+echo "--- AC-8: package.json version is 0.32.8 ---"
+VERSION=$(node -p "require('./package.json').version")
+[ "$VERSION" = "0.32.8" ] || fail "AC-8: expected version 0.32.8, got $VERSION"
+echo "PASS: version 0.32.8"
+
+echo ""
+echo "ALL AC GREEN for v0.32.8 unconditional-streaming-callclaude"

--- a/server/lib/anthropic.test.ts
+++ b/server/lib/anthropic.test.ts
@@ -1,17 +1,30 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// Mock the Anthropic SDK. getClient() constructs `new Anthropic(...)` and then
-// calls `client.messages.create(...)`. We stub the whole module so the return
-// value of `messages.create` is a plain object we control per-test.
+// Mock the Anthropic SDK. After v0.32.8, callClaude uses
+// `client.messages.stream(...).finalMessage()` rather than `messages.create(...)`.
+// The mock's `stream` returns a handle whose `finalMessage` resolves to the same
+// Message-shaped object the tests previously handed to `create`.
+const mockStream = vi.fn();
+// Retained as a tripwire: if any code path slips back to `messages.create(...)`,
+// tests that assert `mockCreate` was never called will fail loudly.
 const mockCreate = vi.fn();
 
 vi.mock("@anthropic-ai/sdk", () => {
   return {
     default: class MockAnthropic {
-      messages = { create: mockCreate };
+      messages = { stream: mockStream, create: mockCreate };
     },
   };
 });
+
+/** Build a stream-handle stub whose `finalMessage()` resolves to `message`. */
+function streamHandle(message: {
+  content: Array<{ type: "text"; text: string }>;
+  stop_reason: string;
+  usage: { input_tokens: number; output_tokens: number };
+}) {
+  return { finalMessage: () => Promise.resolve(message) };
+}
 
 // Credentials path: force ANTHROPIC_API_KEY to be set so getClient() uses the
 // env-var branch and never tries to read ~/.claude/.credentials.json from disk.
@@ -21,6 +34,7 @@ beforeEach(async () => {
   process.env.ANTHROPIC_API_KEY = "sk-test-key";
   const { resetClient } = await import("./anthropic.js");
   resetClient();
+  mockStream.mockReset();
   mockCreate.mockReset();
 });
 
@@ -29,13 +43,34 @@ afterEach(() => {
   else process.env.ANTHROPIC_API_KEY = ORIGINAL_ENV;
 });
 
-describe("callClaude — truncation handling (v0.32.6)", () => {
-  it("throws LLMOutputTruncatedError when response.stop_reason === 'max_tokens'", async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: "text", text: '{"plan": {"stories": [{"id":"US-01","' }],
-      stop_reason: "max_tokens",
-      usage: { input_tokens: 100, output_tokens: 8192 },
-    });
+describe("callClaude — transport (v0.32.8 streaming)", () => {
+  it("calls messages.stream(...).finalMessage() — not messages.create()", async () => {
+    mockStream.mockReturnValueOnce(
+      streamHandle({
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 2 },
+      }),
+    );
+
+    const { callClaude } = await import("./anthropic.js");
+
+    await callClaude({ system: "s", messages: [{ role: "user", content: "u" }] });
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("callClaude — truncation handling (v0.32.6 through streaming path)", () => {
+  it("throws LLMOutputTruncatedError when finalMessage.stop_reason === 'max_tokens'", async () => {
+    mockStream.mockReturnValueOnce(
+      streamHandle({
+        content: [{ type: "text", text: '{"plan": {"stories": [{"id":"US-01","' }],
+        stop_reason: "max_tokens",
+        usage: { input_tokens: 100, output_tokens: 8192 },
+      }),
+    );
 
     const { callClaude, LLMOutputTruncatedError } = await import("./anthropic.js");
 
@@ -50,11 +85,13 @@ describe("callClaude — truncation handling (v0.32.6)", () => {
 
   it("LLMOutputTruncatedError carries the limit and output length", async () => {
     const truncatedText = '{"plan": {"stories": [{"id":"US-01","';
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: "text", text: truncatedText }],
-      stop_reason: "max_tokens",
-      usage: { input_tokens: 100, output_tokens: 8192 },
-    });
+    mockStream.mockReturnValueOnce(
+      streamHandle({
+        content: [{ type: "text", text: truncatedText }],
+        stop_reason: "max_tokens",
+        usage: { input_tokens: 100, output_tokens: 8192 },
+      }),
+    );
 
     const { callClaude, LLMOutputTruncatedError } = await import("./anthropic.js");
 
@@ -76,11 +113,13 @@ describe("callClaude — truncation handling (v0.32.6)", () => {
   });
 
   it("does NOT throw when stop_reason is 'end_turn' (normal completion)", async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: "text", text: '{"ok": true}' }],
-      stop_reason: "end_turn",
-      usage: { input_tokens: 10, output_tokens: 5 },
-    });
+    mockStream.mockReturnValueOnce(
+      streamHandle({
+        content: [{ type: "text", text: '{"ok": true}' }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+    );
 
     const { callClaude } = await import("./anthropic.js");
 
@@ -92,12 +131,34 @@ describe("callClaude — truncation handling (v0.32.6)", () => {
     expect(result.usage.outputTokens).toBe(5);
   });
 
-  it("sends max_tokens=32000 to the SDK when caller does not pass maxTokens (v0.32.7 sweep)", async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: "text", text: "ok" }],
-      stop_reason: "end_turn",
-      usage: { input_tokens: 10, output_tokens: 2 },
+  it("does NOT throw when stop_reason is 'stop_sequence'", async () => {
+    mockStream.mockReturnValueOnce(
+      streamHandle({
+        content: [{ type: "text", text: "done." }],
+        stop_reason: "stop_sequence",
+        usage: { input_tokens: 10, output_tokens: 2 },
+      }),
+    );
+
+    const { callClaude } = await import("./anthropic.js");
+
+    const result = await callClaude({
+      system: "s",
+      messages: [{ role: "user", content: "u" }],
     });
+    expect(result.text).toBe("done.");
+  });
+});
+
+describe("callClaude — max_tokens plumbing (v0.32.7 through streaming path)", () => {
+  it("sends max_tokens=32000 to the SDK when caller does not pass maxTokens", async () => {
+    mockStream.mockReturnValueOnce(
+      streamHandle({
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 2 },
+      }),
+    );
 
     const { callClaude } = await import("./anthropic.js");
 
@@ -106,17 +167,19 @@ describe("callClaude — truncation handling (v0.32.6)", () => {
       messages: [{ role: "user", content: "u" }],
     });
 
-    expect(mockCreate).toHaveBeenCalledTimes(1);
-    const sdkArgs = mockCreate.mock.calls[0][0];
+    expect(mockStream).toHaveBeenCalledTimes(1);
+    const sdkArgs = mockStream.mock.calls[0][0];
     expect(sdkArgs.max_tokens).toBe(32000);
   });
 
   it("explicit maxTokens override still wins over the default (regression positive)", async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: "text", text: "ok" }],
-      stop_reason: "end_turn",
-      usage: { input_tokens: 10, output_tokens: 2 },
-    });
+    mockStream.mockReturnValueOnce(
+      streamHandle({
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 2 },
+      }),
+    );
 
     const { callClaude } = await import("./anthropic.js");
 
@@ -126,23 +189,7 @@ describe("callClaude — truncation handling (v0.32.6)", () => {
       maxTokens: 1024,
     });
 
-    const sdkArgs = mockCreate.mock.calls[0][0];
+    const sdkArgs = mockStream.mock.calls[0][0];
     expect(sdkArgs.max_tokens).toBe(1024);
-  });
-
-  it("does NOT throw when stop_reason is 'stop_sequence'", async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: "text", text: "done." }],
-      stop_reason: "stop_sequence",
-      usage: { input_tokens: 10, output_tokens: 2 },
-    });
-
-    const { callClaude } = await import("./anthropic.js");
-
-    const result = await callClaude({
-      system: "s",
-      messages: [{ role: "user", content: "u" }],
-    });
-    expect(result.text).toBe("done.");
   });
 });

--- a/server/lib/anthropic.ts
+++ b/server/lib/anthropic.ts
@@ -170,12 +170,19 @@ export function extractJson(text: string): unknown {
 
 /**
  * Call Claude API with the given prompt. Handles JSON extraction when jsonMode is true.
+ *
+ * Uses `messages.stream(...).finalMessage()` unconditionally: the Anthropic SDK throws
+ * "Streaming is required for operations that may take longer than 10 minutes" synchronously
+ * when the predicted runtime of a non-streaming request exceeds 600s (v0.32.7's 32000
+ * max_tokens tips the planner/corrector over this threshold). Streaming is explicitly safe
+ * for short calls — no per-call overhead, same `Message` shape returned — so we flip the
+ * whole helper rather than adding a fragile heuristic.
  */
 export async function callClaude(options: CallClaudeOptions): Promise<CallClaudeResult> {
   const anthropic = getClient();
   const effectiveMaxTokens = options.maxTokens ?? DEFAULT_MAX_TOKENS;
 
-  const response = await anthropic.messages.create({
+  const stream = anthropic.messages.stream({
     model: options.model ?? DEFAULT_MODEL,
     max_tokens: effectiveMaxTokens,
     system: options.jsonMode
@@ -184,6 +191,7 @@ export async function callClaude(options: CallClaudeOptions): Promise<CallClaude
       : options.system,
     messages: options.messages,
   });
+  const response = await stream.finalMessage();
 
   // Extract text from response content blocks
   const text = response.content


### PR DESCRIPTION
## Summary

- Swap `callClaude`'s `anthropic.messages.create(...)` → `anthropic.messages.stream(...).finalMessage()` to bypass the SDK's synchronous 10-min non-streaming pre-flight check, which started refusing monday-bot's planner calls after v0.32.7 raised `DEFAULT_MAX_TOKENS` to 32000.
- Same `Message` shape returned → no caller changes → `LLMOutputTruncatedError` still fires on `stop_reason: max_tokens` through the streaming path.
- Closes the class-of-bug arc: v0.32.6 (truncation detection) → v0.32.7 (default max_tokens ceiling) → v0.32.8 (streaming for long calls). `callClaude` is now the single seam handling max_tokens + stop_reason + streaming correctly.

## Test plan

- [x] Plan file `.ai-workspace/plans/2026-04-20-unconditional-streaming-callclaude.md` with 8 binary AC
- [x] Acceptance wrapper `scripts/unconditional-streaming-acceptance.sh` — AC-1..8 all PASS locally
- [x] `server/lib/anthropic.test.ts` retrofitted to stream mock; 7 tests pass including new transport regression test (verifies `messages.stream` invoked, `messages.create` never invoked as tripwire for future regression)
- [x] Full suite: 760 tests passed (was 759, +1 for the new transport test)
- [x] `npx tsc --noEmit` clean
- [x] `git grep messages\.create\( -- server/**/*.ts ':!server/**/*.test.ts'` returns zero matches

## Reporter

Monday via mailbox thread `forge-harness-monday-bot-support` at 2026-04-20T03:35Z (blocker #4 on monday-bot bootstrap).

---
plan-refresh: no-op