### PR TITLE
v0.33.0 PR A2 — acceptance wrapper polish (3 issues, retires #322)

### DIFF
--- a/.ai-workspace/plans/2026-04-20-v0-33-0-pr-a2-acceptance-wrapper-polish.md
+++ b/.ai-workspace/plans/2026-04-20-v0-33-0-pr-a2-acceptance-wrapper-polish.md
@@ -1,0 +1,96 @@
+---
+title: "v0.33.0 PR A2 — acceptance wrapper polish"
+date: 2026-04-20
+owner: forge-plan (planner)
+status: in-flight (delegated)
+parent-triage: .ai-workspace/plans/2026-04-20-v0-33-0-polish-bundle-triage.md
+closes: #315 #321 #323
+retires: #322 (closed as dup of #315 during triage)
+---
+
+## ELI5
+
+Two acceptance wrappers (corrector-crash-fix from v0.32.6, default-max-tokens-sweep from v0.32.7) share three defects: (a) they parse vitest stdout text like `Tests 12 passed` instead of using `--reporter=json`, which is brittle across vitest upgrades; (b) the v0.32.7 wrapper has an AC numbering gap (AC-1..AC-6 + AC-8, no AC-7); (c) both use `wc -l` without whitespace trim, fragile on BSD/macOS. Roughly 40 LoC across two scripts. Zero runtime behavior change — the wrappers still prove the same things, just more robustly.
+
+## Context
+
+**Baseline** (master HEAD `5ac9c1d`, post-v0.32.9):
+- `bash scripts/corrector-crash-fix-acceptance.sh` — exits 0 on master (regression guard — must stay green).
+- `bash scripts/default-max-tokens-sweep-acceptance.sh` — exits 0 on master (regression guard — must stay green).
+- Both wrappers are **LOCAL acceptance gates**, not CI checks (`grep setup-config .github/workflows/` returns nothing, same pattern applies to these wrappers).
+
+**The three defects:**
+- **#315** — stdout string-matching. `scripts/corrector-crash-fix-acceptance.sh:67-73` and `scripts/default-max-tokens-sweep-acceptance.sh:50-56` both match `Tests  *[0-9]+ (failed|passed)` via `grep -qE` to distinguish a pre-existing vitest teardown-rpc flake from a real failure. Fix: use `npx vitest run --reporter=json` and query the structured JSON field (`numFailedTests` at the top level, or equivalent). Retires #322 (closed as dup during triage).
+- **#321** — `scripts/default-max-tokens-sweep-acceptance.sh:32-66` prints AC-1..AC-6 and AC-8, skipping AC-7. Either add `[ -x "$0" ]` as AC-7, or renumber AC-8 down to AC-7. Both satisfy the contiguity AC below.
+- **#323** — `git diff ... | wc -l` may emit leading whitespace on BSD/macOS. Trim via `| tr -d ' '` or equivalent. Applies to corrector wrapper line 81 and max-tokens wrapper line 64.
+
+## Goal
+
+1. Both wrappers use vitest's `--reporter=json` (or equivalent structured parse) instead of stdout string-matching for the full-suite "is it green ignoring the teardown flake" check.
+2. v0.32.7 wrapper's AC numbering is contiguous.
+3. Both wrappers trim `wc -l` before numeric compare.
+4. Both wrappers exit 0 (regression guards still pass).
+5. #315, #321, #323 auto-close via PR `closes` trailer.
+
+## Binary AC
+
+### AC-1 — corrector-crash wrapper still green
+`bash scripts/corrector-crash-fix-acceptance.sh` exits 0, stdout contains `ALL GREEN`.
+
+### AC-2 — max-tokens-sweep wrapper still green
+`bash scripts/default-max-tokens-sweep-acceptance.sh` exits 0, stdout contains `ALL GREEN`.
+
+### AC-3 — #315 reporter=json replaces stdout string-matching
+```bash
+grep -q -- '--reporter=json' scripts/corrector-crash-fix-acceptance.sh
+grep -q -- '--reporter=json' scripts/default-max-tokens-sweep-acceptance.sh
+! grep -qE 'Tests  *[0-9]+ (failed|passed)' scripts/corrector-crash-fix-acceptance.sh
+! grep -qE 'Tests  *[0-9]+ (failed|passed)' scripts/default-max-tokens-sweep-acceptance.sh
+```
+
+### AC-4 — #321 max-tokens-sweep wrapper AC numbering is contiguous
+```bash
+NUMS=$(grep -oE 'check "AC-[0-9]+"' scripts/default-max-tokens-sweep-acceptance.sh | grep -oE '[0-9]+' | sort -n | uniq)
+MIN=$(echo "$NUMS" | head -1)
+MAX=$(echo "$NUMS" | tail -1)
+COUNT=$(echo "$NUMS" | wc -l | tr -d ' ')
+[ "$COUNT" -eq "$((MAX - MIN + 1))" ]
+```
+
+### AC-5 — #323 every `wc -l` use in both wrappers is trimmed
+```bash
+TOTAL=$(grep -cE 'wc -l' scripts/corrector-crash-fix-acceptance.sh scripts/default-max-tokens-sweep-acceptance.sh 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+TRIMMED=$(grep -cE 'wc -l[^|]*\| *(tr -d|awk|sed)' scripts/corrector-crash-fix-acceptance.sh scripts/default-max-tokens-sweep-acceptance.sh 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+[ "$TOTAL" -gt 0 ] && [ "$TOTAL" -eq "$TRIMMED" ]
+```
+
+### AC-6 — this A2 plan file exists (satisfied on merge)
+`test -f .ai-workspace/plans/2026-04-20-v0-33-0-pr-a2-acceptance-wrapper-polish.md`.
+
+## Out of scope
+
+- Any other polish issue (#314, #316, #317, #318, #328, #329, #330, #331, #324 — land in PR B/C/D).
+- Any core anthropic / plan / evaluate / corrector logic — wrappers ONLY.
+- Renaming the wrappers.
+- Adding a `jq` npm dependency — if `jq` isn't on PATH, substitute `node -e` + `fs.readFileSync` + `.numFailedTests` (same structural parse).
+- setup-config surface (that was PR A1).
+
+## Ordering constraints
+
+None. All three defects touch disjoint regions inside each wrapper.
+
+## Critical files
+
+- `scripts/corrector-crash-fix-acceptance.sh` — lines 67-73 (stdout grep → --reporter=json), line 81 (wc -l trim).
+- `scripts/default-max-tokens-sweep-acceptance.sh` — lines 50-56 (stdout grep → --reporter=json), line 64 (wc -l trim), AC numbering.
+- `.ai-workspace/plans/2026-04-20-v0-33-0-pr-a2-acceptance-wrapper-polish.md` — this plan.
+
+## Checkpoint
+
+- [x] Baseline check against master (AC-1, AC-2 green on 5ac9c1d)
+- [x] Run /coherent-plan (2 majors fixed)
+- [x] /delegate invoked
+- [ ] Executor ships branch green
+- [ ] /ship → stateless reviewer → merge + auto-close
+
+Last updated: 2026-04-20T06:50:00+00:00 — delegated.

--- a/scripts/corrector-crash-fix-acceptance.sh
+++ b/scripts/corrector-crash-fix-acceptance.sh
@@ -77,7 +77,7 @@ npm run build > /tmp/ac8.log 2>&1 && AC8=0 || AC8=1
 check "AC-8" "npm run build compiles cleanly" "$AC8"
 
 # AC-10 (partial — AC-9 is this wrapper's own pass/fail): setup.sh unchanged vs master
-SETUP_DIFF=$(git diff origin/master -- setup.sh 2>/dev/null | wc -l || echo "0")
+SETUP_DIFF=$(git diff origin/master -- setup.sh 2>/dev/null | wc -l | tr -d ' ' || echo "0")
 [ "$SETUP_DIFF" -eq 0 ] && AC10=0 || AC10=1
 check "AC-10" "setup.sh unchanged vs origin/master (diff lines: $SETUP_DIFF)" "$AC10"
 

--- a/scripts/corrector-crash-fix-acceptance.sh
+++ b/scripts/corrector-crash-fix-acceptance.sh
@@ -15,6 +15,11 @@ PASS=0
 FAIL=0
 declare -a FAILURES
 
+# Wrapper writes vitest JSON output to a project-relative tmp dir so paths
+# resolve identically under bash (MSYS /tmp ≠ node.exe /tmp on Windows) and
+# node. tmp/ is gitignored per .gitignore.
+mkdir -p tmp
+
 check() {
   local name="$1"
   local description="$2"
@@ -64,8 +69,8 @@ check "AC-6" "plan.test.ts regression-positive (corrector success → outcome:su
 # to the corrector fix. The authoritative signal is `numFailedTests == 0` in
 # vitest's structured JSON output (not stdout text, which is brittle across
 # vitest upgrades).
-npx vitest run --reporter=json --outputFile=/tmp/ac7.json > /tmp/ac7.log 2>&1 || true
-if [ -s /tmp/ac7.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("/tmp/ac7.json","utf-8")); process.exit(d.numFailedTests > 0 ? 1 : 0)'; then
+npx vitest run --reporter=json --outputFile=tmp/ac7.json > /tmp/ac7.log 2>&1 || true
+if [ -s tmp/ac7.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("tmp/ac7.json","utf-8")); process.exit(d.numFailedTests > 0 ? 1 : 0)'; then
   AC7=0
 else
   AC7=1

--- a/scripts/corrector-crash-fix-acceptance.sh
+++ b/scripts/corrector-crash-fix-acceptance.sh
@@ -61,12 +61,11 @@ check "AC-6" "plan.test.ts regression-positive (corrector success → outcome:su
 # AC-7: full vitest suite clean — no test FAILURES. We ignore the non-zero exit
 # when it comes from the pre-existing dashboard-renderer.test.ts teardown-rpc
 # race (Vitest 4.x EnvironmentTeardownError) because that flake is orthogonal
-# to the corrector fix. The authoritative signal is "Tests X passed" with no
-# failed tests reported on the summary line.
-npx vitest run > /tmp/ac7.log 2>&1 || true
-if grep -qE "Tests  [0-9]+ failed" /tmp/ac7.log; then
-  AC7=1
-elif grep -qE "Tests  [0-9]+ passed" /tmp/ac7.log; then
+# to the corrector fix. The authoritative signal is `numFailedTests == 0` in
+# vitest's structured JSON output (not stdout text, which is brittle across
+# vitest upgrades).
+npx vitest run --reporter=json --outputFile=/tmp/ac7.json > /tmp/ac7.log 2>&1 || true
+if [ -s /tmp/ac7.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("/tmp/ac7.json","utf-8")); process.exit(d.numFailedTests > 0 ? 1 : 0)'; then
   AC7=0
 else
   AC7=1

--- a/scripts/default-max-tokens-sweep-acceptance.sh
+++ b/scripts/default-max-tokens-sweep-acceptance.sh
@@ -45,11 +45,11 @@ check "AC-3" "default-maxTokens-passed-through unit test passes" "$AC3"
 npx vitest run server/lib/anthropic.test.ts -t "explicit maxTokens override still wins" > /tmp/ac4.log 2>&1 && AC4=0 || AC4=1
 check "AC-4" "explicit maxTokens override still wins (regression positive)" "$AC4"
 
-# AC-5: full suite clean — no test FAILURES (ignore vitest teardown-rpc flake)
-npx vitest run > /tmp/ac5.log 2>&1 || true
-if grep -qE "Tests  [0-9]+ failed" /tmp/ac5.log; then
-  AC5=1
-elif grep -qE "Tests  [0-9]+ passed" /tmp/ac5.log; then
+# AC-5: full suite clean — no test FAILURES (ignore vitest teardown-rpc flake).
+# Use vitest's structured JSON reporter so we parse numFailedTests rather than
+# stdout text, which is brittle across vitest upgrades.
+npx vitest run --reporter=json --outputFile=/tmp/ac5.json > /tmp/ac5.log 2>&1 || true
+if [ -s /tmp/ac5.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("/tmp/ac5.json","utf-8")); process.exit(d.numFailedTests > 0 ? 1 : 0)'; then
   AC5=0
 else
   AC5=1

--- a/scripts/default-max-tokens-sweep-acceptance.sh
+++ b/scripts/default-max-tokens-sweep-acceptance.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Acceptance wrapper for v0.32.7 — bump DEFAULT_MAX_TOKENS 8192 → 32000 sweep.
-# Runs AC-1..AC-8 from .ai-workspace/plans/2026-04-20-default-max-tokens-sweep.md
+# Runs AC-1..AC-7 from .ai-workspace/plans/2026-04-20-default-max-tokens-sweep.md
+# (AC-8 from the plan — the setup.sh-unchanged guard — is checked here as AC-7
+# so the wrapper's numbering is contiguous; same coverage, just renumbered).
 # Exits 0 iff all ACs pass.
 
 set -euo pipefail
@@ -60,10 +62,10 @@ check "AC-5" "full vitest suite passes (no test failures)" "$AC5"
 npm run build > /tmp/ac6.log 2>&1 && AC6=0 || AC6=1
 check "AC-6" "npm run build compiles cleanly" "$AC6"
 
-# AC-8: setup.sh unchanged vs master
-SETUP_DIFF=$(git diff origin/master -- setup.sh 2>/dev/null | wc -l || echo "0")
-[ "$SETUP_DIFF" -eq 0 ] && AC8=0 || AC8=1
-check "AC-8" "setup.sh unchanged vs origin/master (diff lines: $SETUP_DIFF)" "$AC8"
+# AC-7: setup.sh unchanged vs master
+SETUP_DIFF=$(git diff origin/master -- setup.sh 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+[ "$SETUP_DIFF" -eq 0 ] && AC7=0 || AC7=1
+check "AC-7" "setup.sh unchanged vs origin/master (diff lines: $SETUP_DIFF)" "$AC7"
 
 echo
 echo "=== summary: $PASS pass / $FAIL fail ==="

--- a/scripts/default-max-tokens-sweep-acceptance.sh
+++ b/scripts/default-max-tokens-sweep-acceptance.sh
@@ -14,6 +14,11 @@ PASS=0
 FAIL=0
 declare -a FAILURES
 
+# Wrapper writes vitest JSON output to a project-relative tmp dir so paths
+# resolve identically under bash (MSYS /tmp ≠ node.exe /tmp on Windows) and
+# node. tmp/ is gitignored per .gitignore.
+mkdir -p tmp
+
 check() {
   local name="$1"
   local description="$2"
@@ -50,8 +55,8 @@ check "AC-4" "explicit maxTokens override still wins (regression positive)" "$AC
 # AC-5: full suite clean — no test FAILURES (ignore vitest teardown-rpc flake).
 # Use vitest's structured JSON reporter so we parse numFailedTests rather than
 # stdout text, which is brittle across vitest upgrades.
-npx vitest run --reporter=json --outputFile=/tmp/ac5.json > /tmp/ac5.log 2>&1 || true
-if [ -s /tmp/ac5.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("/tmp/ac5.json","utf-8")); process.exit(d.numFailedTests > 0 ? 1 : 0)'; then
+npx vitest run --reporter=json --outputFile=tmp/ac5.json > /tmp/ac5.log 2>&1 || true
+if [ -s tmp/ac5.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("tmp/ac5.json","utf-8")); process.exit(d.numFailedTests > 0 ? 1 : 0)'; then
   AC5=0
 else
   AC5=1


### PR DESCRIPTION
## Summary

v0.33.0 polish bundle — PR A2 of 5 (acceptance-wrapper surface). Three defects shared across `scripts/corrector-crash-fix-acceptance.sh` (v0.32.6) and `scripts/default-max-tokens-sweep-acceptance.sh` (v0.32.7). Zero runtime behaviour change — wrappers prove the same things, more robustly.

- **#315** — Full-suite check now uses `npx vitest run --reporter=json` + `node -e` JSON parse of `numFailedTests` instead of grep-for-`Tests N passed` stdout string. Robust across vitest upgrades. Applied to both wrappers.
- **#321** — `default-max-tokens-sweep-acceptance.sh` AC numbering is now contiguous (AC-1..AC-7). The prior "AC-1..AC-6 + AC-8" gap is closed by renumbering AC-8 down to AC-7.
- **#323** — Both wrappers now trim `git diff ... | wc -l` via `| tr -d ' '` for BSD/macOS portability.

**Retires #322** — closed during triage as dup of #315; same fix (switch to `--reporter=json`) retires both wrappers' brittle-grep patterns.

**Unplanned in-scope fix (4th commit).** The `jq`-fallback substitution I instructed the executor to use (`node -e` reading vitest's JSON output) hit a Windows-MSYS quirk: `/tmp/ac7.json` resolves to the MSYS `/tmp` (`$USERPROFILE/AppData/Local/Temp`) under bash, but to `C:\tmp\` under node.exe (drive-root semantics). Fix: project-relative `tmp/` (already in `.gitignore`), which bash and node resolve identically on Windows AND works on Linux/macOS. Applied to both wrappers.

**Out-of-scope finding flagged** (not fixed here): `corrector-crash-fix-acceptance.sh` has the same AC-numbering gap as #321 did (AC-9 missing between AC-8 and AC-10). Filed as issue #338 for a future v0.34.x polish run.

Net: 3 files changed, +124/-17.

## Test plan

- [x] **AC-1** `bash scripts/corrector-crash-fix-acceptance.sh` → exit 0, `ALL GREEN`, 9/9 pass
- [x] **AC-2** `bash scripts/default-max-tokens-sweep-acceptance.sh` → exit 0, `ALL GREEN`, 7/7 pass (contiguous AC-1..AC-7)
- [x] **AC-3** both wrappers contain `--reporter=json`; neither contains the brittle `Tests  *[0-9]+ (failed|passed)` pattern as a pass/fail branch
- [x] **AC-4** max-tokens wrapper AC numbers `1,2,3,4,5,6,7` — MIN=1, MAX=7, COUNT=7, contiguous
- [x] **AC-5** both `wc -l` uses (1 per wrapper) are trimmed with `| tr -d ' '`
- [x] **AC-6** plan file `.ai-workspace/plans/2026-04-20-v0-33-0-pr-a2-acceptance-wrapper-polish.md` committed on branch

Both wrappers are **local acceptance gates**, not CI-invoked — no `.github/workflows/*.yml` references them. The regression guard is the reviewer running AC-1/AC-2 locally.

---

Closes #315, closes #321, closes #323. Retires #322 (closed as dup of #315 during triage — no auto-close possible, noted here for audit).

---

plan-refresh: no-op