### PR TITLE
fix(planner): forbid cd <project-basename> prefix in AC commands

### DIFF
--- a/server/lib/prompts/planner.test.ts
+++ b/server/lib/prompts/planner.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  buildPlannerPrompt,
   buildPlannerUserMessage,
   buildMasterPlannerPrompt,
   buildMasterPlannerUserMessage,
@@ -202,5 +203,40 @@ describe("buildUpdatePlannerUserMessage", () => {
     expect(msg).toContain("## Current Plan");
     expect(msg).toContain("## Implementation Notes");
     expect(msg).toContain("Used Redis instead of Memcached");
+  });
+});
+
+describe("AC cwd-policy — prevents doubled-cd defect (monday-bot 2026-04-20)", () => {
+  const modes = ["feature", "full-project", "bugfix"] as const;
+
+  it.each(modes)(
+    "buildPlannerPrompt(%s) tells the model cwd is already projectPath",
+    (mode) => {
+      const prompt = buildPlannerPrompt(mode);
+      expect(prompt).toContain("Working directory");
+      expect(prompt).toContain("cwd is ALREADY the project root");
+      expect(prompt).toContain("projectPath");
+    },
+  );
+
+  it.each(modes)(
+    "buildPlannerPrompt(%s) forbids `cd <project-basename> && ...` prefix",
+    (mode) => {
+      const prompt = buildPlannerPrompt(mode);
+      expect(prompt).toContain("cd <project-basename>");
+      expect(prompt).toContain("cd my-project && npx tsc");
+      expect(prompt).toContain("RIGHT: `npx tsc --noEmit`");
+    },
+  );
+
+  it("the forbidden example names monday-bot so future readers see the provenance", () => {
+    const prompt = buildPlannerPrompt("full-project");
+    expect(prompt).toContain("monday-bot/monday-bot/");
+  });
+
+  it("buildPhasePlannerPrompt inherits the cwd-policy from the base prompt", () => {
+    const prompt = buildPhasePlannerPrompt("feature");
+    expect(prompt).toContain("cwd is ALREADY the project root");
+    expect(prompt).toContain("cd <project-basename>");
   });
 });

--- a/server/lib/prompts/shared/ac-subprocess-rules.ts
+++ b/server/lib/prompts/shared/ac-subprocess-rules.ts
@@ -21,6 +21,15 @@ import { createHash } from "node:crypto";
 export const AC_SUBPROCESS_RULES_PROMPT = `### AC Command Contract
 AC commands execute inside node:child_process.exec() with bash shell.
 Environment: no TTY, no stdin, stdout/stderr captured as evidence, 30s timeout.
+Working directory: cwd is ALREADY the project root (the forge_evaluate \`projectPath\`
+argument). Write AC commands as if you are already inside that directory — do NOT
+prefix them with \`cd <project-basename> && ...\`. That prefix is always wrong: the
+project is already the cwd, so \`cd monday-bot && npm install\` looks for
+\`monday-bot/monday-bot/\` and fails. \`cd\` into *sub-directories* of the project
+(\`cd packages/foo && ...\`) is fine when genuinely needed; the rule is specifically
+against re-entering the project root.
+  WRONG: \`cd my-project && npx tsc --noEmit\`
+  RIGHT: \`npx tsc --noEmit\`
 Exit code 0 = PASS, non-zero = FAIL. Design commands accordingly:
 - Prefer exit-code checks over stdout parsing:
   GOOD: \`npx vitest run -t 'budget'\` (exits 0 on pass)


### PR DESCRIPTION
## Summary

forge_evaluate already sets `cwd=projectPath`, but the planner prompt had no guidance on cwd policy. The LLM defaulted to a safe-looking convention — prepending `cd <basename> && ...` to every AC command — which doubles the cd and makes every AC fail on first run.

Reported by monday-bot on 2026-04-20 during US-01 bootstrap:
```
"evidence": "/usr/bin/bash: line 1: cd: monday-bot: No such file or directory\n"
```

All 5 US-01 ACs failed identically. After stripping the `^cd monday-bot && ` prefix from all 59 ACs in the plan JSON, all ACs PASS on re-evaluate. monday filed an FYI mail (archived at `mailbox/archive/2026-04-20T0510-monday-to-forge-plan-fyi-cd-prefix-defect-on-ac-commands.md`) with a full diagnosis pointing at the planner prompt.

## Fix

Adds a `Working directory:` paragraph to `AC_SUBPROCESS_RULES_PROMPT` (shared between planner and critic via `server/lib/prompts/shared/ac-subprocess-rules.ts`). The paragraph:

1. States that cwd is already `projectPath` at execution time.
2. Explicitly forbids `cd <project-basename> && ...` prefixes (with monday-bot as the named evidence example).
3. Permits `cd` into sub-directories of the project when genuinely needed (`cd packages/foo && ...`) — the rule targets the specific anti-pattern of re-entering the project root.
4. Shows a WRONG/RIGHT example.

Pure additive rule-surface change. No existing rule is modified or removed. `getAcLintRulesHash()` output changes as designed — cached `lint-audit` entries become stale and need re-review via `forge_lint_refresh` (intended behavior per Q0.5/A3-bis).

## Scope

- `server/lib/prompts/shared/ac-subprocess-rules.ts` — +8-line paragraph inside `AC_SUBPROCESS_RULES_PROMPT`.
- `server/lib/prompts/planner.test.ts` — +4 new test cases (each parameterized over 3 modes via `it.each`) pinning the new guidance in `buildPlannerPrompt` and `buildPhasePlannerPrompt`.

## Test plan

- [x] `npx vitest run server/lib/prompts/planner.test.ts` — 33/33 pass (+6 new)
- [x] `npx vitest run server/lib/prompts/ server/lib/lint-audit.test.ts server/tools/lint-refresh.test.ts server/validation/ac-lint.test.ts` — 109/109 pass (no fallout from hash change)
- [x] `npx vitest run` — full suite 768/768 pass + 4 skipped (no regressions)
- [x] `npx vitest run server/smoke/mcp-surface.test.ts` — 6/6 pass
- [x] Critic hook ran against all 12 `.ai-workspace/plans/*.json` — 0 drift findings (verified via `grep '\bcd\s' .ai-workspace/plans/*.json` returning zero matches; MCP critic mode errored with streaming-required on stale dist, fell back to in-session critique per `feedback_mcp_determinism_is_output_schema`)

## Not in scope

- Fixing the 6 code-level enhancements from monday's US-01 stateless review (issues #2-#7 on ziyilam3999/monday-bot). Those are monday-bot code decisions, not forge-harness planner output — replied to monday that those stay in her repo for natural per-story sweep.
- Adding an ac-lint deny-list rule for the `cd <basename> &&` pattern. Prompt-level guidance is the cause-level fix; a lint rule would be a safety net. Can be added later if a second observation shows the prompt guidance isn't enough.

---
plan-refresh: no-op