### PR TITLE
v0.33.0 PR B — anthropic + plan polish (6 issues)

### DIFF
--- a/.ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish.md
+++ b/.ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish.md
@@ -1,0 +1,141 @@
+# v0.33.0 PR B — anthropic + plan polish (6 issues)
+
+Slice B of the v0.33.0 polish bundle. Retires GitHub issues #314, #316, #317, #318, #329, #330.
+
+## ELI5
+
+Clean up six small things in the LLM-call helper and the plan corrector:
+1. Make the "LLM was cut off" check harder to silently break if Anthropic adds a new reason-code (#314).
+2. Drop a redundant "check the error message text" line from a test — the structured fields already cover it (#316).
+3. Let operators raise the corrector token budget via an env var without recompiling (#317).
+4. Hoist a test-scope guard into a suite-wide guard so every test proves the non-streaming path stays dead (#318).
+5. Surface cache-hit/creation token counts that the SDK already returns but we were throwing away (#329).
+6. Merge a dangling JSDoc comment back onto the function it was meant to describe (#330).
+
+No new behavior, no API breaking change, no dependency bump. Pure cleanup of the cost/type/test surfaces touched by v0.32.6–v0.32.8.
+
+## Context
+
+v0.32.6 → v0.32.8 shipped three monday-bot blockers in five days:
+- v0.32.6 raised corrector `max_tokens` 8192 → 32000 after monday-bot's plan truncated mid-string.
+- v0.32.7 swept that bump to every `callClaude` site.
+- v0.32.8 flipped `callClaude` unconditionally to `messages.stream(...).finalMessage()` because 32000 tokens tipped the predicted runtime over the 10-minute non-streaming ceiling.
+
+Each of those three ship-reviews surfaced nits that were triaged to issues rather than folded in-flight (correctly — ship-review's scope was the bug fix, not the surrounding tidy-up). This PR is that deferred follow-up batch.
+
+**Why now:** these issues sit on the `callClaude` and `runCorrector` seams, which are about to see more pressure:
+- monday-bot's next forge_plan invocation will stress the same paths and is the first real external user of `callClaude`.
+- Future cost/usage telemetry work (queued in the v0.34.x triage backlog) will extend the reconcile loop's pricing surface; widening `CallClaudeResult.usage` now (#329) lets that work inherit the richer shape.
+- Every non-polished assertion is one copy-paste away from becoming the idiom for future tests.
+
+**Non-goals:** this PR does not touch the OAuth/API-key auth branch, the `extractJson` helper, the planner/critic/corrector prompts, or any pricing logic. Those live in adjacent files and belong to different slices.
+
+## Goal
+
+When PR B merges, the following invariants hold:
+
+1. `CallClaudeResult.usage` exposes `cacheCreationInputTokens` and `cacheReadInputTokens` as optional numeric fields, populated from `response.usage` when the SDK returns them. Existing fields (`inputTokens`, `outputTokens`) are unchanged.
+2. The truncation check in `callClaude` uses a typed stop-reason comparison that surfaces a TypeScript compile error if the SDK's `stop_reason` union gains a new variant and the new variant is not handled. Runtime behavior for the existing `"max_tokens"` path is unchanged.
+3. `CORRECTOR_MAX_TOKENS` in `server/tools/plan.ts` is exported, and its value falls back to `32000` unless `process.env.FORGE_CORRECTOR_MAX_TOKENS` is set to a positive integer.
+4. `anthropic.test.ts` hoists `expect(mockCreate).not.toHaveBeenCalled()` into a suite-scoped `afterEach`, so the "never falls back to non-streaming" guarantee applies to every test case in the file, not just the one that asserts it today.
+5. `anthropic.test.ts` truncation assertion relies only on the structured `maxTokensLimit` / `outputChars` fields; the two `err.message.toContain(...)` lines are removed.
+6. The orphaned JSDoc block above `CORRECTOR_MAX_TOKENS` in `plan.ts` is consolidated so that every JSDoc block sits directly above the declaration it documents. No function or constant is left with a dangling comment.
+
+## Binary AC
+
+Reviewer runs each command; exit code 0 = pass. All commands runnable from repo root against the merged branch.
+
+1. **AC-B1 (exports — #329 regression guard, source-based):**
+   `grep -E '^export async function callClaude\(' server/lib/anthropic.ts` returns a non-empty match — `callClaude` is still exported as an async function. Source-based (not dist-based) so AC-B1 does not implicitly depend on the build step.
+2. **AC-B2 (types — #329 usage shape, observable via TS):**
+   `npx tsc --noEmit -p tsconfig.json` exits 0. A follow-on grep proves the widening landed: `grep -c 'cacheCreationInputTokens\|cacheReadInputTokens' server/lib/anthropic.ts` returns ≥ 3 (the type field, the test, the extraction).
+3. **AC-B3 (stop_reason — #314 compile-time guard):**
+   `grep -E "stop_reason.*=== ['\"]max_tokens['\"]" server/lib/anthropic.ts` returns **0** matches — the bare string literal comparison must be gone, replaced by a typed narrowing.
+4. **AC-B4 (corrector env override — #317 observable via test):**
+   `npx vitest run -t 'CORRECTOR_MAX_TOKENS'` exits 0 and reports ≥ 1 passing test. The new test asserts (a) the default 32000 when env is unset and (b) the override when `FORGE_CORRECTOR_MAX_TOKENS=12345`.
+5. **AC-B5 (corrector export — #317 structural):**
+   `grep -c '^export const CORRECTOR_MAX_TOKENS' server/tools/plan.ts` returns 1.
+6. **AC-B6 (test tripwire — #318 suite-scoped):**
+   `node -e "const s=require('fs').readFileSync('server/lib/anthropic.test.ts','utf8'); const blocks=s.match(/afterEach\s*\(\s*\(\s*\)\s*=>\s*\{[\s\S]*?\}\s*\)/g)||[]; process.exit(blocks.some(b=>/mockCreate[\s\S]*not[\s\S]*toHaveBeenCalled/.test(b))?0:1)"` exits 0 — at least one `afterEach` block body contains the `mockCreate` not-called assertion. Multi-line safe; would pass on both inline-arrow and block-body afterEach styles.
+7. **AC-B7 (test simplification — #316):**
+   `grep -cE 'err\.message[^)]*\)\.toContain' server/lib/anthropic.test.ts` returns 0. (Baseline on master: 2 — source is `expect(err.message).toContain(...)`; the `)` between `message` and `.toContain` requires the `[^)]*\)` bridge in the pattern. A naive `err.message.toContain` grep with unescaped dots and single-char `.` wildcards returns 0 on master and would silently false-PASS the AC — caught by /delegate's baseline check on 2026-04-20.)
+8. **AC-B8 (JSDoc consolidation — #330):**
+   `node -e "const s=require('fs').readFileSync('server/tools/plan.ts','utf8'); const block=s.match(/\\/\\*\\*[\\s\\S]*?Run a corrector agent[\\s\\S]*?\\*\\//); if(!block) process.exit(0); const idx=s.indexOf(block[0]); const after=s.slice(idx+block[0].length, idx+block[0].length+100); process.exit(/^\\s*(export\\s+)?(async\\s+)?(function|const)/.test(after)?0:1)"` exits 0 — if the "Run a corrector agent" JSDoc still exists, the first non-whitespace token after it is a declaration keyword (not a separate JSDoc).
+9. **AC-B9 (test suite regression — focused):**
+   `npx vitest run server/lib/anthropic.test.ts` exits 0 with 0 failing and 0 skipped tests. All pre-existing transport / truncation / max_tokens cases continue to pass. The new CORRECTOR_MAX_TOKENS test has its own observable check in AC-B4; the executor picks where to colocate it (inside `anthropic.test.ts`, a new `server/tools/plan.test.ts`, or an existing plan test file) — AC-B4 verifies it by name regardless of file.
+10. **AC-B10 (full test suite):**
+    `npm test` exits 0.
+11. **AC-B11 (build):**
+    `npm run build` exits 0 and produces `dist/lib/anthropic.js`, `dist/tools/plan.js`.
+12. **AC-B12 (no drive-by edits — allowlist):**
+    `git diff master...HEAD --name-only` returns a subset of `{server/lib/anthropic.ts, server/lib/anthropic.test.ts, server/tools/plan.ts, server/tools/plan.test.ts, .ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish.md, scripts/pr-b-acceptance.sh, package.json, CHANGELOG.md}`. Note: `server/tools/plan.test.ts` is in the allowlist regardless of whether it pre-exists — the executor may create it for AC-B4's test home.
+
+## Out of scope
+
+- Changing the `callClaude` signature (input shape) — only the return-shape's `usage` field widens.
+- Changing the `DEFAULT_MAX_TOKENS` value (32000 stays).
+- Changing the OAuth / API-key auth branch, `getClient()`, or `resetClient()`.
+- Adding pricing logic for cache tokens (that lives in `server/lib/cost.ts`, belongs to a v0.34.x slice).
+- Touching the planner/critic/corrector prompt constants.
+- Widening `CallClaudeOptions` or adding new call sites.
+- Fixing or refactoring `extractJson` (not a PR B surface).
+- Any changes to monday-bot or monday-bot's plan files.
+- Changing how `tsconfig.json` or `vitest.config.ts` resolve files.
+
+## Ordering constraints
+
+None — the 6 issues are independent. The executor may pick any internal order; AC-B9 and AC-B10 only pass when all six land.
+
+## Verification procedure
+
+```bash
+# 1. Build
+npm run build
+
+# 2. Fast focused tests
+npx vitest run server/lib/anthropic.test.ts server/tools/plan.test.ts
+
+# 3. Full suite
+npm test
+
+# 4. Structural checks
+grep -c 'cacheCreationInputTokens\|cacheReadInputTokens' server/lib/anthropic.ts   # ≥ 3
+grep -E "stop_reason.*=== ['\"]max_tokens['\"]" server/lib/anthropic.ts            # 0 lines
+grep -c '^export const CORRECTOR_MAX_TOKENS' server/tools/plan.ts                  # 1
+grep -cE 'err\.message[^)]*\)\.toContain' server/lib/anthropic.test.ts             # 0 (post-fix); 2 on master
+grep -E "afterEach[\s\S]*mockCreate[\s\S]*not[\s\S]*toHaveBeenCalled" server/lib/anthropic.test.ts  # matches
+
+# 5. Env-override test — test self-manages process.env via vi.resetModules()
+#    (no shell-level env prefix needed; the test sets/unsets the var internally)
+npx vitest run -t 'CORRECTOR_MAX_TOKENS'
+
+# 6. Diff allowlist
+git diff master...HEAD --name-only
+```
+
+## Critical files
+
+- `server/lib/anthropic.ts` — callClaude, CallClaudeResult, LLMOutputTruncatedError. Target for #314 (typed stop_reason) and #329 (usage widening).
+- `server/lib/anthropic.test.ts` — streaming transport + truncation + max_tokens tests. Target for #316 (drop message substring), #318 (afterEach tripwire).
+- `server/tools/plan.ts` — `CORRECTOR_MAX_TOKENS` constant + `runCorrector`. Target for #317 (export + env override) and #330 (JSDoc consolidation).
+- `scripts/pr-b-acceptance.sh` — plan-mandated acceptance wrapper; must run every AC in order and exit 0 iff all pass.
+- `package.json` — version bump in the release stage only (not by the executor).
+- `CHANGELOG.md` — release entry in the release stage only.
+
+## Checkpoint
+
+- [ ] Plan file saved and critiqued via /coherent-plan
+- [ ] Branch created
+- [ ] #329 — CallClaudeResult.usage widened, optional cache fields populated when SDK returns them
+- [ ] #314 — stop_reason check typed so new SDK variants break at compile time
+- [ ] #317 — CORRECTOR_MAX_TOKENS exported; FORGE_CORRECTOR_MAX_TOKENS env override respected
+- [ ] #316 — redundant `err.message.toContain(...)` assertions removed
+- [ ] #318 — `afterEach` tripwire added asserting `mockCreate` was never called
+- [ ] #330 — orphaned JSDoc consolidated; no dangling comment blocks
+- [ ] `scripts/pr-b-acceptance.sh` written and green
+- [ ] Full `npm test` green
+- [ ] PR created, CI green, stateless review passes
+- [ ] Merged via /ship; 6 issues auto-closed by "fixes" trailer
+- [ ] v0.33.0 still pending (bundle release is after PR D)
+
+Last updated: 2026-04-20 — post-/coherent-plan (2 major + 4 minor findings fixed inline, under escalation threshold).

--- a/.ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish.md
+++ b/.ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish.md
@@ -68,7 +68,10 @@ Reviewer runs each command; exit code 0 = pass. All commands runnable from repo 
 11. **AC-B11 (build):**
     `npm run build` exits 0 and produces `dist/lib/anthropic.js`, `dist/tools/plan.js`.
 12. **AC-B12 (no drive-by edits — allowlist):**
-    `git diff master...HEAD --name-only` returns a subset of `{server/lib/anthropic.ts, server/lib/anthropic.test.ts, server/tools/plan.ts, server/tools/plan.test.ts, .ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish.md, scripts/pr-b-acceptance.sh, package.json, CHANGELOG.md}`. Note: `server/tools/plan.test.ts` is in the allowlist regardless of whether it pre-exists — the executor may create it for AC-B4's test home.
+    `git diff master...HEAD --name-only` returns a subset of `{server/lib/anthropic.ts, server/lib/anthropic.test.ts, server/tools/plan.ts, server/tools/plan.test.ts, server/tools/reconcile.test.ts, .ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish.md, scripts/pr-b-acceptance.sh, package.json, CHANGELOG.md}`. Notes: `server/tools/plan.test.ts` is in the allowlist regardless of whether it pre-exists — the executor may create it for AC-B4's test home. `server/tools/reconcile.test.ts` was added by amendment 2026-04-20 so the executor can remove the stale AC8 guard (see AC-B13).
+
+13. **AC-B13 (stale reconcile AC8 guard removed — plan amendment 2026-04-20):**
+    `node -e "const s=require('fs').readFileSync('server/tools/reconcile.test.ts','utf8'); const has=/AC8:\s*(plan\.ts not modified|git diff master\.\.HEAD -- server\/tools\/plan\.ts is empty)/.test(s); process.exit(has?1:0)"` exits 0 — both the `describe(\"handleReconcile — plan.ts untouched\", ...)` block and its single `it(\"AC8: ...\")` case are removed entirely (not renamed or skipped). Rationale: AC8 was a one-time PR-scope guard from PR #164 verifying that that PR did not directly edit plan.ts; it has no perpetual architectural value, and it deterministically fails on any future branch that legitimately edits plan.ts (e.g., PR B for #317 + #330). `AC9: handlePlan called with documentTier:"update"` is the proper perpetual invariant for the reconcile→plan contract and is retained unchanged.
 
 ## Out of scope
 
@@ -81,6 +84,7 @@ Reviewer runs each command; exit code 0 = pass. All commands runnable from repo 
 - Fixing or refactoring `extractJson` (not a PR B surface).
 - Any changes to monday-bot or monday-bot's plan files.
 - Changing how `tsconfig.json` or `vitest.config.ts` resolve files.
+- **Any test in `server/tools/reconcile.test.ts` other than the stale AC8 guard.** AC1–AC7 and AC9 are untouched — PR B only removes the AC8 `describe`+`it` pair that was a one-time PR-scope check left lingering (see AC-B13).
 
 ## Ordering constraints
 
@@ -111,6 +115,9 @@ npx vitest run -t 'CORRECTOR_MAX_TOKENS'
 
 # 6. Diff allowlist
 git diff master...HEAD --name-only
+
+# 7. AC-B13: stale AC8 guard removed
+node -e "const s=require('fs').readFileSync('server/tools/reconcile.test.ts','utf8'); process.exit(/AC8:\s*(plan\.ts not modified|git diff master\.\.HEAD -- server\/tools\/plan\.ts is empty)/.test(s)?1:0)"
 ```
 
 ## Critical files
@@ -118,6 +125,7 @@ git diff master...HEAD --name-only
 - `server/lib/anthropic.ts` — callClaude, CallClaudeResult, LLMOutputTruncatedError. Target for #314 (typed stop_reason) and #329 (usage widening).
 - `server/lib/anthropic.test.ts` — streaming transport + truncation + max_tokens tests. Target for #316 (drop message substring), #318 (afterEach tripwire).
 - `server/tools/plan.ts` — `CORRECTOR_MAX_TOKENS` constant + `runCorrector`. Target for #317 (export + env override) and #330 (JSDoc consolidation).
+- `server/tools/reconcile.test.ts` — delete the stale AC8 one-time PR-scope guard at approximately lines 323–339 (`describe("handleReconcile — plan.ts untouched", ...)` block + its single `it("AC8: ...")`). Do not touch AC1–AC7 or AC9.
 - `scripts/pr-b-acceptance.sh` — plan-mandated acceptance wrapper; must run every AC in order and exit 0 iff all pass.
 - `package.json` — version bump in the release stage only (not by the executor).
 - `CHANGELOG.md` — release entry in the release stage only.
@@ -132,10 +140,11 @@ git diff master...HEAD --name-only
 - [ ] #316 — redundant `err.message.toContain(...)` assertions removed
 - [ ] #318 — `afterEach` tripwire added asserting `mockCreate` was never called
 - [ ] #330 — orphaned JSDoc consolidated; no dangling comment blocks
+- [ ] AC-B13 — stale reconcile AC8 guard removed (plan amendment 2026-04-20; unblocks AC-B10)
 - [ ] `scripts/pr-b-acceptance.sh` written and green
 - [ ] Full `npm test` green
 - [ ] PR created, CI green, stateless review passes
 - [ ] Merged via /ship; 6 issues auto-closed by "fixes" trailer
 - [ ] v0.33.0 still pending (bundle release is after PR D)
 
-Last updated: 2026-04-20 — post-/coherent-plan (2 major + 4 minor findings fixed inline, under escalation threshold).
+Last updated: 2026-04-20 — amended mid-execution after AC-B10 blocker: stale `reconcile.test.ts` AC8 guard from PR #164 trips on any branch legitimately editing plan.ts. Added AC-B13 to remove it, widened AC-B12 allowlist, updated Out of scope + Critical files + Verification procedure to match. Executor applies this amendment as a `docs(plan):` commit on the feature branch per CLAUDE.md's mid-flight-amendment rule.

--- a/scripts/pr-b-acceptance.sh
+++ b/scripts/pr-b-acceptance.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# v0.33.0 PR B acceptance wrapper.
+# Runs AC-B1 through AC-B12 in order and exits 0 iff all pass.
+# Plan: .ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish.md
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+cyan()  { printf '\033[36m%s\033[0m\n' "$*"; }
+
+section() { cyan "=== $1 ==="; }
+pass()    { green "  PASS: $1"; }
+fail()    { red   "  FAIL: $1"; exit 1; }
+
+section "AC-B1 (callClaude still exported as async function)"
+grep -E '^export async function callClaude\(' server/lib/anthropic.ts >/dev/null \
+  || fail "callClaude is not exported as an async function"
+pass "callClaude exported as async function"
+
+section "AC-B2 (tsc clean + cache field plumbing)"
+npx tsc --noEmit -p tsconfig.json
+cache_hits="$(grep -c 'cacheCreationInputTokens\|cacheReadInputTokens' server/lib/anthropic.ts || true)"
+[ "${cache_hits:-0}" -ge 3 ] \
+  || fail "expected >=3 occurrences of cache field names in anthropic.ts, got ${cache_hits}"
+pass "tsc --noEmit green; ${cache_hits} cache-field occurrences"
+
+section "AC-B3 (stop_reason bare string comparison is gone)"
+bad_hits="$(grep -cE "stop_reason.*=== ['\"]max_tokens['\"]" server/lib/anthropic.ts || true)"
+[ "${bad_hits:-0}" = "0" ] \
+  || fail "stop_reason === 'max_tokens' still present (${bad_hits} matches)"
+pass "no bare stop_reason string comparisons"
+
+section "AC-B4 (CORRECTOR_MAX_TOKENS env override test — named match)"
+npx vitest run -t 'CORRECTOR_MAX_TOKENS'
+pass "CORRECTOR_MAX_TOKENS tests pass"
+
+section "AC-B5 (CORRECTOR_MAX_TOKENS exported)"
+export_hits="$(grep -c '^export const CORRECTOR_MAX_TOKENS' server/tools/plan.ts || true)"
+[ "${export_hits:-0}" = "1" ] \
+  || fail "expected exactly 1 'export const CORRECTOR_MAX_TOKENS' match, got ${export_hits}"
+pass "CORRECTOR_MAX_TOKENS export present"
+
+section "AC-B6 (afterEach tripwire asserts mockCreate not called)"
+node -e "const s=require('fs').readFileSync('server/lib/anthropic.test.ts','utf8'); const blocks=s.match(/afterEach\s*\(\s*\(\s*\)\s*=>\s*\{[\s\S]*?\}\s*\)/g)||[]; process.exit(blocks.some(b=>/mockCreate[\s\S]*not[\s\S]*toHaveBeenCalled/.test(b))?0:1)" \
+  || fail "no afterEach block asserts mockCreate was never called"
+pass "afterEach tripwire present"
+
+section "AC-B7 (err.message.toContain assertions removed)"
+toContain_hits="$(grep -cE 'err\.message[^)]*\)\.toContain' server/lib/anthropic.test.ts || true)"
+[ "${toContain_hits:-0}" = "0" ] \
+  || fail "err.message().toContain(...) assertions still present (${toContain_hits} matches)"
+pass "no err.message toContain assertions"
+
+section "AC-B8 (JSDoc 'Run a corrector agent' consolidated or deleted)"
+node -e "const s=require('fs').readFileSync('server/tools/plan.ts','utf8'); const block=s.match(/\/\*\*[\s\S]*?Run a corrector agent[\s\S]*?\*\//); if(!block) process.exit(0); const idx=s.indexOf(block[0]); const after=s.slice(idx+block[0].length, idx+block[0].length+100); process.exit(/^\s*(export\s+)?(async\s+)?(function|const)/.test(after)?0:1)" \
+  || fail "'Run a corrector agent' JSDoc is not directly above a declaration"
+pass "JSDoc consolidation clean"
+
+section "AC-B9 (focused anthropic test suite)"
+npx vitest run server/lib/anthropic.test.ts
+pass "server/lib/anthropic.test.ts green"
+
+section "AC-B10 (full test suite)"
+npm test
+pass "npm test green"
+
+section "AC-B11 (build produces dist files)"
+npm run build
+[ -f dist/lib/anthropic.js ] || fail "dist/lib/anthropic.js missing"
+[ -f dist/tools/plan.js ]    || fail "dist/tools/plan.js missing"
+pass "dist/lib/anthropic.js and dist/tools/plan.js produced"
+
+section "AC-B12 (diff allowlist — no drive-by edits)"
+ALLOWED='^(server/lib/anthropic\.ts|server/lib/anthropic\.test\.ts|server/tools/plan\.ts|server/tools/plan\.test\.ts|\.ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish\.md|scripts/pr-b-acceptance\.sh|package\.json|CHANGELOG\.md)$'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  if ! printf '%s\n' "$f" | grep -qE "$ALLOWED"; then
+    fail "out-of-scope file in diff: $f"
+  fi
+done < <(git diff master...HEAD --name-only)
+pass "diff is a subset of the allowlist"
+
+green "ALL AC PASS"

--- a/scripts/pr-b-acceptance.sh
+++ b/scripts/pr-b-acceptance.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # v0.33.0 PR B acceptance wrapper.
-# Runs AC-B1 through AC-B12 in order and exits 0 iff all pass.
+# Runs AC-B1 through AC-B13 in order and exits 0 iff all pass.
 # Plan: .ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish.md
 set -euo pipefail
 
@@ -73,7 +73,7 @@ npm run build
 pass "dist/lib/anthropic.js and dist/tools/plan.js produced"
 
 section "AC-B12 (diff allowlist — no drive-by edits)"
-ALLOWED='^(server/lib/anthropic\.ts|server/lib/anthropic\.test\.ts|server/tools/plan\.ts|server/tools/plan\.test\.ts|\.ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish\.md|scripts/pr-b-acceptance\.sh|package\.json|CHANGELOG\.md)$'
+ALLOWED='^(server/lib/anthropic\.ts|server/lib/anthropic\.test\.ts|server/tools/plan\.ts|server/tools/plan\.test\.ts|server/tools/reconcile\.test\.ts|\.ai-workspace/plans/2026-04-20-v0-33-0-pr-b-anthropic-plan-polish\.md|scripts/pr-b-acceptance\.sh|package\.json|CHANGELOG\.md)$'
 while IFS= read -r f; do
   [ -z "$f" ] && continue
   if ! printf '%s\n' "$f" | grep -qE "$ALLOWED"; then
@@ -81,5 +81,10 @@ while IFS= read -r f; do
   fi
 done < <(git diff master...HEAD --name-only)
 pass "diff is a subset of the allowlist"
+
+section "AC-B13 (stale reconcile AC8 guard removed — plan amendment 2026-04-20)"
+node -e "const s=require('fs').readFileSync('server/tools/reconcile.test.ts','utf8'); process.exit(/AC8:\s*(plan\.ts not modified|git diff master\.\.HEAD -- server\/tools\/plan\.ts is empty)/.test(s)?1:0)" \
+  || fail "stale AC8 guard still present in server/tools/reconcile.test.ts"
+pass "stale AC8 guard removed"
 
 green "ALL AC PASS"

--- a/server/lib/anthropic.test.ts
+++ b/server/lib/anthropic.test.ts
@@ -41,6 +41,13 @@ beforeEach(async () => {
 afterEach(() => {
   if (ORIGINAL_ENV === undefined) delete process.env.ANTHROPIC_API_KEY;
   else process.env.ANTHROPIC_API_KEY = ORIGINAL_ENV;
+  // Suite-scoped tripwire (#318): callClaude must never fall back to the
+  // non-streaming `messages.create(...)` path — v0.32.8 flipped it to
+  // streaming unconditionally because 32000-token predicted runtimes tripped
+  // the SDK's 10-minute non-streaming ceiling. Hoisting this assertion to
+  // `afterEach` means every test in the file enforces the invariant, not
+  // just the one that asserts it today.
+  expect(mockCreate).not.toHaveBeenCalled();
 });
 
 describe("callClaude — transport (v0.32.8 streaming)", () => {
@@ -105,10 +112,10 @@ describe("callClaude — truncation handling (v0.32.6 through streaming path)", 
     } catch (e) {
       expect(e).toBeInstanceOf(LLMOutputTruncatedError);
       const err = e as InstanceType<typeof LLMOutputTruncatedError>;
+      // Structured fields are the contract — the human-readable `message`
+      // string is prose and is not asserted here (#316).
       expect(err.maxTokensLimit).toBe(8192);
       expect(err.outputChars).toBe(truncatedText.length);
-      expect(err.message).toContain("max_tokens");
-      expect(err.message).toContain("8192");
     }
   });
 

--- a/server/lib/anthropic.ts
+++ b/server/lib/anthropic.ts
@@ -115,7 +115,51 @@ export interface CallClaudeOptions {
 export interface CallClaudeResult {
   text: string;
   parsed?: unknown;
-  usage: { inputTokens: number; outputTokens: number };
+  /**
+   * Token usage from the SDK's `response.usage`.
+   *
+   * `inputTokens` / `outputTokens` are always set. The two cache fields are
+   * optional because the SDK returns them as `number | null` — they are only
+   * populated when the request used prompt caching AND the SDK surfaced a
+   * numeric value. Downstream cost/telemetry code should treat `undefined`
+   * the same as zero.
+   */
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationInputTokens?: number;
+    cacheReadInputTokens?: number;
+  };
+}
+
+/**
+ * Narrowing helper for Anthropic's `stop_reason` union. Returns `true` iff
+ * the caller is looking at the `"max_tokens"` variant, and — crucially —
+ * enforces exhaustive handling of the full `StopReason` union at compile
+ * time via the `never` fallthrough. If the SDK ships a new variant and this
+ * switch is not updated, `tsc --noEmit` fails at the `never` assignment.
+ *
+ * The union is widened to accept `null` because `Message.stop_reason` is
+ * typed `StopReason | null` on the response.
+ */
+function isMaxTokensStop(stopReason: Anthropic.StopReason | null): boolean {
+  switch (stopReason) {
+    case "max_tokens":
+      return true;
+    case "end_turn":
+    case "stop_sequence":
+    case "tool_use":
+    case "pause_turn":
+    case "refusal":
+    case null:
+      return false;
+    default: {
+      // Compile-time exhaustiveness guard — a new SDK variant will surface
+      // here as a TS2322 "Type 'X' is not assignable to type 'never'".
+      const _exhaustive: never = stopReason;
+      return _exhaustive;
+    }
+  }
 }
 
 /**
@@ -201,15 +245,27 @@ export async function callClaude(options: CallClaudeOptions): Promise<CallClaude
 
   // Detect truncation by max_tokens and throw, rather than returning text the
   // caller will fail to parse. Keeps silent-truncation bugs loud — see forge_plan
-  // corrector crash (monday blocker, 2026-04-19, v0.32.6).
-  if (response.stop_reason === "max_tokens") {
+  // corrector crash (monday blocker, 2026-04-19, v0.32.6). Uses a typed
+  // narrowing helper so a new SDK `stop_reason` variant surfaces at compile
+  // time rather than silently slipping past this string-literal check.
+  if (isMaxTokensStop(response.stop_reason)) {
     throw new LLMOutputTruncatedError(effectiveMaxTokens, text.length);
   }
 
-  const usage = {
+  const usage: CallClaudeResult["usage"] = {
     inputTokens: response.usage.input_tokens,
     outputTokens: response.usage.output_tokens,
   };
+  // Cache token counts are `number | null` in the SDK and only populated when
+  // the request used prompt caching. Pass them through when present so
+  // downstream telemetry can distinguish cache hits / creations from
+  // cold-read input tokens (see #329 — v0.34.x cost surface will price these).
+  if (response.usage.cache_creation_input_tokens != null) {
+    usage.cacheCreationInputTokens = response.usage.cache_creation_input_tokens;
+  }
+  if (response.usage.cache_read_input_tokens != null) {
+    usage.cacheReadInputTokens = response.usage.cache_read_input_tokens;
+  }
 
   if (options.jsonMode) {
     const parsed = extractJson(text);

--- a/server/tools/plan.test.ts
+++ b/server/tools/plan.test.ts
@@ -1307,6 +1307,61 @@ describe("documentTier: update", () => {
   });
 });
 
+// #317 — CORRECTOR_MAX_TOKENS export + FORGE_CORRECTOR_MAX_TOKENS env override.
+// The constant is resolved at module load (IIFE reads process.env once), so each
+// test mutates process.env, calls vi.resetModules(), then re-imports plan.ts.
+describe("CORRECTOR_MAX_TOKENS env override (#317)", () => {
+  const ORIGINAL_OVERRIDE = process.env.FORGE_CORRECTOR_MAX_TOKENS;
+
+  afterEach(() => {
+    if (ORIGINAL_OVERRIDE === undefined) {
+      delete process.env.FORGE_CORRECTOR_MAX_TOKENS;
+    } else {
+      process.env.FORGE_CORRECTOR_MAX_TOKENS = ORIGINAL_OVERRIDE;
+    }
+    vi.resetModules();
+  });
+
+  it("defaults to 32000 when FORGE_CORRECTOR_MAX_TOKENS is unset", async () => {
+    delete process.env.FORGE_CORRECTOR_MAX_TOKENS;
+    vi.resetModules();
+    const mod = await import("./plan.js");
+    expect(mod.CORRECTOR_MAX_TOKENS).toBe(32000);
+  });
+
+  it("respects FORGE_CORRECTOR_MAX_TOKENS=12345 override", async () => {
+    process.env.FORGE_CORRECTOR_MAX_TOKENS = "12345";
+    vi.resetModules();
+    const mod = await import("./plan.js");
+    expect(mod.CORRECTOR_MAX_TOKENS).toBe(12345);
+  });
+
+  it("falls back to 32000 when FORGE_CORRECTOR_MAX_TOKENS is non-numeric", async () => {
+    process.env.FORGE_CORRECTOR_MAX_TOKENS = "not-a-number";
+    vi.resetModules();
+    const mod = await import("./plan.js");
+    expect(mod.CORRECTOR_MAX_TOKENS).toBe(32000);
+  });
+
+  it("falls back to 32000 when FORGE_CORRECTOR_MAX_TOKENS is zero or negative", async () => {
+    process.env.FORGE_CORRECTOR_MAX_TOKENS = "0";
+    vi.resetModules();
+    let mod = await import("./plan.js");
+    expect(mod.CORRECTOR_MAX_TOKENS).toBe(32000);
+
+    process.env.FORGE_CORRECTOR_MAX_TOKENS = "-500";
+    vi.resetModules();
+    mod = await import("./plan.js");
+    expect(mod.CORRECTOR_MAX_TOKENS).toBe(32000);
+  });
+
+  it("is exported (structural)", async () => {
+    vi.resetModules();
+    const mod = await import("./plan.js");
+    expect(typeof mod.CORRECTOR_MAX_TOKENS).toBe("number");
+  });
+});
+
 describe("backward compatibility (no documentTier)", () => {
   it("produces execution plan when documentTier is omitted", async () => {
     const plan = makeValidPlan();

--- a/server/tools/plan.ts
+++ b/server/tools/plan.ts
@@ -311,17 +311,29 @@ async function runCritic(
 }
 
 /**
- * Run a corrector agent. Returns corrected plan or the original on failure.
- */
-
-/**
  * Corrector output budget. A full revised execution/master plan can run 20-40KB
  * of indented JSON (stories × AC × paths). 8192 tokens (~27KB) was the default
  * and truncated monday-bot's plan at position 26918 on 2026-04-19 (v0.32.6 fix).
  * 32000 tokens ≈ 105KB — fits every plan size observed so far with headroom.
+ *
+ * Runtime override: set `FORGE_CORRECTOR_MAX_TOKENS` to a positive integer to
+ * raise (or lower) the ceiling without recompiling. Non-positive / unparseable
+ * values fall back to the 32000 default. Exported so tests and external
+ * callers can read the resolved value rather than re-parsing the env var.
  */
-const CORRECTOR_MAX_TOKENS = 32000;
+export const CORRECTOR_MAX_TOKENS: number = (() => {
+  const raw = process.env.FORGE_CORRECTOR_MAX_TOKENS;
+  if (raw === undefined || raw === "") return 32000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    return 32000;
+  }
+  return parsed;
+})();
 
+/**
+ * Run a corrector agent. Returns corrected plan or the original on failure.
+ */
 async function runCorrector(
   plan: ExecutionPlan,
   findings: CritiqueFindings,

--- a/server/tools/reconcile.test.ts
+++ b/server/tools/reconcile.test.ts
@@ -3,7 +3,6 @@ import { join } from "node:path";
 import { mkdir, writeFile, rm, readFile, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { createHash } from "node:crypto";
-import { execSync } from "node:child_process";
 
 // Mock handlePlan — Q0/L5: returns structured updatedPlan + critiqueRounds
 // sidecar fields alongside a text blob. reconcile.ts reads the structured
@@ -317,24 +316,6 @@ describe("handleReconcile — precedence conflict resolution", () => {
     const output = JSON.parse(result.content[0].text);
     expect(output.conflicts).toHaveLength(1);
     expect(output.conflicts[0].winningCategory).toBe("assumption-changed");
-  });
-});
-
-// ── AC8: plan.ts not modified ──
-describe("handleReconcile — plan.ts untouched", () => {
-  it("AC8: git diff master..HEAD -- server/tools/plan.ts is empty", () => {
-    const repoRoot = join(__dirname, "..", "..");
-    let output = "";
-    try {
-      output = execSync("git diff master..HEAD -- server/tools/plan.ts", {
-        cwd: repoRoot,
-        encoding: "utf-8",
-      });
-    } catch {
-      // Skip if not in git context
-      return;
-    }
-    expect(output).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary
- Retires 6 polish issues on the anthropic/plan surface, plus removes a stale AC8 unit-test guard from PR #164 that deterministically tripped on any branch editing `plan.ts`.
- No behavior change: typed `stop_reason` narrowing + cache-token fields in `CallClaudeResult.usage` + `CORRECTOR_MAX_TOKENS` export/env-override + `afterEach` tripwire hoist + redundant assertion removal + orphaned JSDoc consolidation.

### Issues retired
fixes #314, fixes #316, fixes #317, fixes #318, fixes #329, fixes #330

Also: deletes stale `server/tools/reconcile.test.ts` AC8 `plan.ts not modified` guard (one-time PR-scope check from #164 that had no perpetual value — AC9 is the real invariant and is retained).

### Notable
- AC-B13 was added mid-execution via plan amendment after the executor hit the AC8 blocker. The amendment and fix both ride this branch per CLAUDE.md's mid-flight-amendment rule (`docs(plan):` + `test(reconcile):` commits).
- New env var: `FORGE_CORRECTOR_MAX_TOKENS` (positive integer) overrides the 32000 default for `runCorrector`. Unset/invalid → falls back to 32000.
- `CallClaudeResult.usage` widened with optional `cacheCreationInputTokens` + `cacheReadInputTokens` from SDK; existing `inputTokens`/`outputTokens` unchanged.

## Test plan
- [x] `bash scripts/pr-b-acceptance.sh` exits 0 — 13 AC pass including new AC-B13
- [x] `npm test` exits 0 — 772 passed, 4 skipped, 0 failed (was previously blocked by stale AC8; now unblocked)
- [x] `npm run build` produces `dist/lib/anthropic.js`, `dist/tools/plan.js`
- [x] `git diff master...HEAD --name-only` within AC-B12 allowlist (7 files, all in-scope)

---
plan-refresh: no-op