### PR TITLE
v0.33.0 PR E — cumulative minor-version release (#354)

### DIFF
--- a/.ai-workspace/plans/2026-04-20-v0-33-0-pr-e-cumulative-release.md
+++ b/.ai-workspace/plans/2026-04-20-v0-33-0-pr-e-cumulative-release.md
@@ -1,0 +1,103 @@
+# v0.33.0 PR E — Cumulative minor-version release (v0.32.14 → v0.33.0)
+
+## Context
+
+Fifth and final slice of the v0.33.0 polish bundle. PRs A1/A2/B/C/D shipped as patch releases v0.32.9 through v0.32.14; PR E promotes the cumulative work to a minor-version milestone (v0.33.0).
+
+This is a **release-only** PR — no feature code, no behavior changes. Two deliverables:
+
+1. **Version bump**: `package.json` 0.32.14 → 0.33.0.
+2. **CHANGELOG consolidation + header fix**: prepend a consolidated v0.33.0 entry summarizing the polish bundle arc, AND fix issue #354 (CHANGELOG header monotonic-ordering bug).
+
+### Why #354 is bundled (not deferred)
+
+Issue #354 was filed during PR C's stateless review: the `# Changelog` H1 is buried at line 47 of CHANGELOG.md because `/ship` Stage 7 prepends every new version section to the file top, without special-casing an existing title block. v0.33.0 polish entries (v0.32.9–v0.32.14) landed above the H1; pre-polish entries (v0.32.8 and below) sit below it. Bundling #354 into PR E makes sense because:
+
+- PR E is the natural place to add ONE more entry at the top — fixing the H1 ordering at the same time is zero additional risk.
+- If deferred to v0.34.x, the bug would deepen (every new v0.34.x entry would prepend above a mis-placed H1, compounding the drift).
+- Scope remains purely document-formatting — same class as the CHANGELOG-split in PR C.
+
+The underlying `/ship` skill prepend-logic bug is out of scope for this repo — it's a skill-level fix candidate for the ai-brain `/ship` skill definition.
+
+### Git log shape deviation carried forward from PR D
+
+PR D tagged its merge commit (`c92aaf6`) directly as v0.32.14 without creating a separate `chore: release 0.32.14` commit — a deviation from PRs A1/A2/B/C which all have a post-merge chore commit. PR E will mirror PR D: the feature-branch commit `chore(release): v0.33.0 ...` becomes the merge commit, tagged v0.33.0 directly. One commit, one tag, one merge. Rationale: PR E's content IS the release — there's no feature to separate from the release-metadata, so a redundant post-merge chore commit has no signal value.
+
+## Goal
+
+Ship v0.33.0 as a clean minor-version milestone with a readable CHANGELOG that future readers can navigate without encountering a buried H1.
+
+## Binary AC
+
+1. **AC-E1** — `package.json` version is exactly `"0.33.0"`:
+   ```bash
+   node -e "console.log(require('./package.json').version)" | grep -cx '0.33.0' | awk '$1 == 1 { exit 0 } { exit 1 }'
+   ```
+
+2. **AC-E2** — `CHANGELOG.md` line 1 is the `# Changelog` H1 (not a version entry):
+   ```bash
+   awk 'NR==1 { if ($0 == "# Changelog") exit 0; else exit 1 }' CHANGELOG.md
+   ```
+
+3. **AC-E3** — `CHANGELOG.md` contains exactly ONE `# Changelog` H1 (no stray duplicates after prior move):
+   ```bash
+   grep -cE '^# Changelog$' CHANGELOG.md | awk '$1 == 1 { exit 0 } { exit 1 }'
+   ```
+
+4. **AC-E4** — First `## [X.Y.Z]` version header is `## [0.33.0]...`:
+   ```bash
+   grep -nE '^## \[' CHANGELOG.md | head -1 | grep -qE '^[0-9]+:## \[0\.33\.0\]'
+   ```
+
+5. **AC-E5** — Version header monotonic-descending (no version appears BEFORE a higher version in file order):
+   ```bash
+   grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | awk -F'[][]' '{print $2}' > tmp/pr-e-versions.txt && node -e "const fs=require('fs');const v=fs.readFileSync('tmp/pr-e-versions.txt','utf8').trim().split('\n');const cmp=(a,b)=>{const[a1,a2,a3]=a.split('.').map(Number);const[b1,b2,b3]=b.split('.').map(Number);return a1-b1||a2-b2||a3-b3;};for(let i=0;i<v.length-1;i++){if(cmp(v[i],v[i+1])<=0){console.error('non-monotonic at '+i+': '+v[i]+' before '+v[i+1]);process.exit(1);}}"
+   ```
+
+6. **AC-E6** — v0.33.0 CHANGELOG entry references issue #354 (proves bundle intent):
+   ```bash
+   awk '/^## \[0\.33\.0\]/,/^## \[0\.32\.14\]/' CHANGELOG.md | grep -q '#354'
+   ```
+
+7. **AC-E7** — All tests pass (no regressions) with count unchanged from master baseline of 776:
+   ```bash
+   mkdir -p tmp && MSYS_NO_PATHCONV=1 npx vitest run --reporter=json --outputFile=tmp/pr-e-vitest.json > /dev/null 2>&1; node -e "const r=require('./tmp/pr-e-vitest.json'); if (r.numFailedTests === 0 && r.numPassedTests >= 776) process.exit(0); else { console.error('tests: ' + r.numPassedTests + ' passed / ' + r.numFailedTests + ' failed'); process.exit(1); }"
+   ```
+
+8. **AC-E8** — Changes confined to release-only surface (no code edits):
+   ```bash
+   git diff --name-only master...HEAD | grep -vE '^(CHANGELOG\.md|package\.json|\.ai-workspace/plans/2026-04-20-v0-33-0-pr-e-cumulative-release\.md|scripts/pr-e-acceptance\.sh)$' | wc -l | awk '$1 == 0 { exit 0 } { exit 1 }'
+   ```
+
+## Out of scope
+
+1. Any changes to `server/**/*.ts` (no feature code).
+2. Fixing the underlying `/ship` skill prepend-logic bug (candidate for ai-brain v0.34.x task).
+3. Rewriting historical CHANGELOG entries (only the v0.33.0 prepend + H1 relocation).
+4. Resolving any other v0.34.x polish items (#352/#353/#355 from PR C review; #347-#350 from PR B review; #357/#358/#359 from PR D review).
+5. Renderer/dashboard work (monday's forge_status proposal is tracked under Task #111 for v0.34.x).
+6. Issue-closure PRs for pre-v0.32.5 backlog (#271-#303 range).
+7. The `# Changelog` H1 move is the ONLY structural change to existing lines — don't reformat or rewrap historical entries.
+
+## Verification procedure
+
+Reviewer runs `scripts/pr-e-acceptance.sh` from repo root against the feature branch. It executes AC-E1..E8 in order and exits 0 iff all pass. Print-on-pass: `ALL PR E ACCEPTANCE CHECKS PASSED`.
+
+## Critical files
+
+- `package.json` — version field. Bump 0.32.14 → 0.33.0.
+- `CHANGELOG.md` — prepend v0.33.0 entry, move `# Changelog` H1 to top, drop stray intro lines at buried position.
+- `scripts/pr-e-acceptance.sh` — new acceptance wrapper, runs AC-E1..E8.
+- `.ai-workspace/plans/2026-04-20-v0-33-0-pr-e-cumulative-release.md` — this file, in-scope for AC-E8 allowlist.
+
+## Checkpoint
+
+- [x] Plan written, baseline state measured (current tag v0.32.14, CHANGELOG H1 at L47)
+- [x] #354 bug confirmed via direct read of CHANGELOG.md
+- [ ] Run `/coherent-plan` on this plan
+- [ ] Create feature branch, implement edits
+- [ ] Create `scripts/pr-e-acceptance.sh`
+- [ ] Run wrapper locally — all 8 AC green
+- [ ] `/ship` — Stage 5 stateless review + merge + tag v0.33.0
+
+Last updated: 2026-04-20T10:55:00+00:00

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.33.0](https://github.com/ziyilam3999/forge-harness/compare/v0.32.14...v0.33.0) (2026-04-20)
+
+### Miscellaneous
+
+- **v0.33.0 — cumulative minor-version release** closing the five-slice polish bundle that shipped as v0.32.9 through v0.32.14 on 2026-04-20.
+
+  **Arc summary.** The v0.33.0 bundle landed in five PRs (A1/A2/B/C/D/E) over a single day, each a narrow polish surface with its own stateless-reviewer pass:
+
+  - **v0.32.9 (PR A1, #332)** — `setup-config` hardening: drop dead `EXPECTED_DIST` (#306), OS-guard System32 path (#307), host-pollution sha256 assertion (#308), CLI-missing vs CLI-failed fallback wording (#309), stderr note on invalid `settings.json` (#311).
+  - **v0.32.10 (PR A2, #339)** — acceptance-wrapper JSON-reporter migration: `vitest --reporter=json` + `numFailedTests` structured parse replaces brittle stdout grep (#315, retires #322), AC numbering gap closed (#321), `wc -l` whitespace trimmed for BSD portability (#323), project-relative `tmp/` for Windows MSYS path asymmetry.
+  - **v0.32.11 (#342)** — planner cwd-policy fix: forbid `cd <project-basename> && ...` prefix in AC commands. `forge_evaluate` already sets `cwd=projectPath` — the planner's spurious `cd` prefix caused every first-run evaluate to fail (`cd: <project>: No such file or directory`). Reported by monday-bot operator during US-01 bootstrap.
+  - **v0.32.12 (PR B, #346)** — anthropic + plan surface: widen `CallClaudeResult.usage` with optional cache-token fields (#329), typed exhaustive `isMaxTokensStop()` helper replaces bare string-equality (#314), `CORRECTOR_MAX_TOKENS` with env override (#317), suite-scoped `mockCreate.not.toHaveBeenCalled()` tripwire (#318), drop redundant `err.message.toContain` assertions (#316), consolidate orphaned `runCorrector` JSDoc (#330), plan amendment AC-B13 deleted stale `reconcile.test.ts` AC8 guard from PR #164.
+  - **v0.32.13 (PR C, #351)** — CHANGELOG + dashboard polish: split the dense v0.32.8 entry (1315-char single-paragraph) into readable problem/fix/arc-closure paragraphs (#328); dashboard liveness banner now distinguishes `TOOL_RUNNING` true/false, adding a neutral "Idle — no tool running" state when idle > 120s (#331).
+  - **v0.32.14 (PR D, #356)** — evaluate.ts max_tokens audit: confirmed zero explicit `maxTokens` overrides across all 3 `trackedCallClaude` sites in `server/tools/evaluate.ts` (coherence, reverse, critic); locked as a structural invariant via `evaluate-max-tokens-audit.test.ts` with rot-guard companion assertion ensuring at least one `trackedCallClaude` site remains (#324).
+
+  **CHANGELOG header ordering fix (closes #354).** Prior to this release, the `# Changelog` H1 and its intro paragraph were buried between v0.32.9 and v0.32.8 because `/ship` Stage 7 prepends every new version section to the file top without special-casing an existing title block. Each PR in the bundle compounded the drift. This release relocates the H1 + intro back to lines 1-3, restoring readable top-down navigation. The underlying `/ship` skill prepend-logic bug remains a separate candidate for the ai-brain-owned `/ship` skill definition and is out of scope for this repo.
+
+  **What did not change.** Zero runtime code in this release — no `server/**/*.ts` edits. Only `package.json` (version bump 0.32.14 → 0.33.0), `CHANGELOG.md` (this entry + H1 relocation), and a plan/acceptance-wrapper pair under `.ai-workspace/` and `scripts/`.
+
+  **Thanks to monday-bot operator** for the mid-bundle bug reports (#312, #319, #325, #342) that drove the v0.32.6/7/8 streaming-triad closure; the v0.33.0 milestone is the natural capstone for that arc. ([#TBD](https://github.com/ziyilam3999/forge-harness/pull/TBD))
+
 ## [0.32.14](https://github.com/ziyilam3999/forge-harness/compare/v0.32.13...v0.32.14) (2026-04-20)
 
 ### Miscellaneous
@@ -39,14 +64,12 @@
 ### Miscellaneous
 
 - v0.33.0 polish bundle — PR A2 of 5 (acceptance-wrapper surface). Switch both acceptance wrappers from brittle `Tests N passed` stdout grep to `vitest --reporter=json` + `numFailedTests` structured parse (#315, retires #322). Close AC numbering gap in max-tokens-sweep wrapper (#321). Trim `wc -l` whitespace for BSD portability in both wrappers (#323). Unplanned in-scope fix: project-relative `tmp/` for vitest JSON output to avoid Windows MSYS `/tmp` vs node.exe drive-root asymmetry. ([#339](https://github.com/ziyilam3999/forge-harness/pull/339))
+
 ## [0.32.9](https://github.com/ziyilam3999/forge-harness/compare/v0.32.8...v0.32.9) (2026-04-20)
 
 ### Miscellaneous
 
 - v0.33.0 polish bundle — PR A1 of 5 (setup-config surface, 5 issues). Drop dead EXPECTED_DIST (#306), OS-guard System32 path (#307), add host-pollution sha256 assertion (#308, wrapper check count 11→12), distinguish CLI-missing vs CLI-failed fallback wording (#309), stderr note on invalid settings.json (#311). ([#332](https://github.com/ziyilam3999/forge-harness/pull/332))
-# Changelog
-
-All notable changes to this project will be documented in this file.
 
 ## [0.32.8](https://github.com/ziyilam3999/forge-harness/compare/v0.32.7...v0.32.8) (2026-04-20)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-harness",
-  "version": "0.32.14",
+  "version": "0.33.0",
   "type": "module",
   "description": "Composable AI primitives — plan, evaluate, generate, coordinate — as a local MCP server",
   "scripts": {

--- a/scripts/pr-e-acceptance.sh
+++ b/scripts/pr-e-acceptance.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# PR E acceptance wrapper — v0.33.0 cumulative minor-version release.
+# Runs AC-E1..E8 in order. Exits 0 iff all pass.
+
+set -euo pipefail
+export MSYS_NO_PATHCONV=1
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+pass() { printf '  [PASS] AC-E%s: %s\n' "$1" "$2"; }
+fail() { printf '  [FAIL] AC-E%s: %s\n' "$1" "$2"; exit 1; }
+
+mkdir -p tmp
+
+# AC-E1: package.json version == "0.33.0"
+VERSION=$(node -e "console.log(require('./package.json').version)")
+[ "$VERSION" = "0.33.0" ] || fail 1 "package.json version is '$VERSION', expected '0.33.0'"
+pass 1 "package.json version == 0.33.0"
+
+# AC-E2: CHANGELOG.md line 1 is the # Changelog H1
+LINE1=$(awk 'NR==1 { print; exit }' CHANGELOG.md)
+[ "$LINE1" = "# Changelog" ] || fail 2 "line 1 is '$LINE1', expected '# Changelog'"
+pass 2 "CHANGELOG.md line 1 is '# Changelog' H1"
+
+# AC-E3: exactly ONE # Changelog H1 (no stray duplicates)
+H1_COUNT=$(grep -cE '^# Changelog$' CHANGELOG.md)
+[ "$H1_COUNT" -eq 1 ] || fail 3 "found $H1_COUNT '# Changelog' H1 lines, expected exactly 1"
+pass 3 "exactly one '# Changelog' H1"
+
+# AC-E4: first ## [X.Y.Z] version header is [0.33.0]
+FIRST_VERSION=$(grep -nE '^## \[' CHANGELOG.md | head -1)
+echo "$FIRST_VERSION" | grep -qE '^[0-9]+:## \[0\.33\.0\]' || fail 4 "first version header is '$FIRST_VERSION', expected '## [0.33.0]...'"
+pass 4 "first version header is [0.33.0]"
+
+# AC-E5: version headers monotonic-descending
+grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | awk -F'[][]' '{print $2}' > tmp/pr-e-versions.txt
+node -e "
+  const fs = require('fs');
+  const v = fs.readFileSync('tmp/pr-e-versions.txt', 'utf8').trim().split('\n');
+  const cmp = (a, b) => {
+    const [a1, a2, a3] = a.split('.').map(Number);
+    const [b1, b2, b3] = b.split('.').map(Number);
+    return a1 - b1 || a2 - b2 || a3 - b3;
+  };
+  for (let i = 0; i < v.length - 1; i++) {
+    if (cmp(v[i], v[i + 1]) <= 0) {
+      console.error('non-monotonic at index ' + i + ': ' + v[i] + ' before ' + v[i + 1]);
+      process.exit(1);
+    }
+  }
+" || fail 5 "version headers not strictly descending"
+pass 5 "version headers strictly descending"
+
+# AC-E6: v0.33.0 entry references issue #354
+awk '/^## \[0\.33\.0\]/,/^## \[0\.32\.14\]/' CHANGELOG.md | grep -q '#354' || fail 6 "v0.33.0 entry does not reference #354"
+pass 6 "v0.33.0 entry references #354"
+
+# AC-E7: all tests pass, count unchanged from master baseline of 776
+npx vitest run --reporter=json --outputFile=tmp/pr-e-vitest.json > /dev/null 2>&1 || true
+node -e "
+  const r = require('./tmp/pr-e-vitest.json');
+  if (r.numFailedTests === 0 && r.numPassedTests >= 776) process.exit(0);
+  console.error('tests: ' + r.numPassedTests + ' passed / ' + r.numFailedTests + ' failed (expected 0 failed, >= 776 passed)');
+  process.exit(1);
+" || fail 7 "vitest did not meet baseline"
+pass 7 "vitest: all pass, >= 776 passed"
+
+# AC-E8: changes confined to release-only surface
+UNEXPECTED=$(git diff --name-only master...HEAD | grep -vE '^(CHANGELOG\.md|package\.json|\.ai-workspace/plans/2026-04-20-v0-33-0-pr-e-cumulative-release\.md|scripts/pr-e-acceptance\.sh)$' || true)
+if [ -n "$UNEXPECTED" ]; then
+  fail 8 "unexpected files changed: $UNEXPECTED"
+fi
+pass 8 "changes confined to release-only allowlist"
+
+echo ""
+echo "ALL PR E ACCEPTANCE CHECKS PASSED"


### PR DESCRIPTION
## Summary

Fifth and final slice of the v0.33.0 polish bundle. Promotes the cumulative v0.32.9 → v0.32.14 polish work (PRs A1/A2/B/C/D) to the **v0.33.0 minor-version milestone**.

Release-only — zero runtime code changes. Three deliverables:

1. `package.json` version bump 0.32.14 → 0.33.0.
2. `CHANGELOG.md` consolidated v0.33.0 entry summarizing the five-slice arc + per-PR recap.
3. Bundled fix for **#354**: the `# Changelog` H1 and intro paragraph were buried at line 47 between v0.32.9 and v0.32.8 because /ship Stage 7 prepends every new version section to the file top without special-casing the title block. Relocates H1 + intro back to lines 1-3, drops the duplicate, and fixes a cosmetic missing-blank-line between the v0.32.10 entry close and the v0.32.9 header. The underlying /ship skill prepend-logic bug remains a separate candidate for the ai-brain /ship skill definition.

Per plan: mirror PR D git-log-shape — the feature-branch commit becomes the merge commit, tagged v0.33.0 directly. No separate post-merge \`chore: release\` commit.

## Test plan

- [x] `scripts/pr-e-acceptance.sh` runs all 8 AC-E checks (version bump, H1 position + uniqueness, first version header == 0.33.0, monotonic-descending ordering, #354 reference, full vitest at baseline 776+, release-only allowlist) — ALL PASS
- [x] vitest run: 776 passing / 0 failing
- [x] CHANGELOG.md line 1 is the `# Changelog` H1, exactly one H1 in file
- [x] Version headers strictly monotonic-descending from 0.33.0 down to 0.32.1 and earlier

closes #354

---
plan-refresh: no-op