### PR TITLE
fix: corrector-crash-fix-acceptance.sh AC numbering gap (#338)

### DIFF
--- a/scripts/corrector-crash-fix-acceptance.sh
+++ b/scripts/corrector-crash-fix-acceptance.sh
@@ -81,7 +81,11 @@ check "AC-7" "full vitest suite passes (no test failures; teardown-rpc flake ign
 npm run build > /tmp/ac8.log 2>&1 && AC8=0 || AC8=1
 check "AC-8" "npm run build compiles cleanly" "$AC8"
 
-# AC-10 (partial — AC-9 is this wrapper's own pass/fail): setup.sh unchanged vs master
+# AC-9: wrapper script is executable
+[ -x "$0" ] && AC9=0 || AC9=1
+check "AC-9" "wrapper script is executable (\$0 has +x bit)" "$AC9"
+
+# AC-10: setup.sh unchanged vs master
 SETUP_DIFF=$(git diff origin/master -- setup.sh 2>/dev/null | wc -l | tr -d ' ' || echo "0")
 [ "$SETUP_DIFF" -eq 0 ] && AC10=0 || AC10=1
 check "AC-10" "setup.sh unchanged vs origin/master (diff lines: $SETUP_DIFF)" "$AC10"


### PR DESCRIPTION
Closes #338

Auto-fix by /housekeep Stage 4.

Adds concrete AC-9 check (`[ -x "$0" ]`) so printed AC numbering is contiguous AC-1..AC-10 in `scripts/corrector-crash-fix-acceptance.sh`. Same pattern as #321 on the max-tokens wrapper. Trivial fix.