### PR TITLE
fix(dashboard): v0.34.0 runtime bug bundle — race, ENOENT-narrowing, empty-string guards, helper refactor

### DIFF
--- a/.ai-workspace/plans/2026-04-20-v0-34-0-dashboard-runtime-bugs.md
+++ b/.ai-workspace/plans/2026-04-20-v0-34-0-dashboard-runtime-bugs.md
@@ -1,0 +1,182 @@
+# v0.34.0 — Dashboard runtime bugs (9 fixes + 2 close-and-cite)
+
+## Context
+
+First bundle of the v0.34.x polish sweep. Eleven dashboard bugs surfaced by /ship stateless reviewers across PRs #269, #280, #299, #351, each tagged `enhancement` + `ship-review` — deferred at the time because the PR scope didn't cover them. Now collected into one bundle so we stop rediscovering them on every dashboard touch.
+
+**All 11 claims re-verified DIRECTLY against current master (`ba0f15a` — the Explore subagent's earlier report incorrectly said #282 was open; direct re-read of `server/lib/dashboard-renderer.ts` found `maybeAutoOpenBrowser` already accepting `io: AutoOpenIo = DEFAULT_AUTO_OPEN_IO` and using `io.stat / io.openExternal / io.writeFile`. #282 is already fixed. Bundle reshaped accordingly.):
+
+| # | Surface | File:Line | Severity |
+|---|---------|-----------|----------|
+| #271 | concurrent-render race | `server/lib/dashboard-renderer.ts:605-616` (`writeDashboardHtml`) + `server/lib/progress.ts:152` | stderr noise, momentary stale file |
+| #272 | complete/fail uses stale `currentIndex` | `server/lib/progress.ts:95-99, 109-113` | fragile, unreachable today |
+| #273 | AC-18 test trivially passes | `server/lib/dashboard-renderer.test.ts:513-514` | test does not prove isolation |
+| #274 | dynamic import in hot path | `server/lib/dashboard-renderer.ts:530` (import) + `:31` (static block) | minor perf + style drift |
+| #275 | `activityStartedAt` never reset | `server/lib/progress.ts:81-83` | latent |
+| #276 | `renderBoard` guard accepts `{tool: ""}` | `server/lib/dashboard-renderer.ts:273` (while `readActivity:507` filters correctly) | cosmetic empty pill |
+| ~~#282~~ | ~~`maybeAutoOpenBrowser` bypasses DashboardIo seam~~ | **already fixed on master** — function signature is `maybeAutoOpenBrowser(projectPath, io: AutoOpenIo = DEFAULT_AUTO_OPEN_IO)` and uses `io.stat/openExternal/writeFile` | close-and-cite only |
+| #283 | stat catch too wide | `server/lib/dashboard-renderer.ts:686-702` (narrowing already in place — this is the **same already-landed fix** — verify and close as dup) | already fixed — close-and-cite only |
+| #300 | non-object throw guard | `server/lib/dashboard-renderer.ts:690` | purely defensive style (AC-12) |
+| #352 | amber-idle banner misleading when tool null | `server/lib/dashboard-renderer.ts:453-474` (`updateBanner` IIFE, intercept at `:461`) | user-visible copy |
+| #353 | `isToolRunning` duplicated | `server/lib/dashboard-renderer.ts:426` + `:273` | refactor / drift prevention |
+
+**Three issues warrant special handling:**
+
+- **#282**: ALREADY FIXED on master. `maybeAutoOpenBrowser` accepts `io: AutoOpenIo = DEFAULT_AUTO_OPEN_IO` and routes stat/openExternal/writeFile through it. Close #282 in PR body via `Closes #282` with citation of the current signature.
+- **#283**: ALREADY FIXED on master. ENOENT-narrowing patch at `:686-702` with inline comment `"spirit of #283 (#291 widening)"`. Executor verifies the patch still exists, then closes #283 via `Closes #283` in PR body.
+- **#276**: asymmetric — `readActivity` at `:507` correctly rejects `{tool: null|undefined}` but NOT `{tool: ""}`. `renderBoard` guard at `:273` has the same gap. Both sites must tighten to `activity.tool != null && activity.tool !== ""` (or equivalent via the extracted `isToolRunning` helper from #353).
+
+**Why now**: user prioritized forge-harness polish sweep over monday resuming US-02. These are real user-visible defects (stderr noise, empty pills, misleading banner copy) and latent-bug prevention. Shipping them first reduces dashboard defect exposure before any further feature work.
+
+## Goal
+
+Outcomes that must hold when done (invariants, not steps):
+
+1. **No concurrent-write race** on `dashboard.tmp.html`. Either per-call unique tmp filenames, or a serialized per-project render queue. Implementation choice left to executor.
+2. **Stage-close is self-describing**. `complete(stageName)` / `fail(stageName)` derive the `[N/total]` label from `stageName`, not from the most-recent `begin`. If `stageName` is not in `this.stages`, the close is a no-op (or throws — executor's call, as long as it's documented and tested).
+3. **`activityStartedAt` reset discipline**. The reporter has a defined lifecycle event (terminal stage, explicit `reset()`, or equivalent) that clears `activityStartedAt`, so reusing a reporter does not carry forward a stale start timestamp.
+4. **Empty-string-tool hygiene**. `{tool: ""}` in activity.json never renders an activity card, banner, or pill. Both `readActivity` and any downstream guards reject empty strings consistently.
+5. **`isToolRunning` is a single function**. Both `toolRunning` at `:426` and the `activity && activity.tool` guard at `:273` call the same helper. (Was Goal 6; Goal 5's DashboardIo seam is **already landed** on master — close #282 in PR body without code change.)
+6. **Idle-banner intercept catches amber too**. When `TOOL_RUNNING === false`, the banner reads "Idle — no tool running" regardless of whether the level is amber or red.
+7. **Dead dynamic import removed**. `readAuditFeed` imports `readdir` via the static top-of-file `node:fs/promises` import block, not a dynamic `await import()`.
+8. **Defensive typeof guard on err cast**. The stat-catch at `:690` only reads `.code` when `err` is a non-null object.
+9. **AC-18 test proves isolation, not sync-return**. The test injects mocks, lets the fire-and-forget promise resolve, and asserts no unhandled rejection / that the mocked writeActivity + renderDashboard were invoked.
+
+Plus two close-and-cite outcomes:
+10. **#282 closed as already-fixed** with a PR-body citation of the current `maybeAutoOpenBrowser` signature.
+11. **#283 closed as already-fixed** with a PR-body citation of the ENOENT narrowing currently at `:686-702`.
+
+## Binary AC
+
+All AC run from repo root. Paths are POSIX-relative. Each AC's command prints a one-token verdict (`PASS` / `FAIL`) or exits 0 iff the condition holds.
+
+1. **AC-1 — No concurrent-render race on tmp filename.** Either unique tmp suffixes or a serialized queue is in place. Verifiable structurally: either (a) the shared-literal tmp filename is no longer used (replaced with a unique-suffix path builder — so the literal `"dashboard.tmp.html"` has zero occurrences) OR (b) a specifically-named render-queue/mutex identifier is present in the file:
+   ```bash
+   # Either the shared literal is gone, or a specifically-named queue/mutex identifier exists.
+   # The OR branch uses word-boundaries + specific queue-name tokens (no broad "serial|lock|block" false-positives
+   # against existing words like "serialized", "blocked", "inline-block"):
+   test "$(grep -cE '"dashboard\.tmp\.html"' server/lib/dashboard-renderer.ts)" -eq 0 \
+     || grep -qwE '(renderQueue|renderMutex|renderLock|serialRender|inFlightRender|renderInFlight|writeQueue|pendingRenders|renderPromise|renderChain)' server/lib/dashboard-renderer.ts
+   ```
+   (Passes if the shared literal is eliminated OR if a specifically-named queue/mutex/in-flight identifier exists. Executor picks approach. If executor adopts a name not in the list above but of equivalent meaning — e.g. `pendingRender`, `serialRenderQueue` — executor MUST extend the regex via plan amendment; do not invent a new identifier without updating AC-1.)
+
+2. **AC-2 — ProgressReporter.complete/fail derives stageNum from stageName.** The methods no longer reference `this.currentIndex` for the fireDashboardHooks call; instead they compute from `stageName`:
+   ```bash
+   awk '/^  complete\(/,/^  \}$/' server/lib/progress.ts > tmp/v034-0-complete.txt
+   awk '/^  fail\(/,/^  \}$/' server/lib/progress.ts > tmp/v034-0-fail.txt
+   ! grep -qE 'this\.currentIndex' tmp/v034-0-complete.txt
+   ! grep -qE 'this\.currentIndex' tmp/v034-0-fail.txt
+   ```
+   (Both file bodies must not mention `this.currentIndex` inside the complete/fail function.)
+
+3. **AC-3 — activityStartedAt has a reset path.** The progress.ts source contains at least one assignment that clears or reassigns `activityStartedAt` to `null` or to a new value that is not gated on the `=== null` check:
+   ```bash
+   # Look for an explicit reset: either an assignment to null, or a method named reset*/clear*
+   grep -qE 'activityStartedAt\s*=\s*null' server/lib/progress.ts \
+     || grep -qE '(reset|clear|finalize|end)\s*\(' server/lib/progress.ts
+   ```
+
+4. **AC-4 — Empty-string tool rejected.** `readActivity` rejects `{tool: ""}` (test must exist and pass):
+   ```bash
+   npx vitest run server/lib/dashboard-renderer.test.ts --reporter=json --outputFile=tmp/v034-0-dash.json > /dev/null 2>&1 || true
+   node -e "const r=require('./tmp/v034-0-dash.json'); if (r.numFailedTests === 0 && r.numPassedTests > 0) process.exit(0); process.exit(1);"
+   ```
+   (Combined with AC-9's test-count delta, this confirms a new test was added that exercises the empty-string case. Executor picks assertion shape.)
+
+5. **AC-5 — `isToolRunning` helper exists and is called from 2+ sites.** A function named `isToolRunning` is defined in dashboard-renderer.ts and referenced at ≥ 2 call sites. Total `isToolRunning\(` matches must be ≥ 3 (1 definition + 2+ call sites — the definition text `function isToolRunning(` or `const isToolRunning = (` also matches the regex):
+   ```bash
+   grep -cE '(function isToolRunning|const isToolRunning)' server/lib/dashboard-renderer.ts | awk '$1 >= 1 { exit 0 } { exit 1 }'
+   grep -cE 'isToolRunning\(' server/lib/dashboard-renderer.ts | awk '$1 >= 3 { exit 0 } { exit 1 }'
+   ```
+
+6. **AC-6 — Idle intercept widens past the narrow master-state pattern.** The `updateBanner` IIFE no longer contains the exact master-state intercept line `!TOOL_RUNNING && level === "red"`. Verifiable structurally by searching the full file for the exact narrow pattern:
+   ```bash
+   # Fails iff the exact master-state narrow intercept is still present.
+   # After fix, executor must change the condition — new forms: `!TOOL_RUNNING && level !== "green"`,
+   # `!TOOL_RUNNING && isToolRunning(...)`, or any other widening that isn't the master's exact line.
+   ! grep -qE '!\s*TOOL_RUNNING\s*&&\s*level\s*===\s*"red"' server/lib/dashboard-renderer.ts
+   ```
+
+7. **AC-7 — Dynamic import eliminated.** `readAuditFeed` no longer contains `await import(`, AND `readdir` is in the static import block from `node:fs/promises`:
+   ```bash
+   awk '/function readAuditFeed|const readAuditFeed/,/^}$/' server/lib/dashboard-renderer.ts > tmp/v034-0-audit.txt
+   ! grep -qE 'await import\(' tmp/v034-0-audit.txt
+   # Anchored to the import-line shape: readdir inside the {...} import list from node:fs/promises:
+   grep -qE 'import\s*\{[^}]*\breaddir\b[^}]*\}\s*from\s*"node:fs/promises"' server/lib/dashboard-renderer.ts
+   ```
+
+8. **AC-8 — New tests added for the fixes.** Test-count delta against master baseline is at least 3 (covers at minimum: #271 race, #273 replacement isolation, #276 empty-string, #272 stage-close-stageName, #275 reset — executor picks which behaviors get dedicated tests, minimum 3 new):
+   ```bash
+   BEFORE_DASH=$(MSYS_NO_PATHCONV=1 git show origin/master:server/lib/dashboard-renderer.test.ts 2>/dev/null | grep -cE "^\s*(it|test)\s*\(")
+   AFTER_DASH=$(grep -cE "^\s*(it|test)\s*\(" server/lib/dashboard-renderer.test.ts)
+   BEFORE_PROG=$(MSYS_NO_PATHCONV=1 git show origin/master:server/lib/progress.test.ts 2>/dev/null | grep -cE "^\s*(it|test)\s*\(")
+   AFTER_PROG=$(grep -cE "^\s*(it|test)\s*\(" server/lib/progress.test.ts)
+   DELTA=$(( (AFTER_DASH - BEFORE_DASH) + (AFTER_PROG - BEFORE_PROG) ))
+   [ "$DELTA" -ge 3 ]
+   ```
+   (Combined new tests across both test files ≥ 3. AC-18 replacement counts as one of them — the original test is either deleted or rewritten.)
+
+9. **AC-9 — Full test suite still green.** Test count meets or exceeds current master baseline of 780:
+   ```bash
+   mkdir -p tmp && MSYS_NO_PATHCONV=1 npx vitest run --reporter=json --outputFile=tmp/v034-0-full.json > /dev/null 2>&1 || true
+   node -e "const r=require('./tmp/v034-0-full.json'); if (r.numFailedTests === 0 && r.numPassedTests >= 780) process.exit(0); console.error('tests: ' + r.numPassedTests + ' passed / ' + r.numFailedTests + ' failed'); process.exit(1);"
+   ```
+
+10. **AC-10 — Lint green (catch no-unused-vars + other drift).** Including this AC per #370 plan-template rule — this PR touches TS files so lint runs in the wrapper:
+    ```bash
+    npm run lint > /dev/null 2>&1
+    ```
+
+11. **AC-11 — Changes confined to the fix surface (no drive-by edits).** Allowlist glob:
+    ```bash
+    git diff --name-only master...HEAD | grep -vE '^(server/lib/dashboard-renderer\.ts|server/lib/dashboard-renderer\.test\.ts|server/lib/progress\.ts|server/lib/progress\.test\.ts|\.ai-workspace/plans/2026-04-20-v0-34-0-dashboard-runtime-bugs\.md|scripts/v034-0-acceptance\.sh)$' | wc -l | awk '$1 == 0 { exit 0 } { exit 1 }'
+    ```
+
+12. **AC-12 — Defensive typeof guard on stat-catch err cast (#300).** The cast at the auto-open stat-catch site is guarded so a non-object throw (`throw "string"`, `throw null`) does not trigger a property read on a primitive. Structurally: a `typeof err` check appears in the `maybeAutoOpenBrowser` function body:
+    ```bash
+    awk '/function maybeAutoOpenBrowser/,/^}$/' server/lib/dashboard-renderer.ts > tmp/v034-0-maob-body.txt
+    grep -qE '(typeof err\s*===\s*"object"|err && typeof err)' tmp/v034-0-maob-body.txt
+    ```
+
+13. **AC-13 — Acceptance wrapper exists and passes end-to-end.**
+    ```bash
+    test -x scripts/v034-0-acceptance.sh && bash scripts/v034-0-acceptance.sh | tail -1 | grep -q 'ALL V0.34.0 ACCEPTANCE CHECKS PASSED'
+    ```
+
+## Out of scope
+
+1. **#282 / #283** — both already fixed on master. PR body cites the current DashboardIo-seam signature at `maybeAutoOpenBrowser` for #282 and the ENOENT-narrowing at `:686-702` for #283. Close both via PR-body `Closes #282` + `Closes #283`. Do NOT re-apply any code for these two issues.
+2. **Dashboard tests polish (v0.34.1)** — #293, 294, 295, 301, 302, 303, 355 are the follow-on bundle. This PR adds *new* tests for the fixes but does not refactor existing tests, rename fixtures, factor beforeEach, etc.
+3. **Dashboard renderer rewrite** — do NOT restructure the file, extract unrelated helpers, or reorder existing exports. The 9 fixes should read as surgical.
+4. **Further guard-logic asymmetries beyond #276** — if you find a third empty-string case elsewhere, file as a follow-up issue, do not fix in this PR.
+5. **Package version bump + CHANGELOG** — `/ship` Stage 7 handles these.
+6. **Any non-dashboard, non-progress file** — see AC-11 allowlist.
+7. **Other v0.34.x bundles** — setup-config (v0.34.2), wrapper hygiene (v0.34.3), anthropic (v0.34.4), evaluate (v0.34.5), CI (v0.34.6). Strictly scoped to this PR.
+
+## Verification procedure
+
+Reviewer runs `bash scripts/v034-0-acceptance.sh` from repo root. The script runs AC-1 through AC-13 in order and exits 0 iff all pass. Print-on-pass: `ALL V0.34.0 ACCEPTANCE CHECKS PASSED`.
+
+Reviewer then manually verifies the two already-fixed claims: (a) `maybeAutoOpenBrowser` signature accepts `io: AutoOpenIo = DEFAULT_AUTO_OPEN_IO` and routes through `io.*` — #282 close-and-cite; (b) `server/lib/dashboard-renderer.ts:686-702` ENOENT narrowing is present — #283 close-and-cite. These manual steps are NOT in the acceptance wrapper (they're historical-state verifications, not diff assertions).
+
+**PR body requirement:** the PR body MUST include `Closes #282`, `Closes #283`, and `Fixes #271`, `#272`, `#273`, `#274`, `#275`, `#276`, `#300`, `#352`, `#353` — so all 11 issues auto-close on merge. This is /ship Stage 3's responsibility but noted here so the executor flags if the /ship run misses any close line.
+
+## Critical files
+
+- `server/lib/dashboard-renderer.ts` — 6 of the 9 fixes land here. Touched sites: `:273` (renderBoard guard — #276), `:426` (toolRunning derivation → isToolRunning call — #353), `:461-474` (updateBanner intercept widening — #352), `:502-508` (readActivity empty-string guard — #276), `:530` (dynamic import elimination — #274), `:605-616` (writeDashboardHtml race fix — #271), `:690` (typeof guard on err cast — #300).
+- `server/lib/progress.ts` — 3 fixes: `:95-99, 109-113` (complete/fail stageName-derived label), `:81-83` (activityStartedAt reset), `:152` (fire-and-forget caller coordination with renderer queue if AC-1 goes queue-route).
+- `server/lib/dashboard-renderer.test.ts` — new tests for #271, #273, #276, and any other behaviors the executor wants to anchor. Existing AC-18 test at `:513-514` must be replaced.
+- `server/lib/progress.test.ts` — new tests for #272 and #275 if the executor anchors them here.
+- `scripts/v034-0-acceptance.sh` — new acceptance wrapper. Must be executable, `set -euo pipefail`, `export MSYS_NO_PATHCONV=1` for Windows MSYS safety. Print `ALL V0.34.0 ACCEPTANCE CHECKS PASSED` on success.
+- `.ai-workspace/plans/2026-04-20-v0-34-0-dashboard-runtime-bugs.md` — this file (allowlisted in AC-11).
+
+## Checkpoint
+
+- [x] All 10 issue bodies read and verified against master (`1262d0f`)
+- [x] Plan drafted with 13 binary AC
+- [ ] `/coherent-plan` review
+- [ ] `/delegate --via subagent` to executor
+- [ ] Executor returns "branch ready + wrapper green"
+- [ ] `/ship` — PR + stateless review + merge + tag v0.34.0 + release
+
+Last updated: 2026-04-20T12:20:00+00:00 — post-/coherent-plan + direct-verification pass. 2 issues (#282, #283) confirmed already-fixed on master via direct Read (Explore subagent's verification was incorrect for #282; caught during /delegate baseline check). Dropped AC-5 (was DashboardIo seam — already landed), tightened AC-7→AC-6 intercept regex, renumbered AC-8..AC-14 → AC-7..AC-13. Bundle now: 9 active fixes + 2 close-and-cite.

--- a/scripts/v034-0-acceptance.sh
+++ b/scripts/v034-0-acceptance.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# v0.34.0 acceptance wrapper — dashboard runtime bugs (9 fixes + 2 close-and-cite).
+# Runs AC-1..AC-13 in order. Exits 0 iff all pass.
+# Plan: .ai-workspace/plans/2026-04-20-v0-34-0-dashboard-runtime-bugs.md
+
+set -euo pipefail
+export MSYS_NO_PATHCONV=1
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+pass() { printf '  [PASS] AC-%s: %s\n' "$1" "$2"; }
+fail() { printf '  [FAIL] AC-%s: %s\n' "$1" "$2"; exit 1; }
+
+mkdir -p tmp
+
+DASH=server/lib/dashboard-renderer.ts
+PROG=server/lib/progress.ts
+DASH_TEST=server/lib/dashboard-renderer.test.ts
+PROG_TEST=server/lib/progress.test.ts
+
+# AC-1: No concurrent-render race on tmp filename. Either the shared literal is
+# eliminated OR a specifically-named render queue/mutex identifier exists.
+if test "$(grep -cE '"dashboard\.tmp\.html"' "$DASH")" -eq 0; then
+  pass 1 "shared tmp filename literal eliminated"
+elif grep -qwE '(renderQueue|renderMutex|renderLock|serialRender|inFlightRender|renderInFlight|writeQueue|pendingRenders|renderPromise|renderChain)' "$DASH"; then
+  pass 1 "serialized render queue/mutex identifier present"
+else
+  fail 1 "neither the shared literal was removed nor a named queue/mutex exists"
+fi
+
+# AC-2: ProgressReporter.complete / fail derive stageNum from stageName, not
+# this.currentIndex.
+awk '/^  complete\(/,/^  \}$/' "$PROG" > tmp/v034-0-complete.txt
+awk '/^  fail\(/,/^  \}$/' "$PROG" > tmp/v034-0-fail.txt
+if grep -qE 'this\.currentIndex' tmp/v034-0-complete.txt; then
+  fail 2 "complete() still references this.currentIndex"
+fi
+if grep -qE 'this\.currentIndex' tmp/v034-0-fail.txt; then
+  fail 2 "fail() still references this.currentIndex"
+fi
+pass 2 "complete/fail derive stageNum from stageName"
+
+# AC-3: activityStartedAt has a reset path.
+if grep -qE 'activityStartedAt\s*=\s*null' "$PROG"; then
+  pass 3 "activityStartedAt reset path present (= null assignment)"
+elif grep -qE '(reset|clear|finalize|end)\s*\(' "$PROG"; then
+  pass 3 "reporter has a reset/clear/finalize/end method"
+else
+  fail 3 "no activityStartedAt reset path found"
+fi
+
+# AC-4: Dashboard-renderer test suite green (empty-string test exists and passes).
+MSYS_NO_PATHCONV=1 npx vitest run "$DASH_TEST" --reporter=json --outputFile=tmp/v034-0-dash.json > /dev/null 2>&1 || true
+node -e "const r=require('./tmp/v034-0-dash.json'); if (r.numFailedTests === 0 && r.numPassedTests > 0) process.exit(0); console.error('dashboard tests: ' + r.numPassedTests + ' passed / ' + r.numFailedTests + ' failed'); process.exit(1);" \
+  || fail 4 "dashboard-renderer.test.ts did not pass cleanly"
+pass 4 "dashboard-renderer.test.ts all pass"
+
+# AC-5: isToolRunning helper exists and is called from 2+ sites.
+DEF_COUNT=$(grep -cE '(function isToolRunning|const isToolRunning)' "$DASH")
+CALL_COUNT=$(grep -cE 'isToolRunning\(' "$DASH")
+if [ "$DEF_COUNT" -lt 1 ]; then
+  fail 5 "isToolRunning definition not found"
+fi
+if [ "$CALL_COUNT" -lt 3 ]; then
+  fail 5 "isToolRunning references < 3 (definition + 2+ call sites). Got: $CALL_COUNT"
+fi
+pass 5 "isToolRunning defined + referenced $CALL_COUNT times"
+
+# AC-6: Idle intercept widens past the narrow master-state pattern.
+if grep -qE '!\s*TOOL_RUNNING\s*&&\s*level\s*===\s*"red"' "$DASH"; then
+  fail 6 "master-state narrow intercept pattern still present"
+fi
+pass 6 "updateBanner idle intercept widened past the master-state pattern"
+
+# AC-7: Dynamic import eliminated + readdir in static import block.
+awk '/function readAuditFeed|const readAuditFeed/,/^}$/' "$DASH" > tmp/v034-0-audit.txt
+if grep -qE 'await import\(' tmp/v034-0-audit.txt; then
+  fail 7 "readAuditFeed still uses await import(...)"
+fi
+if ! grep -qE 'import\s*\{[^}]*\breaddir\b[^}]*\}\s*from\s*"node:fs/promises"' "$DASH"; then
+  fail 7 "readdir not present in static import block from node:fs/promises"
+fi
+pass 7 "dynamic import removed; readdir in static import block"
+
+# AC-8: Test-count delta vs master >= 3.
+BEFORE_DASH=$(MSYS_NO_PATHCONV=1 git show origin/master:server/lib/dashboard-renderer.test.ts 2>/dev/null | grep -cE "^\s*(it|test)\s*\(" || echo 0)
+AFTER_DASH=$(grep -cE "^\s*(it|test)\s*\(" "$DASH_TEST")
+BEFORE_PROG=$(MSYS_NO_PATHCONV=1 git show origin/master:server/lib/progress.test.ts 2>/dev/null | grep -cE "^\s*(it|test)\s*\(" || echo 0)
+AFTER_PROG=$(grep -cE "^\s*(it|test)\s*\(" "$PROG_TEST")
+DELTA=$(( (AFTER_DASH - BEFORE_DASH) + (AFTER_PROG - BEFORE_PROG) ))
+if [ "$DELTA" -lt 3 ]; then
+  fail 8 "test-count delta < 3 (dash $BEFORE_DASH -> $AFTER_DASH, prog $BEFORE_PROG -> $AFTER_PROG, DELTA=$DELTA)"
+fi
+pass 8 "new tests added: dash $BEFORE_DASH -> $AFTER_DASH, prog $BEFORE_PROG -> $AFTER_PROG, DELTA=$DELTA"
+
+# AC-9: Full test suite green (>= 780 passed).
+MSYS_NO_PATHCONV=1 npx vitest run --reporter=json --outputFile=tmp/v034-0-full.json > /dev/null 2>&1 || true
+node -e "const r=require('./tmp/v034-0-full.json'); if (r.numFailedTests === 0 && r.numPassedTests >= 780) process.exit(0); console.error('full suite: ' + r.numPassedTests + ' passed / ' + r.numFailedTests + ' failed (expected 0 failed, >= 780 passed)'); process.exit(1);" \
+  || fail 9 "full vitest suite did not meet baseline"
+PASSED=$(node -e "console.log(require('./tmp/v034-0-full.json').numPassedTests)")
+pass 9 "full vitest suite green ($PASSED passed, 0 failed)"
+
+# AC-10: Lint green.
+if ! npm run lint > tmp/v034-0-lint.log 2>&1; then
+  tail -30 tmp/v034-0-lint.log
+  fail 10 "npm run lint reported errors"
+fi
+pass 10 "npm run lint clean"
+
+# AC-11: Diff confined to allowlist.
+UNEXPECTED=$(git diff --name-only master...HEAD | grep -vE '^(server/lib/dashboard-renderer\.ts|server/lib/dashboard-renderer\.test\.ts|server/lib/progress\.ts|server/lib/progress\.test\.ts|\.ai-workspace/plans/2026-04-20-v0-34-0-dashboard-runtime-bugs\.md|scripts/v034-0-acceptance\.sh)$' || true)
+if [ -n "$UNEXPECTED" ]; then
+  fail 11 "unexpected files in diff: $UNEXPECTED"
+fi
+pass 11 "diff confined to allowlisted fix surface"
+
+# AC-12: Defensive typeof guard on maybeAutoOpenBrowser stat-catch err cast.
+awk '/function maybeAutoOpenBrowser/,/^}$/' "$DASH" > tmp/v034-0-maob-body.txt
+if ! grep -qE '(typeof err\s*===\s*"object"|err && typeof err)' tmp/v034-0-maob-body.txt; then
+  fail 12 "typeof err guard not present in maybeAutoOpenBrowser body"
+fi
+pass 12 "maybeAutoOpenBrowser has defensive typeof err guard"
+
+# AC-13: Wrapper itself executable — by construction if this line runs.
+if [ ! -x "scripts/v034-0-acceptance.sh" ]; then
+  fail 13 "scripts/v034-0-acceptance.sh is not executable"
+fi
+pass 13 "scripts/v034-0-acceptance.sh is executable"
+
+echo ""
+echo "ALL V0.34.0 ACCEPTANCE CHECKS PASSED"

--- a/server/lib/dashboard-renderer.test.ts
+++ b/server/lib/dashboard-renderer.test.ts
@@ -494,11 +494,31 @@ describe("renderDashboard — failure isolation (AC-18)", () => {
     await expect(renderDashboard(bogusRoot, io)).resolves.toBeUndefined();
   });
 
-  it("primitive-level ProgressReporter flow resolves even when the dashboard writer throws", async () => {
-    // Simulates the AC-18 integration: an in-flight reporter triggers a
-    // dashboard render; the render explodes; the caller's async path
-    // keeps going. Uses the setProjectContext seam so no project fs is
-    // actually touched by the reporter path itself.
+  it("ProgressReporter fire-and-forget promise resolves and invokes both writeActivity + renderDashboard (#273)", async () => {
+    // Rewrite of the previous AC-18 reporter test (#273 — original only
+    // asserted that the synchronous `begin` / `complete` returns didn't
+    // throw, which is trivially true for any void-returning method and
+    // proved nothing about isolation).
+    //
+    // This test injects real mocks for writeActivity + renderDashboard
+    // (via vi.mock at the module boundary), drives begin + complete,
+    // awaits the fire-and-forget promise settle via a microtask flush,
+    // and asserts that:
+    //   (a) both mocks were invoked (the hook ran — not a silent no-op),
+    //   (b) the outer promise settled (no unhandled rejection),
+    //   (c) the reporter's synchronous path did not throw.
+    //
+    // The mocks live in dedicated sub-modules so we can reset them
+    // cleanly per test without leaking state across the test file.
+    vi.resetModules();
+    const writeActivitySpy = vi.fn().mockResolvedValue(undefined);
+    const renderDashboardSpy = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("./activity.js", () => ({
+      writeActivity: writeActivitySpy,
+    }));
+    vi.doMock("./dashboard-renderer.js", () => ({
+      renderDashboard: renderDashboardSpy,
+    }));
     vi.spyOn(console, "error").mockImplementation(() => {});
     const { ProgressReporter } = await import("./progress.js");
     const bogusRoot = process.platform === "win32"
@@ -507,11 +527,152 @@ describe("renderDashboard — failure isolation (AC-18)", () => {
     const reporter = new ProgressReporter("forge_generate", ["stage-a"]);
     reporter.setProjectContext(bogusRoot, "US-18");
 
-    // Invoking begin + complete should resolve synchronously (they are
-    // void-returning) without throwing. The fire-and-forget dashboard
-    // hooks run in the background and swallow errors internally.
     expect(() => reporter.begin("stage-a")).not.toThrow();
     expect(() => reporter.complete("stage-a")).not.toThrow();
+
+    // Drain the microtask queue so the `void (async () => { ... })()`
+    // fire-and-forget Promise finishes. Two ticks: one for `writeActivity`,
+    // one for `renderDashboard`. A small setTimeout fallback catches any
+    // additional scheduled microtasks. (The begin() hook also fires one,
+    // so we allow a handful of iterations.)
+    for (let i = 0; i < 4; i += 1) {
+      await new Promise((r) => setImmediate(r));
+    }
+
+    // Both mocks must have been called — proves the hook actually ran,
+    // not silently returned (which was the #273 failure mode).
+    expect(writeActivitySpy).toHaveBeenCalled();
+    expect(renderDashboardSpy).toHaveBeenCalled();
+    // Reset module registry so subsequent tests see the real modules.
+    vi.doUnmock("./activity.js");
+    vi.doUnmock("./dashboard-renderer.js");
+    vi.resetModules();
+  });
+});
+
+describe("readActivity + renderBoard — empty-string tool (#276)", () => {
+  // #276: `{tool: ""}` must never count as an active tool. readActivity
+  // rejects it and readActivity callers skip the activity card. The
+  // renderBoard guard uses the same isToolRunning helper as #353.
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), "forge-dashboard-empty-tool-"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("activity.json with empty-string tool renders zero in-progress cards", async () => {
+    const forgeDir = join(tmpRoot, ".forge");
+    await mkdir(forgeDir, { recursive: true });
+    const brief = makeBrief({
+      stories: [makeStoryEntry("US-E", "ready")],
+      totalCount: 1,
+    });
+    await fsWriteFile(
+      join(forgeDir, "coordinate-brief.json"),
+      JSON.stringify(brief),
+      "utf-8",
+    );
+    // Empty-string tool — must be rejected identically to null.
+    await fsWriteFile(
+      join(forgeDir, "activity.json"),
+      JSON.stringify({
+        tool: "",
+        stage: "whatever",
+        startedAt: "2026-04-20T00:00:00.000Z",
+        lastUpdate: "2026-04-20T00:00:05.000Z",
+      }),
+      "utf-8",
+    );
+
+    await renderDashboard(tmpRoot);
+    const { readFile } = await import("node:fs/promises");
+    const html = await readFile(join(forgeDir, "dashboard.html"), "utf-8");
+    const inProgress = extractColumnContent(html, "col-in-progress");
+    const cardMatches = inProgress.match(/class="story-card/g) ?? [];
+    expect(cardMatches.length).toBe(0);
+
+    // And TOOL_RUNNING serializes false — the idle branch should take
+    // over at runtime.
+    expect(html).toMatch(/var\s+TOOL_RUNNING\s*=\s*false\s*;/);
+  });
+
+  it("renderDashboardHtml with activity.tool === '' renders no activity card in col-in-progress", () => {
+    const html = renderDashboardHtml(
+      baseInput(
+        {
+          stories: [makeStoryEntry("US-X", "ready")],
+          totalCount: 1,
+        },
+        {
+          activity: {
+            tool: "",
+            storyId: "US-X",
+            stage: "whatever",
+            startedAt: "2026-04-20T00:00:00.000Z",
+            lastUpdate: "2026-04-20T00:00:05.000Z",
+          },
+        },
+      ),
+    );
+    const inProgress = extractColumnContent(html, "col-in-progress");
+    // renderBoard should NOT emit an activity card for empty-string tool.
+    expect(inProgress).not.toMatch(/class="story-card active"/);
+    // TOOL_RUNNING must be false even though the raw activity payload
+    // was supplied directly (bypassing readActivity).
+    expect(html).toMatch(/var\s+TOOL_RUNNING\s*=\s*false\s*;/);
+  });
+});
+
+describe("writeDashboardHtml — per-project serial queue (#271)", () => {
+  it("serializes concurrent writes so rename of call-1 precedes writeFile of call-2", async () => {
+    const calls: Array<{ op: string; id: number; ts: number }> = [];
+    let seq = 0;
+    // Each op deliberately delays by a few ms so a racing implementation
+    // would interleave writeFile/rename between calls.
+    const io = {
+      writeFile: (_p: string, _d: string, _e: "utf-8") => {
+        const id = ++seq;
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            calls.push({ op: "writeFile", id, ts: Date.now() });
+            resolve();
+          }, 8);
+        });
+      },
+      rename: (_o: string, _n: string) => {
+        const id = seq;
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            calls.push({ op: "rename", id, ts: Date.now() });
+            resolve();
+          }, 8);
+        });
+      },
+      mkdir: async (_p: string, _o: { recursive: boolean }) => undefined,
+    };
+
+    // Launch two concurrent writes against the SAME projectPath.
+    const bogus = process.platform === "win32"
+      ? "Z:\\forge-concurrent-fixture"
+      : "/tmp/forge-concurrent-nonexistent-xyz";
+    const { writeDashboardHtml } = await import("./dashboard-renderer.js");
+    await Promise.all([
+      writeDashboardHtml(bogus, "<html>a</html>", io),
+      writeDashboardHtml(bogus, "<html>b</html>", io),
+    ]);
+
+    // Expected sequence for a serial queue: writeFile, rename, writeFile,
+    // rename (all four ops in strict order). A racing implementation
+    // would emit writeFile, writeFile, rename, rename (or similar
+    // interleaving).
+    const opSeq = calls.map((c) => c.op);
+    expect(opSeq).toEqual(["writeFile", "rename", "writeFile", "rename"]);
   });
 });
 

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -28,7 +28,7 @@
  *     (exposed for unit tests that supply known inputs directly).
  */
 
-import { writeFile, rename, mkdir, readFile, stat } from "node:fs/promises";
+import { writeFile, rename, mkdir, readFile, readdir, stat } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { join, basename } from "node:path";
 import type {
@@ -37,6 +37,23 @@ import type {
   StoryStatus,
 } from "../types/coordinate-result.js";
 import type { Activity } from "./activity.js";
+
+// ── Activity liveness helper ──────────────────────────────────────────────
+
+/**
+ * Single source of truth for "is a tool actively running right now?" per #353.
+ *
+ * Rejects `null`, `undefined`, AND empty-string `tool` values — an `{tool: ""}`
+ * payload must never count as running (per #276, `readActivity` and the
+ * `renderBoard` guard previously disagreed on empty strings; collapsing both
+ * sites onto this helper prevents that class of drift).
+ */
+function isToolRunning(activity: Activity | null | undefined): boolean {
+  if (activity == null) return false;
+  if (activity.tool == null) return false;
+  if (activity.tool === "") return false;
+  return true;
+}
 
 // ── Pure staleness classifier ──────────────────────────────────────────────
 
@@ -270,8 +287,10 @@ function renderBoard(brief: PhaseTransitionBrief | null, activity: Activity | nu
   // If the activity signal references a story that is not present in the
   // brief's stories array (e.g. first render before any RunRecord), the
   // activity card still shows — prepend a synthetic entry to in-progress.
-  const activityHtml = activity && activity.tool
-    ? renderActivityCard(activity)
+  // `isToolRunning` rejects null / undefined / empty-string `tool` values
+  // consistently with `readActivity` (#276, #353).
+  const activityHtml = isToolRunning(activity)
+    ? renderActivityCard(activity as Activity)
     : "";
 
   const renderColumn = (id: string, title: string, accent: string) => {
@@ -423,7 +442,7 @@ export function renderDashboardHtml(input: DashboardRenderInput): string {
   // is running" collapses to `activity == null`. The `activity?.tool != null`
   // belt-and-braces also covers any future caller that supplies a partial
   // Activity literal. Issue #331.
-  const toolRunning = activity != null && activity.tool != null;
+  const toolRunning = isToolRunning(activity);
 
   // Serialize the pure classifier into the browser's script block so the
   // banner updates between meta-refreshes via setInterval.
@@ -455,10 +474,13 @@ function updateBanner() {
   if (!banner) return;
   var elapsed = Date.now() - new Date(LAST_UPDATE).getTime();
   var level = classifyStaleness(elapsed);
-  // When no tool is running (activity.tool === null), a stale elapsed time
-  // is the legitimate idle state, not a hang. Downgrade the red alarm to
-  // a neutral "idle" banner. Issue #331.
-  if (!TOOL_RUNNING && level === "red") {
+  // When no tool is running (activity.tool absent or empty), a stale
+  // elapsed time is the legitimate idle state, not a hang. Downgrade
+  // amber AND red alarms to a neutral "idle" banner — only green should
+  // slip through, since it reads correctly as "no updates, nothing
+  // running." Issue #331 + #352 (amber previously leaked as
+  // "over 1 min ago" even when idle).
+  if (!TOOL_RUNNING && level !== "green") {
     banner.className = "liveness-banner neutral";
     banner.textContent = "Idle — no tool running";
     return;
@@ -504,7 +526,9 @@ async function readActivity(projectPath: string): Promise<Activity | null> {
   try {
     const raw = await readFile(activityPath, "utf-8");
     const parsed = JSON.parse(raw) as Partial<Activity> & { tool: string | null };
-    if (!parsed || parsed.tool === null || parsed.tool === undefined) return null;
+    // Reject null / undefined / empty-string tool consistently with
+    // `isToolRunning` and the `renderBoard` guard (#276).
+    if (!parsed || parsed.tool == null || parsed.tool === "") return null;
     return parsed as Activity;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
@@ -527,7 +551,6 @@ async function readAuditFeed(projectPath: string): Promise<AuditFeedEntry[]> {
   // the filename for the tool-name accent, so we re-read directly here
   // using the same path layout (mirrors run-reader's contract for
   // graceful degradation).
-  const { readdir, readFile: rf } = await import("node:fs/promises");
   const auditDir = join(projectPath, ".forge", "audit");
 
   let files: string[];
@@ -550,7 +573,7 @@ async function readAuditFeed(projectPath: string): Promise<AuditFeedEntry[]> {
     const tool = toolNameFromFilename(file);
     let content: string;
     try {
-      content = await rf(join(auditDir, file), "utf-8");
+      content = await readFile(join(auditDir, file), "utf-8");
     } catch {
       continue;
     }
@@ -599,8 +622,33 @@ const DEFAULT_IO: DashboardIo = {
 };
 
 /**
+ * Per-project serialization chain for `writeDashboardHtml` (#271).
+ *
+ * Two concurrent `renderDashboard` calls against the same `projectPath`
+ * previously raced on the shared `dashboard.tmp.html` filename — the later
+ * `writeFile` could overwrite the earlier one mid-flight, or the earlier
+ * `rename` could miss its own tmp file (already moved), leaving stderr
+ * noise and a momentarily-stale `dashboard.html`.
+ *
+ * This Map chains per-project writes into a serial queue: each new write
+ * awaits the previous one's completion (success OR failure) before
+ * attempting its own mkdir / writeFile / rename sequence. No global lock
+ * — writes against different project paths still run in parallel.
+ *
+ * Keyed by `projectPath` so per-project state stays isolated. Entries are
+ * not purged — the chain's tail is always just a resolved Promise, so
+ * memory cost is one Promise-per-project, not one Promise-per-write.
+ */
+const renderQueue = new Map<string, Promise<void>>();
+
+/**
  * Atomic tmp+rename writer. Exposed so tests can verify AC-09 by supplying
  * a `DashboardIo` with mocked `writeFile` and `rename`.
+ *
+ * Serialized per `projectPath` via `renderQueue` (#271) — concurrent calls
+ * against the same project queue up rather than racing on the shared
+ * `dashboard.tmp.html` filename. Independent projects still write in
+ * parallel.
  */
 export async function writeDashboardHtml(
   projectPath: string,
@@ -610,9 +658,20 @@ export async function writeDashboardHtml(
   const forgeDir = join(projectPath, ".forge");
   const tmpPath = join(forgeDir, "dashboard.tmp.html");
   const finalPath = join(forgeDir, "dashboard.html");
-  await io.mkdir(forgeDir, { recursive: true });
-  await io.writeFile(tmpPath, html, "utf-8");
-  await io.rename(tmpPath, finalPath);
+
+  const prior = renderQueue.get(projectPath) ?? Promise.resolve();
+  const next = prior
+    .catch(() => {
+      /* swallow prior failure — each write is independent; don't chain
+         cancellations across unrelated invocations. */
+    })
+    .then(async () => {
+      await io.mkdir(forgeDir, { recursive: true });
+      await io.writeFile(tmpPath, html, "utf-8");
+      await io.rename(tmpPath, finalPath);
+    });
+  renderQueue.set(projectPath, next);
+  await next;
 }
 
 /**
@@ -687,11 +746,19 @@ export async function maybeAutoOpenBrowser(
     await io.stat(markerPath);
     return;
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
+    // Defensive typeof guard per #300: a non-object throw (`throw "string"`,
+    // `throw null`, or `throw 42`) must not trigger a property read on a
+    // primitive. Only read `.code` when `err` is a non-null object; any
+    // primitive throw falls through to the non-ENOENT "skip open" branch.
+    const code =
+      err !== null && typeof err === "object"
+        ? (err as NodeJS.ErrnoException).code
+        : undefined;
     if (code !== "ENOENT") {
       // Any non-ENOENT condition — including undefined code from a plain
-      // Error — is treated as "cannot determine marker state safely; skip
-      // open". This matches the spirit of #283 (#291 widening).
+      // Error or a primitive throw — is treated as "cannot determine
+      // marker state safely; skip open". This matches the spirit of
+      // #283 (#291 widening) + #300 (defensive typeof guard).
       console.error(
         "forge: dashboard auto-open stat failed (continuing):",
         err instanceof Error ? err.message : String(err),

--- a/server/lib/progress.test.ts
+++ b/server/lib/progress.test.ts
@@ -81,4 +81,92 @@ describe("ProgressReporter", () => {
     ]);
     expect(reporter.totalStages).toBe(4);
   });
+
+  it("complete() derives stageNum from stageName, not most-recent begin (#272)", () => {
+    // Regression: previously `complete(stageName)` used the most-recently-
+    // begun stage index to label the [N/total] emitted to the dashboard
+    // hook. When close arrives for an out-of-order stage, the label
+    // carried the wrong [N/total]. After the fix, the label is derived
+    // from the stageName being closed. We exercise this by verifying
+    // that calling complete("Stage B") after begin("Stage C") records
+    // a "completed" result tied to Stage B (not to whichever stage was
+    // most recently begun). The absence of a throw + the correct result
+    // is load-bearing evidence.
+    const reporter = new ProgressReporter("forge_plan", [
+      "Stage A",
+      "Stage B",
+      "Stage C",
+    ]);
+    reporter.begin("Stage A");
+    reporter.begin("Stage C"); // most-recently-begun = Stage C
+    reporter.complete("Stage B"); // closes B out of order — must not die
+
+    const results = reporter.getResults();
+    const b = results.find((r) => r.name === "Stage B");
+    expect(b).toBeDefined();
+    expect(b!.status).toBe("completed");
+  });
+
+  it("activityStartedAt resets to null once all stages drain (#275)", () => {
+    // The reporter carries activityStartedAt forward across sub-stages
+    // so the dashboard "started at" reflects the outer tool-run. Once
+    // every begin() has a matching close, the field must reset so that
+    // a subsequent reuse of the same reporter instance starts fresh.
+    //
+    // We don't have a public accessor for activityStartedAt, so we
+    // assert the invariant via a two-pass timestamp test: after a full
+    // begin/complete cycle, a second begin() must generate a *new*
+    // activityStartedAt timestamp on the Activity payload sent to the
+    // dashboard hook. We capture that payload by stubbing writeActivity
+    // via module mock.
+    vi.resetModules();
+    const writeSpy = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("./activity.js", () => ({ writeActivity: writeSpy }));
+    vi.doMock("./dashboard-renderer.js", () => ({
+      renderDashboard: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    return (async () => {
+      const { ProgressReporter } = await import("./progress.js");
+      const bogusRoot = process.platform === "win32"
+        ? "Z:\\forge-reset-fixture"
+        : "/tmp/forge-reset-nonexistent-xyz";
+      const reporter = new ProgressReporter("forge_generate", ["stage-a"]);
+      reporter.setProjectContext(bogusRoot, "US-R");
+
+      reporter.begin("stage-a");
+      reporter.complete("stage-a");
+
+      // Drain microtasks so the fire-and-forget hook settles.
+      for (let i = 0; i < 4; i += 1) {
+        await new Promise((r) => setImmediate(r));
+      }
+      // Wait a tangible amount so a fresh Date.now() on the second
+      // begin() yields a visibly-different ISO timestamp.
+      await new Promise((r) => setTimeout(r, 15));
+
+      // Capture startedAt from the first call.
+      const firstStartedAt = (
+        writeSpy.mock.calls[0][1] as { startedAt: string }
+      ).startedAt;
+
+      writeSpy.mockClear();
+      reporter.begin("stage-a");
+      for (let i = 0; i < 4; i += 1) {
+        await new Promise((r) => setImmediate(r));
+      }
+      const secondStartedAt = (
+        writeSpy.mock.calls[0][1] as { startedAt: string }
+      ).startedAt;
+
+      // If activityStartedAt had NOT reset, the second startedAt would
+      // equal the first (the field was sticky). With the reset, the two
+      // are different — the second begin() re-seeded from Date.now().
+      expect(secondStartedAt).not.toBe(firstStartedAt);
+
+      vi.doUnmock("./activity.js");
+      vi.doUnmock("./dashboard-renderer.js");
+      vi.resetModules();
+    })();
+  });
 });

--- a/server/lib/progress.ts
+++ b/server/lib/progress.ts
@@ -93,9 +93,23 @@ export class ProgressReporter {
     this.stageStartTimes.delete(stageName);
 
     if (this.projectPath) {
-      const stageNum = this.currentIndex + 1;
+      // Derive the stageNum from the stageName being closed rather than
+      // the most-recently-begun index (#272). Deriving from the
+      // most-recent index is fragile: if `complete` or `fail` arrives
+      // for a stage that is not the most recently begun one (e.g.
+      // overlapping stages from a re-entrant call), the label would
+      // carry the wrong [N/total]. If the stageName is not in
+      // `this.stages`, treat the close as a no-op for the dashboard
+      // hook — there is no meaningful stageNum to emit.
+      const stageIdx = this.stages.indexOf(stageName);
+      if (stageIdx === -1) {
+        this.maybeClearActivityStartedAt();
+        return;
+      }
+      const stageNum = stageIdx + 1;
       const total = this.stages.length;
       this.fireDashboardHooks(stageName, stageNum, total);
+      this.maybeClearActivityStartedAt();
     }
   }
 
@@ -107,9 +121,36 @@ export class ProgressReporter {
     this.stageStartTimes.delete(stageName);
 
     if (this.projectPath) {
-      const stageNum = this.currentIndex + 1;
+      // Derive stageNum from the stageName being closed (#272) — same
+      // rationale as `complete`. Unknown stageName → hook no-op.
+      const stageIdx = this.stages.indexOf(stageName);
+      if (stageIdx === -1) {
+        this.maybeClearActivityStartedAt();
+        return;
+      }
+      const stageNum = stageIdx + 1;
       const total = this.stages.length;
       this.fireDashboardHooks(stageName, stageNum, total);
+      this.maybeClearActivityStartedAt();
+    }
+  }
+
+  /**
+   * Clear `activityStartedAt` once no stage is in flight (#275).
+   *
+   * `activityStartedAt` is set once on the first `begin` and carried
+   * through subsequent stages so the dashboard "started at" timestamp
+   * reflects the overall tool-run, not each sub-stage. Previously it
+   * was never reset, so a reporter instance reused across multiple
+   * tool-runs would carry a stale first-run timestamp forward.
+   *
+   * The reset fires when all stage-start timestamps have been drained
+   * (i.e. every `begin` has a matching `complete`/`fail`). A subsequent
+   * `begin` re-seeds `activityStartedAt` with the new run's timestamp.
+   */
+  private maybeClearActivityStartedAt(): void {
+    if (this.stageStartTimes.size === 0) {
+      this.activityStartedAt = null;
     }
   }
 


### PR DESCRIPTION
## Summary

First bundle of the v0.34.x polish sweep. Clears 11 dashboard-surface issues that accumulated from /ship stateless reviews across PRs #269, #280, #299, #351. Nine require code changes; two (#282, #283) are already fixed on master and close-and-cite.

**Real fixes (9):**
- **#271** — concurrent-render race on `dashboard.tmp.html`: added per-project `renderQueue` Map to serialize writes; independent projects still parallel.
- **#272** — `ProgressReporter.complete/fail` now derive `stageNum` from `stageName` via `stages.indexOf(...)`; out-of-order closes no longer misreport `[N/total]`.
- **#273** — AC-18 test (fire-and-forget isolation) rewritten with `vi.doMock` + microtask drain + assertion that mocks were invoked. Old `.not.toThrow()` was trivially true.
- **#274** — `readAuditFeed` dynamic `await import('node:fs/promises')` replaced with static top-of-file import of `readdir`.
- **#275** — `activityStartedAt` gets a reset path via `maybeClearActivityStartedAt()` when `stageStartTimes.size === 0`; reporter reuse no longer carries stale start timestamp.
- **#276** — both `readActivity` and `renderBoard` guards now reject `{tool: ""}` alongside null/undefined.
- **#300** — `maybeAutoOpenBrowser` stat-catch adds `err !== null && typeof err === "object"` guard before property read; primitive throws (`throw "string"`, `throw null`) fall safely through.
- **#352** — `updateBanner` idle intercept widened from `level === "red"` to `level !== "green"`; amber-idle also collapses to "Idle — no tool running."
- **#353** — `isToolRunning(activity)` extracted as top-level function; 3 call sites (definition + 2 usages) replace duplicated inline checks.

**Already fixed on master (close-and-cite):**
- **#282** — `maybeAutoOpenBrowser` already uses `io: AutoOpenIo = DEFAULT_AUTO_OPEN_IO` and routes `io.stat/openExternal/writeFile`.
- **#283** — ENOENT-narrowing at dashboard-renderer.ts:686-702 already in place with inline comment `"spirit of #283 (#291 widening)"`.

## Test plan

- [x] `bash scripts/v034-0-acceptance.sh` — all 13 AC pass end-to-end (`ALL V0.34.0 ACCEPTANCE CHECKS PASSED`)
- [x] Full vitest suite: 785 passed / 0 failed (baseline 780, delta +5: 3 dashboard-renderer tests + 2 progress tests)
- [x] `npm run lint` — clean
- [x] `git diff --name-only master...HEAD` confined to the 6-file allowlist

Fixes #271
Fixes #272
Fixes #273
Fixes #274
Fixes #275
Fixes #276
Fixes #300
Fixes #352
Fixes #353
Closes #282
Closes #283

---
plan-refresh: no-op