### PR TITLE
fix(dashboard): v0.34.1 tests + polish — JSDoc, inline const, docstring + chooseBannerCopy extract

### DIFF
--- a/.ai-workspace/plans/2026-04-20-v0-34-1-dashboard-tests-polish.md
+++ b/.ai-workspace/plans/2026-04-20-v0-34-1-dashboard-tests-polish.md
@@ -1,0 +1,135 @@
+# v0.34.1 — dashboard tests + polish (4 fixes + 3 close-and-cite)
+
+## Context
+
+Second bundle of the v0.34.x polish sweep. Seven dashboard test/doc issues filed from earlier /ship reviews. Direct-verification against current master (post-v0.33.2, SHA `1b09203`) showed **3 of 7 are already fixed** — the PR #290/#299 follow-ups landed but the issues weren't closed:
+
+| # | Claim | Master state | Bucket |
+|---|-------|--------------|--------|
+| #293 | `PROJECT_ROOT` fixture misleadingly named `/tmp/forge-auto-open-...` | `FIXTURE_PROJECT_ROOT` at L684, comment at L682 "Renamed from the previous `/tmp/forge-auto-open-nonexistent-xyz`" | **close-and-cite** |
+| #294 | Two describes duplicate beforeEach/afterEach plumbing | `useAutoOpenEnvGate()` helper at L690 factors it; called at L703 + L748 | **close-and-cite** |
+| #295 | env-gate test buried in stat-narrowing describe | Comment at L787 "lives in its own describe per #295"; already moved | **close-and-cite** |
+| #301 | `useAutoOpenEnvGate` JSDoc missing "registers hooks on enclosing describe" | Only has a non-JSDoc comment | **real fix** |
+| #302 | `const eperm` only referenced once — inline it | Still present at test L752, referenced only at L754 | **real fix** (trivial) |
+| #303 | `maybeAutoOpenBrowser` docstring doesn't note env var re-read per invocation | Docstring at L709-717; no mention of per-invocation toggle | **real fix** (trivial) |
+| #355 | Idle-banner tests assert substring-in-HTML, not runtime-branch selection | `updateBanner` IIFE at L472; extract `chooseBannerCopy` helper following `classifyStaleness` pattern at L72 | **real fix** (small refactor) |
+
+**Why now**: bundle follows v0.33.2 dashboard runtime fixes. Strictly test/doc scope — no behavior changes beyond #355's refactor (which is a pure extract-helper move matching `classifyStaleness`'s existing `.toString()` serialization pattern).
+
+## Goal
+
+Outcomes that must hold when done:
+
+1. **`useAutoOpenEnvGate` has a JSDoc docstring** explaining it registers `beforeEach`/`afterEach` against the enclosing describe at call-time (side-effect-ish, must be called from inside a describe).
+2. **The `eperm` constant is inlined** at its single use-site — no stray named constant that reads like it's shared.
+3. **`maybeAutoOpenBrowser` docstring notes the per-invocation env-var check** — explicitly states that toggling `FORGE_DASHBOARD_AUTO_OPEN` mid-process will take effect on the next invocation.
+4. **`chooseBannerCopy` helper exists as a pure top-level function** (mirroring `classifyStaleness`) and is serialized into the `updateBanner` IIFE via `.toString()`. Unit tests exercise the helper directly (runtime-branch coverage for the idle banner).
+5. **#293, #294, #295 closed via PR body** with `Closes #<n>` citations of the existing master state.
+
+## Binary AC
+
+1. **AC-1 — `useAutoOpenEnvGate` has a JSDoc docstring that documents the hook registration.** Extract the 30 lines preceding the function declaration; assert the block contains JSDoc syntax (`/**` or `*/`) AND mentions register/install/hook semantics:
+   ```bash
+   grep -B 30 '^function useAutoOpenEnvGate' server/lib/dashboard-renderer.test.ts | tail -30 > tmp/v034-1-envgate-jsdoc.txt
+   # Must contain a JSDoc close marker to prove a JSDoc block exists just before the function:
+   grep -qE '^\s*\*/' tmp/v034-1-envgate-jsdoc.txt
+   # And the JSDoc body mentions register/install/hook semantics (case-insensitive):
+   grep -qiE '(register|install|hook)' tmp/v034-1-envgate-jsdoc.txt
+   ```
+   (Narrow enough to catch fix-not-applied, broad enough to let the executor write natural prose — uppercase or lowercase.)
+
+2. **AC-2 — `const eperm = Object.assign(...)` is not present.** The constant is either inlined at its use-site or removed:
+   ```bash
+   ! grep -qE 'const\s+eperm\s*=' server/lib/dashboard-renderer.test.ts
+   ```
+
+3. **AC-3 — `maybeAutoOpenBrowser` docstring notes per-invocation env check.** Extract the 30 lines preceding the function signature; assert a phrase about per-invocation / per-call / per-render / re-read / toggle-mid-process:
+   ```bash
+   grep -B 30 '^export async function maybeAutoOpenBrowser' server/lib/dashboard-renderer.ts | tail -30 > tmp/v034-1-maob-jsdoc.txt
+   grep -qiE '(per[- ]invocation|per[- ]call|per[- ]render|re[- ]read|each call|each invocation|toggled? mid)' tmp/v034-1-maob-jsdoc.txt
+   ```
+
+4. **AC-4 — `chooseBannerCopy` helper exists at top level and is serialized into the IIFE.** Structurally:
+   ```bash
+   # Top-level function declaration (export or non-export acceptable, but not inside another function):
+   grep -qE '^(export )?function chooseBannerCopy\(' server/lib/dashboard-renderer.ts
+   # Serialized into the dashboard HTML via .toString() (matching classifyStaleness pattern):
+   grep -qE 'chooseBannerCopy\.toString\(\)' server/lib/dashboard-renderer.ts
+   # Called from within the updateBanner IIFE body (exact substring — no need for awk extraction):
+   grep -qE 'chooseBannerCopy\(' server/lib/dashboard-renderer.ts
+   ```
+
+5. **AC-5 — Unit test exercises `chooseBannerCopy`.** The test file must contain at least one invocation of the helper (not just a reference — an actual call site with parens):
+   ```bash
+   grep -qE 'chooseBannerCopy\(' server/lib/dashboard-renderer.test.ts
+   ```
+   (A call-with-parens implies the helper is being invoked inside a test body. An identifier reference in a comment / import would not match `\(`.)
+
+6. **AC-6 — Test count delta ≥ 1.** At least one new test across dashboard-renderer.test.ts + progress.test.ts (covers the new chooseBannerCopy tests; executor may also add one for #303 if they want):
+   ```bash
+   BEFORE_DASH=$(MSYS_NO_PATHCONV=1 git show origin/master:server/lib/dashboard-renderer.test.ts 2>/dev/null | grep -cE "^\s*(it|test)\s*\(")
+   AFTER_DASH=$(grep -cE "^\s*(it|test)\s*\(" server/lib/dashboard-renderer.test.ts)
+   DELTA=$((AFTER_DASH - BEFORE_DASH))
+   [ "$DELTA" -ge 1 ]
+   ```
+
+7. **AC-7 — Full test suite still green.** Suite ≥ 785 baseline (post-v0.33.2):
+   ```bash
+   mkdir -p tmp && MSYS_NO_PATHCONV=1 npx vitest run --reporter=json --outputFile=tmp/v034-1-full.json > /dev/null 2>&1 || true
+   node -e "const r=require('./tmp/v034-1-full.json'); if (r.numFailedTests === 0 && r.numPassedTests >= 785) process.exit(0); console.error('tests: ' + r.numPassedTests + ' passed / ' + r.numFailedTests + ' failed'); process.exit(1);"
+   ```
+
+8. **AC-8 — Lint green.**
+   ```bash
+   npm run lint > /dev/null 2>&1
+   ```
+
+9. **AC-9 — Changes confined to allowlist.**
+   ```bash
+   git diff --name-only master...HEAD | grep -vE '^(server/lib/dashboard-renderer\.ts|server/lib/dashboard-renderer\.test\.ts|\.ai-workspace/plans/2026-04-20-v0-34-1-dashboard-tests-polish\.md|scripts/v034-1-acceptance\.sh)$' | wc -l | awk '$1 == 0 { exit 0 } { exit 1 }'
+   ```
+
+10. **AC-10 — Acceptance wrapper exists and passes.**
+    ```bash
+    test -x scripts/v034-1-acceptance.sh && bash scripts/v034-1-acceptance.sh | tail -1 | grep -q 'ALL V0.34.1 ACCEPTANCE CHECKS PASSED'
+    ```
+
+## Out of scope
+
+1. **#293, #294, #295** — already fixed on master. PR body uses `Closes #293`, `Closes #294`, `Closes #295`. Do NOT re-apply any code for these.
+2. **`classifyStaleness` refactor** — existing pattern. Do NOT alter it; only mirror it for `chooseBannerCopy`.
+3. **Idle-banner HTML test preservation** — the existing `"Idle — no tool running"` substring-in-HTML tests (from v0.33.0 PR C) STAY. AC-5's new tests are in addition; do not delete the existing ones.
+4. **`progress.ts` / `progress.test.ts`** — this bundle is strictly dashboard-renderer scope. v0.34.1 allowlist does not include progress.
+5. **Package version bump + CHANGELOG** — `/ship` Stage 7 handles.
+6. **Other v0.34.x bundles.**
+
+## Verification procedure
+
+Reviewer runs `bash scripts/v034-1-acceptance.sh` from repo root. Exits 0 iff all 10 AC pass. Print-on-pass: `ALL V0.34.1 ACCEPTANCE CHECKS PASSED`.
+
+Reviewer manually verifies the 3 already-fixed claims by reading master state:
+- (a) `FIXTURE_PROJECT_ROOT` at `dashboard-renderer.test.ts:684` — #293 done
+- (b) `useAutoOpenEnvGate()` helper at `:690` called from `:703` + `:748` — #294 done
+- (c) Env-gate test in its own describe per comment at `:787` — #295 done
+
+**PR body requirement:** include `Closes #293`, `Closes #294`, `Closes #295` (already-fixed), plus `Fixes #301`, `Fixes #302`, `Fixes #303`, `Fixes #355` (real fixes).
+
+## Critical files
+
+- `server/lib/dashboard-renderer.ts` — #303 docstring fix at `maybeAutoOpenBrowser` JSDoc (starting ~L709); #355 `chooseBannerCopy` helper added at top level near `classifyStaleness` (L72), serialized into `updateBanner` IIFE (L472).
+- `server/lib/dashboard-renderer.test.ts` — #301 JSDoc for `useAutoOpenEnvGate` at L690; #302 inline `eperm` at L752/L754; #355 unit tests for `chooseBannerCopy`.
+- `scripts/v034-1-acceptance.sh` — new acceptance wrapper. Must be executable, `set -euo pipefail`, `export MSYS_NO_PATHCONV=1`.
+- `.ai-workspace/plans/2026-04-20-v0-34-1-dashboard-tests-polish.md` — this file (allowlisted in AC-9).
+
+## Checkpoint
+
+- [x] All 7 issue bodies re-verified against master (`1b09203` post-v0.33.2)
+- [x] 3 already-fixed issues identified (#293, #294, #295) — close-and-cite only
+- [x] 4 real fixes sized: 3 trivial doc/cleanup + 1 refactor (#355)
+- [x] Plan drafted with 10 binary AC
+- [ ] `/coherent-plan` review
+- [ ] `/delegate --via subagent` to executor
+- [ ] Executor returns "branch ready + wrapper green"
+- [ ] `/ship` — PR + stateless review + merge + tag v0.33.3 + release
+
+Last updated: 2026-04-20T12:50:00+00:00 — post-/coherent-plan (4 findings, 4 fixed: AC-1 dead awk removed + case-insensitive JSDoc check + wider `-B 30` grep, AC-3 awk→grep simpler extract, AC-5 OR branch removed — require call-with-parens, Critical files line range smoothed).

--- a/scripts/v034-1-acceptance.sh
+++ b/scripts/v034-1-acceptance.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# v0.34.1 acceptance wrapper — dashboard tests + polish (4 real fixes + 3 close-and-cite).
+# Runs AC-1..AC-10 in order. Exits 0 iff all pass.
+# Plan: .ai-workspace/plans/2026-04-20-v0-34-1-dashboard-tests-polish.md
+
+set -euo pipefail
+export MSYS_NO_PATHCONV=1
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+pass() { printf '  [PASS] AC-%s: %s\n' "$1" "$2"; }
+fail() { printf '  [FAIL] AC-%s: %s\n' "$1" "$2"; exit 1; }
+
+mkdir -p tmp
+
+DASH=server/lib/dashboard-renderer.ts
+DASH_TEST=server/lib/dashboard-renderer.test.ts
+
+# AC-1: `useAutoOpenEnvGate` has a JSDoc docstring that documents the hook
+# registration (register/install/hook keyword, case-insensitive).
+grep -B 30 '^function useAutoOpenEnvGate' "$DASH_TEST" | tail -30 > tmp/v034-1-envgate-jsdoc.txt
+if ! grep -qE '^\s*\*/' tmp/v034-1-envgate-jsdoc.txt; then
+  fail 1 "no JSDoc close marker (*/) found in 30 lines preceding useAutoOpenEnvGate"
+fi
+if ! grep -qiE '(register|install|hook)' tmp/v034-1-envgate-jsdoc.txt; then
+  fail 1 "JSDoc block preceding useAutoOpenEnvGate does not mention register/install/hook"
+fi
+pass 1 "useAutoOpenEnvGate has JSDoc documenting hook registration"
+
+# AC-2: `const eperm = Object.assign(...)` is not present — inlined or removed.
+if grep -qE 'const\s+eperm\s*=' "$DASH_TEST"; then
+  fail 2 "const eperm = ... still present; should be inlined at its single use-site"
+fi
+pass 2 "eperm constant inlined"
+
+# AC-3: `maybeAutoOpenBrowser` docstring notes per-invocation env check.
+grep -B 30 '^export async function maybeAutoOpenBrowser' "$DASH" | tail -30 > tmp/v034-1-maob-jsdoc.txt
+if ! grep -qiE '(per[- ]invocation|per[- ]call|per[- ]render|re[- ]read|each call|each invocation|toggled? mid)' tmp/v034-1-maob-jsdoc.txt; then
+  fail 3 "maybeAutoOpenBrowser docstring does not note per-invocation env-var check"
+fi
+pass 3 "maybeAutoOpenBrowser docstring notes per-invocation env check"
+
+# AC-4: chooseBannerCopy helper exists at top level and is serialized into the IIFE.
+if ! grep -qE '^(export )?function chooseBannerCopy\(' "$DASH"; then
+  fail 4 "top-level function chooseBannerCopy(...) not declared"
+fi
+if ! grep -qE 'chooseBannerCopy\.toString\(\)' "$DASH"; then
+  fail 4 "chooseBannerCopy.toString() not serialized into dashboard HTML"
+fi
+if ! grep -qE 'chooseBannerCopy\(' "$DASH"; then
+  fail 4 "chooseBannerCopy(...) not called anywhere in the renderer"
+fi
+pass 4 "chooseBannerCopy defined, serialized via .toString(), and called"
+
+# AC-5: Unit test exercises chooseBannerCopy — helper invoked (call-with-parens).
+if ! grep -qE 'chooseBannerCopy\(' "$DASH_TEST"; then
+  fail 5 "chooseBannerCopy is not invoked in dashboard-renderer.test.ts"
+fi
+pass 5 "dashboard-renderer.test.ts invokes chooseBannerCopy"
+
+# AC-6: Test count delta >= 1 vs master.
+BEFORE_DASH=$(MSYS_NO_PATHCONV=1 git show origin/master:server/lib/dashboard-renderer.test.ts 2>/dev/null | grep -cE "^\s*(it|test)\s*\(" || echo 0)
+AFTER_DASH=$(grep -cE "^\s*(it|test)\s*\(" "$DASH_TEST")
+DELTA=$(( AFTER_DASH - BEFORE_DASH ))
+if [ "$DELTA" -lt 1 ]; then
+  fail 6 "test-count delta < 1 (dashboard: $BEFORE_DASH -> $AFTER_DASH, DELTA=$DELTA)"
+fi
+pass 6 "new tests added (dashboard: $BEFORE_DASH -> $AFTER_DASH, DELTA=$DELTA)"
+
+# AC-7: Full test suite green (>= 785 passed).
+MSYS_NO_PATHCONV=1 npx vitest run --reporter=json --outputFile=tmp/v034-1-full.json > /dev/null 2>&1 || true
+node -e "const r=require('./tmp/v034-1-full.json'); if (r.numFailedTests === 0 && r.numPassedTests >= 785) process.exit(0); console.error('full suite: ' + r.numPassedTests + ' passed / ' + r.numFailedTests + ' failed (expected 0 failed, >= 785 passed)'); process.exit(1);" \
+  || fail 7 "full vitest suite did not meet baseline"
+PASSED=$(node -e "console.log(require('./tmp/v034-1-full.json').numPassedTests)")
+pass 7 "full vitest suite green ($PASSED passed, 0 failed)"
+
+# AC-8: Lint green.
+if ! npm run lint > tmp/v034-1-lint.log 2>&1; then
+  tail -30 tmp/v034-1-lint.log
+  fail 8 "npm run lint reported errors"
+fi
+pass 8 "npm run lint clean"
+
+# AC-9: Diff confined to allowlist.
+UNEXPECTED=$(git diff --name-only master...HEAD | grep -vE '^(server/lib/dashboard-renderer\.ts|server/lib/dashboard-renderer\.test\.ts|\.ai-workspace/plans/2026-04-20-v0-34-1-dashboard-tests-polish\.md|scripts/v034-1-acceptance\.sh)$' || true)
+if [ -n "$UNEXPECTED" ]; then
+  fail 9 "unexpected files in diff: $UNEXPECTED"
+fi
+pass 9 "diff confined to allowlisted fix surface"
+
+# AC-10: Wrapper itself is executable — by construction if this line runs.
+if [ ! -x "scripts/v034-1-acceptance.sh" ]; then
+  fail 10 "scripts/v034-1-acceptance.sh is not executable"
+fi
+pass 10 "scripts/v034-1-acceptance.sh is executable"
+
+echo ""
+echo "ALL V0.34.1 ACCEPTANCE CHECKS PASSED"

--- a/server/lib/dashboard-renderer.test.ts
+++ b/server/lib/dashboard-renderer.test.ts
@@ -21,6 +21,7 @@ import { join } from "node:path";
 
 import {
   classifyStaleness,
+  chooseBannerCopy,
   renderDashboardHtml,
   renderDashboard,
   maybeAutoOpenBrowser,
@@ -149,6 +150,60 @@ describe("classifyStaleness (AC-05)", () => {
 
   it("boundary: exactly 120000ms is amber", () => {
     expect(classifyStaleness(120_000)).toBe("amber");
+  });
+});
+
+describe("chooseBannerCopy (#355) — runtime branch selection", () => {
+  // Pure-function coverage of the banner copy/class pair that the
+  // `updateBanner` IIFE renders inside the browser. Extracted as a
+  // top-level helper so the runtime branches are exercised directly
+  // instead of substring-matched against serialized HTML.
+
+  it("tool-not-running + amber level → neutral idle banner (idle, not hang)", () => {
+    const copy = chooseBannerCopy("amber", false, 90_000);
+    expect(copy.className).toBe("liveness-banner neutral");
+    expect(copy.textContent).toBe("Idle — no tool running");
+  });
+
+  it("tool-not-running + red level → neutral idle banner (idle, not hang)", () => {
+    const copy = chooseBannerCopy("red", false, 150_000);
+    expect(copy.className).toBe("liveness-banner neutral");
+    expect(copy.textContent).toBe("Idle — no tool running");
+  });
+
+  it("tool-not-running + green level → green live-copy (idle downgrade skipped when level is green)", () => {
+    // When level is green the IIFE does not downgrade — the green copy
+    // reads naturally as "nothing stale yet" even without a running tool.
+    const copy = chooseBannerCopy("green", false, 10_000);
+    expect(copy.className).toBe("liveness-banner green");
+    expect(copy.textContent).toContain("Live — last update");
+  });
+
+  it("tool-running + red level → red 'may be hung' copy (legitimate hang alarm)", () => {
+    const copy = chooseBannerCopy("red", true, 150_000);
+    expect(copy.className).toBe("liveness-banner red");
+    expect(copy.textContent).toBe("No update for 2+ min — may be hung");
+  });
+
+  it("tool-running + amber level → amber 'over 1 min ago' copy", () => {
+    const copy = chooseBannerCopy("amber", true, 90_000);
+    expect(copy.className).toBe("liveness-banner amber");
+    expect(copy.textContent).toBe("Last update: over 1 min ago");
+  });
+
+  it("tool-running + green level → green live-copy with seconds-since-update", () => {
+    const copy = chooseBannerCopy("green", true, 30_000);
+    expect(copy.className).toBe("liveness-banner green");
+    // Math.round(30000 / 1000) === 30
+    expect(copy.textContent).toBe("Live — last update 30s ago");
+  });
+
+  it("elapsedMs only affects green live-copy text, not amber/red copy", () => {
+    // amber/red copies are fixed strings — they don't embed elapsedMs.
+    const amber = chooseBannerCopy("amber", true, 999_999);
+    expect(amber.textContent).toBe("Last update: over 1 min ago");
+    const red = chooseBannerCopy("red", true, 999_999);
+    expect(red.textContent).toBe("No update for 2+ min — may be hung");
   });
 });
 

--- a/server/lib/dashboard-renderer.test.ts
+++ b/server/lib/dashboard-renderer.test.ts
@@ -684,9 +684,19 @@ describe("writeDashboardHtml — per-project serial queue (#271)", () => {
 const FIXTURE_PROJECT_ROOT =
   process.platform === "win32" ? "Z:\\project-fixture" : "/project-fixture";
 
-// Factored shared setup/teardown for auto-open describes per #294. Returns
-// nothing — the afterEach hook restores mocks globally. Call from the top of
-// each describe that exercises the env-gated auto-open path.
+/**
+ * Shared setup/teardown helper for auto-open describes (#294, #301).
+ *
+ * Side effect: when invoked from inside a `describe` block, registers a
+ * `beforeEach` hook that silences `console.error` and installs the
+ * `FORGE_DASHBOARD_AUTO_OPEN=1` env gate, plus an `afterEach` hook that
+ * deletes the env var and restores all mocks.
+ *
+ * Must be called at the top of the enclosing `describe` — the
+ * `beforeEach`/`afterEach` hooks register against the currently-active
+ * describe scope, so calling this outside a describe (or inside an `it`)
+ * would attach hooks to the wrong suite.
+ */
 function useAutoOpenEnvGate(): void {
   beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -749,9 +759,8 @@ describe("maybeAutoOpenBrowser — stat catch narrowing (#283 + #291)", () => {
 
   it("non-ENOENT stat error (e.g. EPERM) skips open and does NOT call openExternal or writeFile", async () => {
     const calls: Array<{ op: string }> = [];
-    const eperm = Object.assign(new Error("EPERM"), { code: "EPERM" });
     const io: AutoOpenIo = {
-      stat: async () => { throw eperm; },
+      stat: async () => { throw Object.assign(new Error("EPERM"), { code: "EPERM" }); },
       openExternal: async () => { calls.push({ op: "openExternal" }); },
       writeFile: async () => { calls.push({ op: "writeFile" }); },
     };

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -710,7 +710,9 @@ const DEFAULT_AUTO_OPEN_IO: AutoOpenIo = {
  * Gates (both must hold):
  *   1. `FORGE_DASHBOARD_AUTO_OPEN=1` in the environment (opt-in; default off
  *      so `npm test`, CI, and MCP servers launched without the flag never
- *      spawn a browser).
+ *      spawn a browser). The env var is re-read on each invocation — toggling
+ *      `FORGE_DASHBOARD_AUTO_OPEN` mid-process takes effect on the next call
+ *      (per-invocation check, not a startup-time snapshot). Issue #303.
  *   2. Marker `.forge/.dashboard-opened` must be absent. First successful
  *      open writes the marker; subsequent renders are no-ops. Delete the
  *      marker to re-open the tab (e.g. after closing it accidentally).

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -75,6 +75,55 @@ export function classifyStaleness(elapsedMs: number): "green" | "amber" | "red" 
   return "green";
 }
 
+// ── Banner-copy selector ───────────────────────────────────────────────────
+
+/**
+ * Pure function: (staleness level, tool-running flag, elapsedMs) → banner
+ * (className + textContent) pair.
+ *
+ * Encodes the runtime branch selection that the `updateBanner` IIFE runs
+ * inside the browser. Extracted as a top-level helper (mirroring
+ * `classifyStaleness`) so unit tests can exercise each branch directly
+ * without parsing HTML. Serialized verbatim into the HTML `<script>` block
+ * via `${chooseBannerCopy.toString()}` so the browser runs the same logic.
+ *
+ * Branch semantics:
+ *   - When no tool is running and the level is stale (amber/red), downgrade
+ *     to a neutral "Idle — no tool running" banner. Being idle is not a hang.
+ *   - When a tool is running (or level is green), render the level-appropriate
+ *     copy — red for likely-hung, amber for slow-tick, green for live.
+ *
+ * Issues: #331, #352, #355.
+ */
+export function chooseBannerCopy(
+  level: "green" | "amber" | "red",
+  toolRunning: boolean,
+  elapsedMs: number,
+): { className: string; textContent: string } {
+  if (!toolRunning && level !== "green") {
+    return {
+      className: "liveness-banner neutral",
+      textContent: "Idle — no tool running",
+    };
+  }
+  if (level === "red") {
+    return {
+      className: "liveness-banner red",
+      textContent: "No update for 2+ min — may be hung",
+    };
+  }
+  if (level === "amber") {
+    return {
+      className: "liveness-banner amber",
+      textContent: "Last update: over 1 min ago",
+    };
+  }
+  return {
+    className: "liveness-banner green",
+    textContent: "Live — last update " + Math.round(elapsedMs / 1000) + "s ago",
+  };
+}
+
 // ── Column layout (status → column id) ────────────────────────────────────
 
 /** The 6 column ids. Encoded once; used by renderer + tested by AC-02. */
@@ -444,9 +493,10 @@ export function renderDashboardHtml(input: DashboardRenderInput): string {
   // Activity literal. Issue #331.
   const toolRunning = isToolRunning(activity);
 
-  // Serialize the pure classifier into the browser's script block so the
-  // banner updates between meta-refreshes via setInterval.
+  // Serialize the pure classifier + banner-copy selector into the browser's
+  // script block so the banner updates between meta-refreshes via setInterval.
   const classifierSrc = classifyStaleness.toString();
+  const bannerCopySrc = chooseBannerCopy.toString();
 
   const html = `<!DOCTYPE html>
 <html>
@@ -466,6 +516,7 @@ ${renderFeed(auditEntries)}
 </div>
 <script>
 ${classifierSrc}
+${bannerCopySrc}
 var LAST_UPDATE = ${JSON.stringify(lastUpdate)};
 var ACTIVITY_STARTED = ${JSON.stringify(activityStarted)};
 var TOOL_RUNNING = ${JSON.stringify(toolRunning)};
@@ -474,25 +525,13 @@ function updateBanner() {
   if (!banner) return;
   var elapsed = Date.now() - new Date(LAST_UPDATE).getTime();
   var level = classifyStaleness(elapsed);
-  // When no tool is running (activity.tool absent or empty), a stale
-  // elapsed time is the legitimate idle state, not a hang. Downgrade
-  // amber AND red alarms to a neutral "idle" banner — only green should
-  // slip through, since it reads correctly as "no updates, nothing
-  // running." Issue #331 + #352 (amber previously leaked as
-  // "over 1 min ago" even when idle).
-  if (!TOOL_RUNNING && level !== "green") {
-    banner.className = "liveness-banner neutral";
-    banner.textContent = "Idle — no tool running";
-    return;
-  }
-  banner.className = "liveness-banner " + level;
-  if (level === "red") {
-    banner.textContent = "No update for 2+ min — may be hung";
-  } else if (level === "amber") {
-    banner.textContent = "Last update: over 1 min ago";
-  } else {
-    banner.textContent = "Live — last update " + Math.round(elapsed / 1000) + "s ago";
-  }
+  // Runtime branch selection lives in chooseBannerCopy (#355) so the unit
+  // tests can exercise each branch directly rather than substring-matching
+  // against the serialized HTML. Idle-vs-running downgrade logic and the
+  // level-specific copy are encoded there. Issues #331, #352, #355.
+  var copy = chooseBannerCopy(level, TOOL_RUNNING, elapsed);
+  banner.className = copy.className;
+  banner.textContent = copy.textContent;
 }
 updateBanner();
 setInterval(updateBanner, 1000);


### PR DESCRIPTION
## Summary

Second bundle of the v0.34.x polish sweep. 4 real fixes + 3 close-and-cite (already fixed on master).

**Real fixes (4):**
- **#301** — `useAutoOpenEnvGate` helper now has a JSDoc docstring explaining that it registers `beforeEach`/`afterEach` against the enclosing describe at call-time.
- **#302** — `const eperm` constant inlined at its single use-site (the non-ENOENT stat-throw test); no stray named constant reading like it's shared.
- **#303** — `maybeAutoOpenBrowser` docstring now notes the env-var check runs per invocation (so toggling `FORGE_DASHBOARD_AUTO_OPEN` mid-process takes effect on the next render).
- **#355** — `chooseBannerCopy(level, toolRunning, elapsedMs)` extracted as a pure top-level helper returning `{ className, textContent }`. Serialized into the `updateBanner` IIFE via `.toString()` exactly like `classifyStaleness`. 7 new tests cover all 6 branch combinations (green/amber/red × running/idle) + an `elapsedMs`-affects-only-green regression guard.

**Close-and-cite (already fixed on master — verified directly during plan):**
- **#293** — `FIXTURE_PROJECT_ROOT` rename already landed (comment at test L682 notes "Renamed from the previous `/tmp/forge-auto-open-nonexistent-xyz`").
- **#294** — `useAutoOpenEnvGate()` helper already factors shared beforeEach/afterEach.
- **#295** — env-gate test already moved to its own describe per comment at L787.

## Test plan

- [x] `bash scripts/v034-1-acceptance.sh` — all 10 AC pass end-to-end (`ALL V0.34.1 ACCEPTANCE CHECKS PASSED`)
- [x] Full vitest suite: 792 passed / 0 failed (baseline 785, delta +7 — all `chooseBannerCopy` coverage)
- [x] `npm run lint` — clean
- [x] Diff confined to 4-file allowlist (dashboard-renderer.ts, dashboard-renderer.test.ts, plan file, wrapper script)

Fixes #301
Fixes #302
Fixes #303
Fixes #355
Closes #293
Closes #294
Closes #295

---
plan-refresh: no-op