### PR TITLE
fix(setup-config): v0.34.2 polish — spawnClaude shell:false + JSDoc + wrapper hygiene

### DIFF
--- a/scripts/setup-config-acceptance.sh
+++ b/scripts/setup-config-acceptance.sh
@@ -4,9 +4,11 @@
 # AC-1..AC-10 are checked against an isolated scratch HOME so the reviewer's
 # real ~/.claude.json is never touched.
 #
-# Exit 0 iff all AC pass. Windows-only: requires Git Bash / MSYS2 (cygpath,
-# /c/Windows/System32 path form). Non-Windows hosts will be detected and the
-# wrapper will exit with a clear message rather than running broken checks.
+# Exit 0 iff all AC pass. This wrapper is designed for Windows (Git Bash /
+# MSYS2): it relies on cygpath and the `/c/Windows/System32` path form for the
+# PATH-stripping AC-4 case. On non-Windows hosts the MSYS-specific bits are
+# best-effort fallbacks — some checks (especially AC-4's PATH stripping) may
+# be less meaningful, but the wrapper will still run.
 
 set -euo pipefail
 
@@ -14,6 +16,18 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$REPO_ROOT"
+
+# ---------- Host-pollution snapshot (AC-9 precondition for #308) ----------
+# Capture sha256 of the reviewer's real ~/.claude.json (or record ABSENT)
+# BEFORE any child process — including the pre-flight rebuild step — can fire.
+# This is the invariant for AC-9: "host config is byte-identical before/after."
+# Uses node to avoid sha256sum/shasum portability traps.
+HOST_CLAUDE_JSON="$HOME/.claude.json"
+if [ -f "$HOST_CLAUDE_JSON" ]; then
+  HOST_CLAUDE_JSON_BEFORE_SHA256=$(node -e 'console.log(require("crypto").createHash("sha256").update(require("fs").readFileSync(process.argv[1])).digest("hex"));' "$HOST_CLAUDE_JSON")
+else
+  HOST_CLAUDE_JSON_BEFORE_SHA256="ABSENT"
+fi
 
 # ---------- Scratch HOME setup (bridges Git Bash / MSYS path mismatch) ----------
 # Git Bash's /tmp maps to $USERPROFILE/AppData/Local/Temp, which Node sees as
@@ -51,18 +65,6 @@ if [ ! -f "$REPO_ROOT/dist/index.js" ]; then
   npm run build >/dev/null 2>&1
 fi
 [ -f "$REPO_ROOT/dist/index.js" ] && ok "dist/index.js exists" || fail "dist/index.js missing after build"
-
-# ---------- Host-pollution capture (AC-9 precondition for #308) ----------
-# The wrapper must not mutate the reviewer's real ~/.claude.json. We sha256 it
-# (or record its absence) now, and re-check at the end before summary. Any
-# divergence = fail loud. Uses node to avoid sha256sum/shasum portability traps.
-HOST_CLAUDE_JSON="$HOME/.claude.json"
-if [ -f "$HOST_CLAUDE_JSON" ]; then
-  # Compute sha256 of host ~/.claude.json before any subprocess runs.
-  HOST_CLAUDE_JSON_BEFORE_SHA256=$(node -e 'console.log(require("crypto").createHash("sha256").update(require("fs").readFileSync(process.argv[1])).digest("hex"));' "$HOST_CLAUDE_JSON")
-else
-  HOST_CLAUDE_JSON_BEFORE_SHA256="ABSENT"
-fi
 
 # ---------- AC-1 — primary path writes canonical shape ----------
 ac "AC-1 — primary path shape"
@@ -271,7 +273,7 @@ else
   HOST_CLAUDE_JSON_AFTER_SHA256="ABSENT"
 fi
 if [ "$HOST_CLAUDE_JSON_BEFORE_SHA256" = "$HOST_CLAUDE_JSON_AFTER_SHA256" ]; then
-  ok "AC-9 host ~/.claude.json unchanged (sha256 before=after=$HOST_CLAUDE_JSON_BEFORE_SHA256)"
+  ok "AC-9 host ~/.claude.json unchanged (sha256 before=after)"
 else
   fail "AC-9 host ~/.claude.json mutated (sha256 before=$HOST_CLAUDE_JSON_BEFORE_SHA256 after=$HOST_CLAUDE_JSON_AFTER_SHA256)"
 fi

--- a/scripts/setup-config.cjs
+++ b/scripts/setup-config.cjs
@@ -19,6 +19,12 @@ const path = require("path");
 const os = require("os");
 const { spawnSync } = require("child_process");
 
+// Cache of the resolved claude binary path. Declared at module scope (above the
+// first call into resolveClaude()) so the `let` binding is initialized before
+// any top-level code that triggers a spawnClaude() chain.
+// `undefined` = not yet resolved; `null` = resolution ran and found nothing.
+let claudeBinaryPathCache;
+
 const repoRoot = process.argv[2];
 if (!repoRoot) {
   console.error("ERROR: repo root path argument required.");
@@ -96,10 +102,6 @@ function tryClaudeMcpAdd(distIndexAbs) {
   }
   return { ok: true, reason: null };
 }
-
-// Cache of the resolved claude binary path. `undefined` = not yet resolved;
-// `null` = resolution ran and found nothing (binary not on PATH).
-let claudeBinaryPathCache;
 
 /**
  * Resolve the absolute path to the `claude` CLI binary, without going through a

--- a/scripts/setup-config.cjs
+++ b/scripts/setup-config.cjs
@@ -53,6 +53,20 @@ if (primary.reason === "missing") {
 }
 process.exit(0);
 
+/**
+ * Attempt to register the forge MCP server via the `claude` CLI (primary path).
+ *
+ * Returns a tagged union describing the outcome:
+ *   - `{ ok: true,  reason: null }`       — registration succeeded.
+ *   - `{ ok: false, reason: "missing" }`  — `claude` CLI was not found on PATH;
+ *                                            caller should fall back to direct write.
+ *   - `{ ok: false, reason: "failed" }`   — `claude` CLI was present but
+ *                                            `claude mcp add` returned non-zero;
+ *                                            caller should fall back to direct write.
+ *
+ * @param {string} distIndexAbs Absolute path (forward-slash form) to `dist/index.js`.
+ * @returns {{ ok: boolean, reason: "missing" | "failed" | null }}
+ */
 function tryClaudeMcpAdd(distIndexAbs) {
   const probeSpawn = spawnClaude(["--version"]);
   if (!probeSpawn.available) {
@@ -83,24 +97,69 @@ function tryClaudeMcpAdd(distIndexAbs) {
   return { ok: true, reason: null };
 }
 
-// Spawn the claude CLI with args. Handles Windows `.cmd` shim via shell: true.
+// Cache of the resolved claude binary path. `undefined` = not yet resolved;
+// `null` = resolution ran and found nothing (binary not on PATH).
+let claudeBinaryPathCache;
+
+/**
+ * Resolve the absolute path to the `claude` CLI binary, without going through a
+ * shell. Using `shell: false` in spawnSync avoids cmd.exe string-splitting bugs
+ * when the dist path (or any argv entry) contains spaces.
+ *
+ * Windows: `where claude` lists every candidate; prefer the `.cmd` shim because
+ *   node's spawnSync on Windows invokes .cmd/.bat directly only with shell:true
+ *   OR when handed the `.cmd` path explicitly. We choose the latter.
+ * Unix/MSYS: `which claude` prints the first match on PATH; use as-is.
+ *
+ * Returns the absolute path string, or `null` if the binary is not on PATH.
+ */
+function resolveClaude() {
+  if (claudeBinaryPathCache !== undefined) {
+    return claudeBinaryPathCache;
+  }
+  const locator = process.platform === "win32" ? "where" : "which";
+  const probe = spawnSync(locator, ["claude"], { encoding: "utf-8" });
+  if (probe.error || probe.status !== 0 || !probe.stdout) {
+    claudeBinaryPathCache = null;
+    return null;
+  }
+  const candidates = probe.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (candidates.length === 0) {
+    claudeBinaryPathCache = null;
+    return null;
+  }
+  // On Windows, prefer the `.cmd` shim so spawnSync with shell:false can invoke it.
+  // Fall back to the first candidate otherwise.
+  let chosen = candidates[0];
+  if (process.platform === "win32") {
+    const cmdShim = candidates.find((c) => /\.cmd$/i.test(c));
+    if (cmdShim) {
+      chosen = cmdShim;
+    }
+  }
+  claudeBinaryPathCache = chosen;
+  return chosen;
+}
+
+// Spawn the claude CLI with args using an explicitly resolved binary path.
 // Returns { available: boolean, result: SpawnSyncResult | null }.
-// `available: false` means the binary was not found on PATH (ENOENT).
+// `available: false` means the binary was not found on PATH.
+// shell:false is load-bearing — it prevents cmd.exe string-splitting when any
+// argv entry (e.g., dist path) contains spaces.
 function spawnClaude(args) {
-  const result = spawnSync("claude", args, {
+  const claudeBin = resolveClaude();
+  if (!claudeBin) {
+    return { available: false, result: null };
+  }
+  const result = spawnSync(claudeBin, args, {
     encoding: "utf-8",
-    shell: process.platform === "win32",
+    shell: false,
   });
   if (result.error && result.error.code === "ENOENT") {
     return { available: false, result };
-  }
-  // On Windows with shell:true, ENOENT surfaces differently — a non-zero exit
-  // and stderr like "'claude' is not recognized..." Treat that as unavailable too.
-  if (process.platform === "win32" && result.status !== 0 && result.stderr) {
-    const stderr = result.stderr.toString();
-    if (stderr.includes("not recognized") || stderr.includes("command not found")) {
-      return { available: false, result };
-    }
   }
   return { available: true, result };
 }
@@ -150,8 +209,10 @@ function emitMigrationWarnings() {
     } catch (err) {
       // settings.json is not valid JSON or unreadable. We can't inspect it for the
       // stale `mcpServers.forge` entry, so surface a note rather than silently skip.
+      // JSON.parse always throws an Error with a populated `.message`; readFileSync
+      // throws fs errors that also carry `.message`. Both cases give us a useful string.
       console.error(
-        `setup-config: note — ~/.claude/settings.json is not valid JSON (${err && err.message ? err.message : "parse error"}). Skipping the pre-v0.32.5 migration check for this file; fix or remove it if you want the check to run on the next setup.`
+        `setup-config: note — ~/.claude/settings.json is not valid JSON (${err.message}). Skipping the pre-v0.32.5 migration check for this file; fix or remove it if you want the check to run on the next setup.`
       );
     }
   }

--- a/scripts/v034-2-acceptance.sh
+++ b/scripts/v034-2-acceptance.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# v0.34.2 acceptance wrapper — setup-config polish (6 fixes, 1 deferred).
+# Runs AC-1..AC-12 in order. Exits 0 iff all pass.
+# Plan: .ai-workspace/plans/2026-04-20-v0-34-2-setup-config-polish.md
+
+set -euo pipefail
+export MSYS_NO_PATHCONV=1
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+pass() { printf '  [PASS] AC-%s: %s\n' "$1" "$2"; }
+fail() { printf '  [FAIL] AC-%s: %s\n' "$1" "$2"; exit 1; }
+
+mkdir -p tmp
+
+CFG=scripts/setup-config.cjs
+WRAPPER=scripts/setup-config-acceptance.sh
+
+# AC-1: spawnClaude no longer uses shell: true.
+awk '/^function spawnClaude/,/^}$/' "$CFG" > tmp/v034-2-spawnClaude.txt
+if grep -qE 'shell\s*:\s*true' tmp/v034-2-spawnClaude.txt; then
+  fail 1 "spawnClaude still contains shell: true"
+fi
+pass 1 "spawnClaude does not use shell: true"
+
+# AC-2: spawnClaude (or a sibling helper) resolves the claude binary explicitly.
+if grep -qE '(which|where|resolveClaude|\.cmd|claudeBin|claudePath|binaryPath)' tmp/v034-2-spawnClaude.txt \
+   || grep -qE '(resolveClaude|findClaude|locateClaude)' "$CFG"; then
+  pass 2 "claude binary resolution present (direct or via helper)"
+else
+  fail 2 "no explicit claude binary resolution found"
+fi
+
+# AC-3: wrapper header matches behavior (soft OR guard).
+if head -15 "$WRAPPER" | grep -qE '(exit with a clear message|will exit|exits? early)'; then
+  # Header still promises early-exit → must have a non-MSYS exit path.
+  if head -60 "$WRAPPER" | grep -qE '(OSTYPE|uname).*' \
+     && head -60 "$WRAPPER" | grep -qE '\bexit\s+[1-9]'; then
+    pass 3 "wrapper header retained with OS guard + exit"
+  else
+    fail 3 "wrapper header promises early-exit but no OSTYPE/uname + exit path found in first 60 lines"
+  fi
+else
+  pass 3 "wrapper header softened (no early-exit promise)"
+fi
+
+# AC-4: sha256 snapshot captured before any subprocess.
+SHA_LINE=$(grep -nE 'HOST_CLAUDE_JSON_BEFORE_SHA256=' "$WRAPPER" | head -1 | cut -d: -f1 || true)
+BUILD_LINE=$(grep -nE 'npm run build|npm install|npx ' "$WRAPPER" | head -1 | cut -d: -f1 || true)
+if [ -z "${BUILD_LINE:-}" ]; then
+  pass 4 "no build/install subprocess in wrapper (vacuously ordered)"
+elif [ -n "${SHA_LINE:-}" ] && [ "$SHA_LINE" -lt "$BUILD_LINE" ]; then
+  pass 4 "sha256 snapshot (line $SHA_LINE) precedes first subprocess (line $BUILD_LINE)"
+else
+  fail 4 "sha256 snapshot (line ${SHA_LINE:-none}) does not precede first subprocess (line $BUILD_LINE)"
+fi
+
+# AC-5: AC-9 success line omits hex.
+if grep -E '^\s*ok\s+"AC-9[^"]*unchanged' "$WRAPPER" | grep -qvE '\$HOST_CLAUDE_JSON_(BEFORE|AFTER)_SHA256'; then
+  pass 5 "AC-9 success line does not interpolate sha256 hex"
+else
+  fail 5 "AC-9 success line still interpolates sha256 hex"
+fi
+
+# AC-6: tryClaudeMcpAdd has JSDoc documenting return shape.
+grep -B 30 '^function tryClaudeMcpAdd' "$CFG" | tail -30 > tmp/v034-2-mcpadd-jsdoc.txt
+if ! grep -qE '^\s*\*/' tmp/v034-2-mcpadd-jsdoc.txt; then
+  fail 6 "no JSDoc close marker (*/) found in 30 lines preceding tryClaudeMcpAdd"
+fi
+if ! grep -qE '(reason|ok|missing|failed|tagged|union)' tmp/v034-2-mcpadd-jsdoc.txt; then
+  fail 6 "JSDoc block preceding tryClaudeMcpAdd does not mention reason/ok/missing/failed"
+fi
+pass 6 "tryClaudeMcpAdd has JSDoc documenting tagged union return shape"
+
+# AC-7: err.message ternary fallback removed.
+if grep -qE 'err\s*&&\s*err\.message\s*\?' "$CFG"; then
+  fail 7 "dead-code ternary 'err && err.message ? ...' still present"
+fi
+pass 7 "err.message ternary fallback removed"
+
+# AC-8: full test suite green (>= 792 passed).
+MSYS_NO_PATHCONV=1 npx vitest run --reporter=json --outputFile=tmp/v034-2-full.json > /dev/null 2>&1 || true
+node -e "const r=require('./tmp/v034-2-full.json'); if (r.numFailedTests === 0 && r.numPassedTests >= 792) process.exit(0); console.error('full suite: ' + r.numPassedTests + ' passed / ' + r.numFailedTests + ' failed (expected 0 failed, >= 792 passed)'); process.exit(1);" \
+  || fail 8 "full vitest suite did not meet baseline"
+PASSED=$(node -e "console.log(require('./tmp/v034-2-full.json').numPassedTests)")
+pass 8 "full vitest suite green ($PASSED passed, 0 failed)"
+
+# AC-9: lint green.
+if ! npm run lint > tmp/v034-2-lint.log 2>&1; then
+  tail -30 tmp/v034-2-lint.log
+  fail 9 "npm run lint reported errors"
+fi
+pass 9 "npm run lint clean"
+
+# AC-10: setup-config-acceptance.sh still passes end-to-end (Windows/MSYS only).
+# The setup-config-acceptance.sh wrapper expects MSYS path semantics for $HOME
+# (e.g. /c/Users/...), which MSYS_NO_PATHCONV=1 disables — so we unset that
+# env var for this child invocation only.
+if echo "${OSTYPE:-}" | grep -qE 'msys|cygwin|win32'; then
+  if env -u MSYS_NO_PATHCONV bash "$WRAPPER" > tmp/v034-2-setup-config-wrapper.log 2>&1; then
+    pass 10 "setup-config-acceptance.sh passed end-to-end"
+  else
+    tail -30 tmp/v034-2-setup-config-wrapper.log
+    fail 10 "setup-config-acceptance.sh failed"
+  fi
+else
+  pass 10 "non-Windows host — skipping setup-config-acceptance.sh (wrapper is Windows-targeted)"
+fi
+
+# AC-11: diff confined to allowlist.
+UNEXPECTED=$(git diff --name-only master...HEAD | grep -vE '^(scripts/setup-config\.cjs|scripts/setup-config-acceptance\.sh|\.ai-workspace/plans/2026-04-20-v0-34-2-setup-config-polish\.md|scripts/v034-2-acceptance\.sh)$' || true)
+if [ -n "$UNEXPECTED" ]; then
+  fail 11 "unexpected files in diff: $UNEXPECTED"
+fi
+pass 11 "diff confined to allowlisted fix surface"
+
+# AC-12: this wrapper exists and is executable — by construction if this line runs.
+if [ ! -x "scripts/v034-2-acceptance.sh" ]; then
+  fail 12 "scripts/v034-2-acceptance.sh is not executable"
+fi
+pass 12 "scripts/v034-2-acceptance.sh is executable"
+
+echo ""
+echo "ALL V0.34.2 ACCEPTANCE CHECKS PASSED"


### PR DESCRIPTION
## Summary

Third bundle of the v0.34.x polish sweep. 6 setup-config fixes; 1 issue (#279 intermittent Windows-backslash-stripping dir) deferred as unreproduced.

**Fixes:**
- **#310** — `spawnClaude` refactored from `shell: true` to explicit binary resolution (`which claude` on Unix, `where claude.cmd` on Windows) with `shell: false`. Paths containing spaces (e.g., `C:\Users\Some User\...`) now work correctly. Caught a TDZ bug mid-refactor via the wrapper self-check — fixup commit.
- **#333** — Softened `setup-config-acceptance.sh` header: removed "will exit with a clear message" claim (no actual early-exit path existed). Header now accurately describes best-effort fallbacks.
- **#334** — `HOST_CLAUDE_JSON_BEFORE_SHA256` snapshot hoisted to the top of the wrapper (before any subprocess runs).
- **#335** — AC-9 success `ok` line no longer prints the full sha256 hex — just "before=after". Fail branch still prints both for debugging.
- **#336** — `tryClaudeMcpAdd` got a JSDoc block documenting the tagged-union return `{ ok: boolean, reason: "missing" | "failed" | null }`.
- **#337** — Dead `err.message` ternary fallback removed from the `JSON.parse` catch (SyntaxError always populates `.message`).

**Deferred:** #279 (intermittent Windows-backslash-stripping mkdir creating `C:Users<name>coding_projectsforge-harnesstmp/`) — still unreproduced. Will revisit when next touching /ship Stage 5/10 output paths.

## Test plan

- [x] `bash scripts/v034-2-acceptance.sh` — all 12 AC pass (`ALL V0.34.2 ACCEPTANCE CHECKS PASSED`)
- [x] `bash scripts/setup-config-acceptance.sh` — still passes end-to-end on Windows/MSYS (AC-10 in the new wrapper)
- [x] Full vitest suite: 792 passed / 0 failed (baseline)
- [x] `npm run lint` — clean
- [x] Diff confined to 4-file allowlist

Fixes #310
Fixes #333
Fixes #334
Fixes #335
Fixes #336
Fixes #337

---
plan-refresh: no-op