### PR TITLE
fix: tighten elapsedMs upper bound in checkTimeBudget test

### DIFF
--- a/server/lib/coordinator.test.ts
+++ b/server/lib/coordinator.test.ts
@@ -634,7 +634,7 @@ describe("checkTimeBudget", () => {
     const result = checkTimeBudget(callerStart, 10_000, records);
     // elapsed should be ~5000ms (from callerStart), not ~3_600_000ms (from records).
     expect(result.elapsedMs).toBeGreaterThanOrEqual(5000);
-    expect(result.elapsedMs).toBeLessThan(60_000);
+    expect(result.elapsedMs).toBeLessThan(10_000);
   });
 
   it("maxTimeMs missing → time no-op, warningLevel none", () => {


### PR DESCRIPTION
Closes #371

Auto-fix by /housekeep Stage 4.

Option A from the issue body: tightens the `elapsedMs` upper bound from `60_000` to `10_000` in the "startTimeMs present is authoritative" test in `server/lib/coordinator.test.ts`. The test uses `Date.now() - 5000` as the caller start, so realistic elapsed is ~5000-5050ms; a 10_000ms upper bound remains generous while catching any regression where `priorRecords` (hour-old timestamps) accidentally override caller-provided `startTimeMs`.