### PR TITLE
v0.34.3 — acceptance wrapper hygiene (6 fixes)

### DIFF
--- a/scripts/corrector-crash-fix-acceptance.sh
+++ b/scripts/corrector-crash-fix-acceptance.sh
@@ -52,25 +52,26 @@ grep -q '"corrector-failed"' server/lib/run-record.ts && AC3=0 || AC3=1
 check "AC-3" "run-record.ts outcome union includes 'corrector-failed'" "$AC3"
 
 # AC-4: Truncation unit test passes
-npx vitest run server/lib/anthropic.test.ts > /tmp/ac4.log 2>&1 && AC4=0 || AC4=1
+npx vitest run server/lib/anthropic.test.ts > tmp/ac4.log 2>&1 && AC4=0 || AC4=1
 check "AC-4" "anthropic.test.ts (truncation) passes" "$AC4"
 
 # AC-5: corrector-failed unit tests pass (the 4 new tests in the v0.32.6 block)
-npx vitest run server/tools/plan.test.ts -t "corrector-failed" > /tmp/ac5.log 2>&1 && AC5=0 || AC5=1
+npx vitest run server/tools/plan.test.ts -t "corrector-failed" > tmp/ac5.log 2>&1 && AC5=0 || AC5=1
 check "AC-5" "plan.test.ts corrector-failed outcome tests pass" "$AC5"
 
-# AC-6: regression-positive — corrector success still yields outcome:success
-npx vitest run server/tools/plan.test.ts -t "corrector succeeds" > /tmp/ac6.log 2>&1 && AC6=0 || AC6=1
-check "AC-6" "plan.test.ts regression-positive (corrector success → outcome:success) passes" "$AC6"
+# AC-6: regression-positive -- corrector success still yields outcome:success
+npx vitest run server/tools/plan.test.ts -t "corrector succeeds" > tmp/ac6.log 2>&1 && AC6=0 || AC6=1
+check "AC-6" "plan.test.ts regression-positive (corrector success -> outcome:success) passes" "$AC6"
 
-# AC-7: full vitest suite clean — no test FAILURES. We ignore the non-zero exit
+# AC-7: full vitest suite clean -- no test FAILURES. We ignore the non-zero exit
 # when it comes from the pre-existing dashboard-renderer.test.ts teardown-rpc
 # race (Vitest 4.x EnvironmentTeardownError) because that flake is orthogonal
 # to the corrector fix. The authoritative signal is `numFailedTests == 0` in
 # vitest's structured JSON output (not stdout text, which is brittle across
-# vitest upgrades).
-npx vitest run --reporter=json --outputFile=tmp/ac7.json > /tmp/ac7.log 2>&1 || true
-if [ -s tmp/ac7.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("tmp/ac7.json","utf-8")); process.exit(d.numFailedTests > 0 ? 1 : 0)'; then
+# vitest upgrades). A `typeof === "number"` guard prevents schema drift from
+# vacuously passing (undefined > 0 is false in JS) -- #340.
+npx vitest run --reporter=json --outputFile=tmp/ac7.json > tmp/ac7.log 2>&1 || true
+if [ -s tmp/ac7.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("tmp/ac7.json","utf-8")); if (typeof d.numFailedTests !== "number") process.exit(2); process.exit(d.numFailedTests > 0 ? 1 : 0)'; then
   AC7=0
 else
   AC7=1
@@ -78,7 +79,7 @@ fi
 check "AC-7" "full vitest suite passes (no test failures; teardown-rpc flake ignored)" "$AC7"
 
 # AC-8: TypeScript build clean
-npm run build > /tmp/ac8.log 2>&1 && AC8=0 || AC8=1
+npm run build > tmp/ac8.log 2>&1 && AC8=0 || AC8=1
 check "AC-8" "npm run build compiles cleanly" "$AC8"
 
 # AC-9: wrapper script is executable
@@ -100,7 +101,7 @@ if [ "$FAIL" -gt 0 ]; then
     echo "  - $f"
   done
   echo
-  echo "Inspect logs under /tmp/ac*.log for failing ACs."
+  echo "Inspect logs under tmp/ac*.log for failing ACs."
   exit 1
 fi
 

--- a/scripts/default-max-tokens-sweep-acceptance.sh
+++ b/scripts/default-max-tokens-sweep-acceptance.sh
@@ -45,18 +45,20 @@ check "AC-1" "DEFAULT_MAX_TOKENS literal is 32000 in anthropic.ts" "$AC1"
 check "AC-2" "no stale DEFAULT_MAX_TOKENS = 8192 literal" "$AC2"
 
 # AC-3: default-passed-through unit test passes
-npx vitest run server/lib/anthropic.test.ts -t "max_tokens=32000 to the SDK when caller does not pass maxTokens" > /tmp/ac3.log 2>&1 && AC3=0 || AC3=1
+npx vitest run server/lib/anthropic.test.ts -t "max_tokens=32000 to the SDK when caller does not pass maxTokens" > tmp/ac3.log 2>&1 && AC3=0 || AC3=1
 check "AC-3" "default-maxTokens-passed-through unit test passes" "$AC3"
 
 # AC-4: explicit override still wins
-npx vitest run server/lib/anthropic.test.ts -t "explicit maxTokens override still wins" > /tmp/ac4.log 2>&1 && AC4=0 || AC4=1
+npx vitest run server/lib/anthropic.test.ts -t "explicit maxTokens override still wins" > tmp/ac4.log 2>&1 && AC4=0 || AC4=1
 check "AC-4" "explicit maxTokens override still wins (regression positive)" "$AC4"
 
-# AC-5: full suite clean — no test FAILURES (ignore vitest teardown-rpc flake).
+# AC-5: full suite clean -- no test FAILURES (ignore vitest teardown-rpc flake).
 # Use vitest's structured JSON reporter so we parse numFailedTests rather than
-# stdout text, which is brittle across vitest upgrades.
-npx vitest run --reporter=json --outputFile=tmp/ac5.json > /tmp/ac5.log 2>&1 || true
-if [ -s tmp/ac5.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("tmp/ac5.json","utf-8")); process.exit(d.numFailedTests > 0 ? 1 : 0)'; then
+# stdout text, which is brittle across vitest upgrades. A `typeof === "number"`
+# guard prevents schema drift from vacuously passing (undefined > 0 is false in
+# JS) -- #340.
+npx vitest run --reporter=json --outputFile=tmp/ac5.json > tmp/ac5.log 2>&1 || true
+if [ -s tmp/ac5.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("tmp/ac5.json","utf-8")); if (typeof d.numFailedTests !== "number") process.exit(2); process.exit(d.numFailedTests > 0 ? 1 : 0)'; then
   AC5=0
 else
   AC5=1
@@ -64,7 +66,7 @@ fi
 check "AC-5" "full vitest suite passes (no test failures)" "$AC5"
 
 # AC-6: TypeScript build clean
-npm run build > /tmp/ac6.log 2>&1 && AC6=0 || AC6=1
+npm run build > tmp/ac6.log 2>&1 && AC6=0 || AC6=1
 check "AC-6" "npm run build compiles cleanly" "$AC6"
 
 # AC-7: setup.sh unchanged vs master
@@ -82,7 +84,7 @@ if [ "$FAIL" -gt 0 ]; then
     echo "  - $f"
   done
   echo
-  echo "Inspect logs under /tmp/ac*.log for failing ACs."
+  echo "Inspect logs under tmp/ac*.log for failing ACs."
   exit 1
 fi
 

--- a/scripts/q1-cross-phase-acceptance.sh
+++ b/scripts/q1-cross-phase-acceptance.sh
@@ -14,6 +14,10 @@
 set -u
 export MSYS_NO_PATHCONV=1
 
+# Log files go to project-relative tmp/ so paths resolve identically under MSYS
+# bash and node.exe on Windows (#341). tmp/ is gitignored.
+mkdir -p tmp
+
 DECISION_FILE=".ai-workspace/audits/2026-04-15-c1-bootstrap-exemption-decision.md"
 PLAN_FILE=".ai-workspace/plans/2026-04-15-q1-cross-phase-grep-audit.md"
 
@@ -59,38 +63,38 @@ ok "skipped per ordering constraint (AC-3 XOR AC-4)"
 
 # ── AC-5 — ac-lint clean ─────────────────────────────────────────────────
 section "AC-5 — ac-lint test green"
-if npx vitest run server/validation/ac-lint.test.ts >/tmp/ac5.log 2>&1; then
+if npx vitest run server/validation/ac-lint.test.ts >tmp/ac5.log 2>&1; then
   ok "ac-lint.test.ts green"
 else
-  bad "ac-lint.test.ts failed (see /tmp/ac5.log)"
-  tail -15 /tmp/ac5.log
+  bad "ac-lint.test.ts failed (see tmp/ac5.log)"
+  tail -15 tmp/ac5.log
 fi
 
 # ── AC-6 — build green ───────────────────────────────────────────────────
 section "AC-6 — npm run build exits 0"
-if npm run build >/tmp/ac6.log 2>&1; then
+if npm run build >tmp/ac6.log 2>&1; then
   ok "build clean"
 else
-  bad "build failed (see /tmp/ac6.log)"
-  tail -15 /tmp/ac6.log
+  bad "build failed (see tmp/ac6.log)"
+  tail -15 tmp/ac6.log
 fi
 
 # ── AC-7 — lint green ────────────────────────────────────────────────────
 section "AC-7 — npm run lint exits 0"
-if npm run lint >/tmp/ac7.log 2>&1; then
+if npm run lint >tmp/ac7.log 2>&1; then
   ok "lint clean"
 else
-  bad "lint failed (see /tmp/ac7.log)"
-  tail -15 /tmp/ac7.log
+  bad "lint failed (see tmp/ac7.log)"
+  tail -15 tmp/ac7.log
 fi
 
 # ── AC-8 — npm test green ────────────────────────────────────────────────
 section "AC-8 — npm test exits 0"
-if npm test >/tmp/ac8.log 2>&1; then
+if npm test >tmp/ac8.log 2>&1; then
   ok "test suite clean"
 else
-  bad "test suite failed (see /tmp/ac8.log)"
-  tail -20 /tmp/ac8.log
+  bad "test suite failed (see tmp/ac8.log)"
+  tail -20 tmp/ac8.log
 fi
 
 # ── AC-9 — diff scope ────────────────────────────────────────────────────

--- a/scripts/v034-3-acceptance.sh
+++ b/scripts/v034-3-acceptance.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Acceptance wrapper for v0.34.3 -- wrapper-hygiene polish slice.
+# Runs AC-1..AC-11 + AC-13 from
+#   .ai-workspace/plans/2026-04-20-v0-34-3-wrapper-hygiene.md
+# Exits 0 iff every AC passes. AC-12 (this wrapper's own existence + green
+# status) is satisfied by the fact that this script is being run; we do not
+# self-check AC-12.
+#
+# Usage: bash scripts/v034-3-acceptance.sh
+# Prereqs: node, npm, git, bash, awk, grep, sort, seq, wc, tr, test. No jq.
+#
+# Convention (matches corrector-crash-fix-acceptance.sh): collects failures
+# into a FAILURES array and prints a summary at end rather than `set -e`
+# first-fail-exit, so a single AC failure does not hide downstream failures.
+
+set -u
+# MSYS_NO_PATHCONV=1 disables Git Bash path mangling when any downstream step
+# uses `origin/master:<path>` syntax. Cheap insurance; harmless when unused.
+export MSYS_NO_PATHCONV=1
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PASS=0
+FAIL=0
+declare -a FAILURES
+
+# tmp/ hosts vitest JSON output + logs. Project-relative so MSYS bash and
+# node.exe see the same path on Windows (#341).
+mkdir -p tmp
+
+check() {
+  local name="$1"
+  local description="$2"
+  local exit_code="$3"
+  if [ "$exit_code" -eq 0 ]; then
+    echo "  PASS  $name  $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $name  $description"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: $description")
+  fi
+}
+
+echo "=== v0.34.3 wrapper-hygiene acceptance ==="
+echo
+
+# ---------------------------------------------------------------------------
+# AC-1 (#338): corrector-crash-fix-acceptance.sh has contiguous AC labels.
+# Non-comment AC-N labels form 1..N with no gaps, no duplicates.
+# ---------------------------------------------------------------------------
+LABELS=$(grep -vE '^[[:space:]]*#' scripts/corrector-crash-fix-acceptance.sh \
+  | grep -oE 'AC-[0-9]+' \
+  | sort -u \
+  | sed 's/AC-//' \
+  | sort -n \
+  | tr '\n' ',' \
+  | sed 's/,$//')
+N=$(echo "$LABELS" | tr ',' '\n' | wc -l | tr -d ' ')
+EXPECTED=$(seq 1 "$N" | tr '\n' ',' | sed 's/,$//')
+if [ "$LABELS" = "$EXPECTED" ]; then AC1=0; else AC1=1; fi
+check "AC-1" "corrector wrapper AC labels contiguous 1..$N (got=$LABELS want=$EXPECTED)" "$AC1"
+
+# ---------------------------------------------------------------------------
+# AC-2 (#340a): corrector wrapper type-guards numFailedTests.
+# ---------------------------------------------------------------------------
+if grep -qE 'typeof[[:space:]]+d\.numFailedTests[[:space:]]*(!==|===)[[:space:]]*"number"' \
+  scripts/corrector-crash-fix-acceptance.sh; then AC2=0; else AC2=1; fi
+check "AC-2" "corrector wrapper has typeof numFailedTests === 'number' guard" "$AC2"
+
+# ---------------------------------------------------------------------------
+# AC-3 (#340b): default-max-tokens wrapper type-guards numFailedTests.
+# ---------------------------------------------------------------------------
+if grep -qE 'typeof[[:space:]]+d\.numFailedTests[[:space:]]*(!==|===)[[:space:]]*"number"' \
+  scripts/default-max-tokens-sweep-acceptance.sh; then AC3=0; else AC3=1; fi
+check "AC-3" "default-max-tokens wrapper has typeof numFailedTests === 'number' guard" "$AC3"
+
+# ---------------------------------------------------------------------------
+# AC-4 (#341): No /tmp/ac*.log references remain in the three affected
+# wrappers. Per-file loop distinguishes grep exit 0 (match=fail), exit 1
+# (no match=pass this file), and anything else (grep error=fail) -- avoids
+# the `! grep` false-pass where exit 2 would flip to 0.
+# ---------------------------------------------------------------------------
+AC4=0
+for f in \
+  scripts/corrector-crash-fix-acceptance.sh \
+  scripts/default-max-tokens-sweep-acceptance.sh \
+  scripts/q1-cross-phase-acceptance.sh
+do
+  if [ ! -f "$f" ]; then
+    echo "    missing file: $f"
+    AC4=1
+    continue
+  fi
+  OUT=$(grep -nE '/tmp/ac[0-9*]' "$f" 2>&1)
+  RC=$?
+  case $RC in
+    0) echo "    /tmp/ac* match in $f:"; echo "$OUT" | sed 's/^/      /'; AC4=1 ;;
+    1) : ;;  # no match = pass this file
+    *) echo "    grep error (rc=$RC) on $f: $OUT"; AC4=1 ;;
+  esac
+done
+check "AC-4" "no /tmp/ac*.log refs in 3 affected wrappers (corrector, default-max, q1)" "$AC4"
+
+# ---------------------------------------------------------------------------
+# AC-5 (#343): F57-cd-basename rule-object exists in AC_LINT_RULES.
+# Matches the id property shape, tolerating single or double quotes.
+# ---------------------------------------------------------------------------
+if grep -qE 'id:[[:space:]]*["'\'']F57-cd-basename["'\'']' \
+  server/lib/prompts/shared/ac-subprocess-rules.ts; then AC5=0; else AC5=1; fi
+check "AC-5" "F57-cd-basename rule object present in AC_LINT_RULES" "$AC5"
+
+# ---------------------------------------------------------------------------
+# AC-6 (#343): F57 unit test exists and passes (and is actually discovered
+# by vitest -- `numPassedTests >= 1` defeats --passWithNoTests silent-exit-0).
+# ---------------------------------------------------------------------------
+rm -f tmp/v034-3-f57.json
+npx vitest run server/validation/ac-lint.test.ts -t "F57-cd-basename" \
+  --reporter=json --outputFile=tmp/v034-3-f57.json > tmp/v034-3-f57.log 2>&1 || true
+if [ -s tmp/v034-3-f57.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("tmp/v034-3-f57.json","utf8")); if (typeof d.numPassedTests !== "number" || d.numPassedTests < 1) { console.error("F57 test missing: numPassedTests=", d.numPassedTests); process.exit(1); } if (typeof d.numFailedTests !== "number") process.exit(2); if (d.numFailedTests > 0) process.exit(1); process.exit(0);'; then
+  AC6=0
+else
+  AC6=1
+fi
+check "AC-6" "F57-cd-basename vitest filter yields numPassedTests>=1 and 0 failures" "$AC6"
+
+# ---------------------------------------------------------------------------
+# AC-7 (#344): ac-subprocess-rules.ts is fully ASCII (no byte > 0x7F).
+# Node (not grep -P) to avoid the MSYS "unibyte/UTF-8 locale" exit-2 flip.
+# ---------------------------------------------------------------------------
+if node -e 'const s=require("fs").readFileSync("server/lib/prompts/shared/ac-subprocess-rules.ts","utf8"); process.exit(/[^\x00-\x7F]/.test(s)?1:0)'; then
+  AC7=0
+else
+  AC7=1
+fi
+check "AC-7" "ac-subprocess-rules.ts is fully ASCII (no bytes > 0x7F)" "$AC7"
+
+# ---------------------------------------------------------------------------
+# AC-8 (#345): Each of the five cwd-policy tokens appears exactly once -- in
+# its AC_CWD_POLICY_* constant declaration -- and nowhere else under
+# server/lib/prompts/. Token 4 contains literal backticks so the assignments
+# MUST be single-quoted in shell context.
+# ---------------------------------------------------------------------------
+AC8=0
+# shellcheck disable=SC2016
+TOKENS=(
+  'cwd is ALREADY the project root'
+  'cd <project-basename>'
+  'cd my-project && npx tsc'
+  'RIGHT: `npx tsc --noEmit`'
+  'monday-bot/monday-bot/'
+)
+for TOKEN in "${TOKENS[@]}"; do
+  COUNT=$(grep -rnF "$TOKEN" server/lib/prompts/ \
+    | grep -vE 'AC_CWD_POLICY_[A-Z_]+[[:space:]]*=' \
+    | wc -l | tr -d ' ')
+  if [ "$COUNT" != "0" ]; then
+    echo "    token leak: \"$TOKEN\" has $COUNT non-assignment occurrence(s)"
+    grep -rnF "$TOKEN" server/lib/prompts/ | grep -vE 'AC_CWD_POLICY_[A-Z_]+[[:space:]]*=' | sed 's/^/      /'
+    AC8=1
+  fi
+done
+check "AC-8" "all 5 cwd-policy tokens single-sourced behind AC_CWD_POLICY_* constants" "$AC8"
+
+# ---------------------------------------------------------------------------
+# AC-9: Full vitest suite clean -- numFailedTests === 0 and numPassedTests
+# >= 793 (master 792 + 1 for additive F57 coverage; our branch adds 7 F57
+# tests so the real count is 799, which comfortably exceeds 793).
+# ---------------------------------------------------------------------------
+rm -f tmp/v034-3-full.json
+npx vitest run --reporter=json --outputFile=tmp/v034-3-full.json > tmp/v034-3-full.log 2>&1 || true
+if [ -s tmp/v034-3-full.json ] && node -e 'const d=JSON.parse(require("fs").readFileSync("tmp/v034-3-full.json","utf-8")); if (typeof d.numFailedTests !== "number") { console.error("numFailedTests missing"); process.exit(2); } if (d.numFailedTests > 0) { console.error("numFailedTests=", d.numFailedTests); process.exit(1); } if (typeof d.numPassedTests !== "number") { console.error("numPassedTests missing"); process.exit(3); } if (d.numPassedTests < 793) { console.error("numPassedTests=", d.numPassedTests, "below 793"); process.exit(1); } process.exit(0);'; then
+  AC9=0
+else
+  AC9=1
+fi
+check "AC-9" "full vitest suite: numFailedTests=0 and numPassedTests>=793" "$AC9"
+
+# ---------------------------------------------------------------------------
+# AC-10: npm run lint exits 0.
+# ---------------------------------------------------------------------------
+if npm run lint > tmp/v034-3-lint.log 2>&1; then AC10=0; else AC10=1; fi
+check "AC-10" "npm run lint exits 0" "$AC10"
+
+# ---------------------------------------------------------------------------
+# AC-11: npm run build exits 0.
+# ---------------------------------------------------------------------------
+if npm run build > tmp/v034-3-build.log 2>&1; then AC11=0; else AC11=1; fi
+check "AC-11" "npm run build exits 0" "$AC11"
+
+# ---------------------------------------------------------------------------
+# AC-13: No drive-by edits. Branch diff vs origin/master touches only the
+# allowlisted paths. Pre-fetch origin/master so the diff resolves on shallow
+# CI clones.
+# ---------------------------------------------------------------------------
+git fetch --no-tags --prune --depth=100 origin master > tmp/v034-3-fetch.log 2>&1 || true
+BAD=$(git diff --name-only origin/master...HEAD 2>/dev/null \
+  | grep -vE '^(scripts/v034-3-acceptance\.sh|scripts/corrector-crash-fix-acceptance\.sh|scripts/default-max-tokens-sweep-acceptance\.sh|scripts/q1-cross-phase-acceptance\.sh|server/lib/prompts/shared/ac-subprocess-rules\.ts|server/lib/prompts/planner\.test\.ts|server/validation/ac-lint\.test\.ts|server/lib/lint-audit\.test\.ts|\.ai-workspace/plans/.+)$' \
+  || true)
+if [ -z "$BAD" ]; then AC13=0; else AC13=1; fi
+if [ -n "$BAD" ]; then
+  echo "    out-of-allowlist paths in diff:"
+  echo "$BAD" | sed 's/^/      /'
+fi
+check "AC-13" "branch diff vs origin/master only touches allowlisted paths" "$AC13"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "=== summary: $PASS pass / $FAIL fail ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "FAILURES:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  echo
+  echo "Inspect logs under tmp/v034-3-*.log for failing ACs."
+  exit 1
+fi
+
+echo "ALL GREEN"
+exit 0

--- a/server/lib/prompts/planner.test.ts
+++ b/server/lib/prompts/planner.test.ts
@@ -12,6 +12,13 @@ import {
   DEFAULT_MAX_CONTEXT_CHARS,
   type ContextEntry,
 } from "./planner.js";
+import {
+  AC_CWD_POLICY_MARKER,
+  AC_CWD_POLICY_BASENAME_TOKEN,
+  AC_CWD_POLICY_WRONG_EXAMPLE,
+  AC_CWD_POLICY_RIGHT_EXAMPLE,
+  AC_CWD_POLICY_PROVENANCE,
+} from "./shared/ac-subprocess-rules.js";
 
 describe("truncateContext", () => {
   it("returns all entries when within budget", () => {
@@ -214,29 +221,29 @@ describe("AC cwd-policy — prevents doubled-cd defect (monday-bot 2026-04-20)",
     (mode) => {
       const prompt = buildPlannerPrompt(mode);
       expect(prompt).toContain("Working directory");
-      expect(prompt).toContain("cwd is ALREADY the project root");
+      expect(prompt).toContain(AC_CWD_POLICY_MARKER);
       expect(prompt).toContain("projectPath");
     },
   );
 
   it.each(modes)(
-    "buildPlannerPrompt(%s) forbids `cd <project-basename> && ...` prefix",
+    "buildPlannerPrompt(%s) forbids the doubled-cd-into-basename prefix",
     (mode) => {
       const prompt = buildPlannerPrompt(mode);
-      expect(prompt).toContain("cd <project-basename>");
-      expect(prompt).toContain("cd my-project && npx tsc");
-      expect(prompt).toContain("RIGHT: `npx tsc --noEmit`");
+      expect(prompt).toContain(AC_CWD_POLICY_BASENAME_TOKEN);
+      expect(prompt).toContain(AC_CWD_POLICY_WRONG_EXAMPLE);
+      expect(prompt).toContain(AC_CWD_POLICY_RIGHT_EXAMPLE);
     },
   );
 
   it("the forbidden example names monday-bot so future readers see the provenance", () => {
     const prompt = buildPlannerPrompt("full-project");
-    expect(prompt).toContain("monday-bot/monday-bot/");
+    expect(prompt).toContain(AC_CWD_POLICY_PROVENANCE);
   });
 
   it("buildPhasePlannerPrompt inherits the cwd-policy from the base prompt", () => {
     const prompt = buildPhasePlannerPrompt("feature");
-    expect(prompt).toContain("cwd is ALREADY the project root");
-    expect(prompt).toContain("cd <project-basename>");
+    expect(prompt).toContain(AC_CWD_POLICY_MARKER);
+    expect(prompt).toContain(AC_CWD_POLICY_BASENAME_TOKEN);
   });
 });

--- a/server/lib/prompts/shared/ac-subprocess-rules.ts
+++ b/server/lib/prompts/shared/ac-subprocess-rules.ts
@@ -2,34 +2,61 @@
  * Shared source of truth for AC subprocess-safety rules (Q0.5/A1 + A2).
  *
  * Consumers:
- *   - `server/lib/prompts/planner.ts` — embeds AC_SUBPROCESS_RULES_PROMPT.
- *   - `server/lib/prompts/critic.ts` — embeds AC_SUBPROCESS_RULES_PROMPT +
+ *   - `server/lib/prompts/planner.ts` -- embeds AC_SUBPROCESS_RULES_PROMPT.
+ *   - `server/lib/prompts/critic.ts` -- embeds AC_SUBPROCESS_RULES_PROMPT +
  *     cites AC_LINT_RULES by id in findings (Q0.5/A2).
- *   - `server/validation/ac-lint.ts` — mechanical lint at the primitive boundary.
- *   - `server/lib/lint-audit.ts` — calls `getAcLintRulesHash()` for staleness check (Q0.5/A3-bis).
+ *   - `server/validation/ac-lint.ts` -- mechanical lint at the primitive boundary.
+ *   - `server/lib/lint-audit.ts` -- calls `getAcLintRulesHash()` for staleness check (Q0.5/A3-bis).
  *
- * Do NOT duplicate these patterns elsewhere — import from here.
+ * Do NOT duplicate these patterns elsewhere -- import from here.
  */
 
 import { createHash } from "node:crypto";
 
 /**
+ * Shared cwd-policy prose tokens (#345).
+ *
+ * Each constant holds exactly one canonical phrasing that appears in the
+ * LLM-facing prompt AND is asserted in tests. Instead of duplicating the
+ * phrase in both the prompt template and the test file, each site imports
+ * the same constant by name -- a prompt reword now requires changing exactly
+ * one line, and tests automatically follow. Five tokens total; they cover
+ * the cwd-policy block's load-bearing phrases.
+ *
+ * NOTE: prettier may split long string literals across lines. These are
+ * deliberately kept on a single line so the AC-8 filter regex
+ * `AC_CWD_POLICY_[A-Z_]+[[:space:]]*=` matches the assignment form. Do not
+ * reflow without updating the AC-8 check.
+ */
+// prettier-ignore
+export const AC_CWD_POLICY_MARKER = "cwd is ALREADY the project root";
+// prettier-ignore
+export const AC_CWD_POLICY_BASENAME_TOKEN = "cd <project-basename>";
+// prettier-ignore
+export const AC_CWD_POLICY_WRONG_EXAMPLE = "cd my-project && npx tsc";
+// prettier-ignore
+export const AC_CWD_POLICY_RIGHT_EXAMPLE = "RIGHT: `npx tsc --noEmit`";
+// prettier-ignore
+export const AC_CWD_POLICY_PROVENANCE = "monday-bot/monday-bot/";
+
+/**
  * Human-readable prompt block embedded into planner/critic system prompts.
- * Byte-identical extraction of the original planner "AC Command Contract"
- * section. Any future edit to the rule text must happen here only.
+ * ASCII-only per #344: no bytes outside 0x00-0x7F anywhere in this file. Use
+ * `--` for emphasis dashes (not em-dash U+2014), and plain ASCII throughout.
+ * Any future edit to the rule text must happen here only.
  */
 export const AC_SUBPROCESS_RULES_PROMPT = `### AC Command Contract
 AC commands execute inside node:child_process.exec() with bash shell.
 Environment: no TTY, no stdin, stdout/stderr captured as evidence, 30s timeout.
-Working directory: cwd is ALREADY the project root (the forge_evaluate \`projectPath\`
-argument). Write AC commands as if you are already inside that directory — do NOT
-prefix them with \`cd <project-basename> && ...\`. That prefix is always wrong: the
+Working directory: ${AC_CWD_POLICY_MARKER} (the forge_evaluate \`projectPath\`
+argument). Write AC commands as if you are already inside that directory -- do NOT
+prefix them with \`${AC_CWD_POLICY_BASENAME_TOKEN} && ...\`. That prefix is always wrong: the
 project is already the cwd, so \`cd monday-bot && npm install\` looks for
-\`monday-bot/monday-bot/\` and fails. \`cd\` into *sub-directories* of the project
+\`${AC_CWD_POLICY_PROVENANCE}\` and fails. \`cd\` into *sub-directories* of the project
 (\`cd packages/foo && ...\`) is fine when genuinely needed; the rule is specifically
 against re-entering the project root.
-  WRONG: \`cd my-project && npx tsc --noEmit\`
-  RIGHT: \`npx tsc --noEmit\`
+  WRONG: \`${AC_CWD_POLICY_WRONG_EXAMPLE} --noEmit\`
+  ${AC_CWD_POLICY_RIGHT_EXAMPLE}
 Exit code 0 = PASS, non-zero = FAIL. Design commands accordingly:
 - Prefer exit-code checks over stdout parsing:
   GOOD: \`npx vitest run -t 'budget'\` (exits 0 on pass)
@@ -38,7 +65,7 @@ Exit code 0 = PASS, non-zero = FAIL. Design commands accordingly:
   BAD:  \`cmd | grep -q 'x' && ! grep -q 'y'\`
   GOOD: \`OUT=$(cmd 2>&1); echo "$OUT" | grep -q 'x' && ! echo "$OUT" | grep -q 'y'\`
 - No count-based regex on test runner summary lines (format is TTY-dependent).
-- 30s timeout — keep commands focused. Use -t filters for test suites instead of running all tests.`;
+- 30s timeout -- keep commands focused. Use -t filters for test suites instead of running all tests.`;
 
 /**
  * Structured deny-list rules, consumed by `lintAcCommand` and cited by critic.
@@ -53,7 +80,7 @@ export interface AcLintRule {
   description: string;
   /** Regex applied to the full AC command string. */
   pattern: RegExp;
-  /** Severity — only "suspect" for now (scope of A1/A2). */
+  /** Severity -- only "suspect" for now (scope of A1/A2). */
   severity: "suspect";
   /** Concrete WRONG example that this rule flags. */
   wrongExample: string;
@@ -107,13 +134,13 @@ export const AC_LINT_RULES: AcLintRule[] = [
     description:
       "grep inspecting source tree (src/, server/, lib/) instead of verifying observable behavior",
     // Q0.5/A2 MAJOR-2 fix: structural anchoring. Require the path token to
-    // appear as a DIRECT grep argument — flags, optional quoted pattern,
-    // then (src|server|lib)/path — NOT as trailing text anywhere after grep.
+    // appear as a DIRECT grep argument -- flags, optional quoted pattern,
+    // then (src|server|lib)/path -- NOT as trailing text anywhere after grep.
     // This rejects benign chains like
     //   `grep -q 'ok' out.log && curl localhost/src/main.js`
     // (where `src/` is inside a URL, not a grep arg), while still matching
     //   `grep -n 'callClaude\|trackedCallClaude' server/lib/coordinator.ts`
-    // (where `\|` appears inside a quoted grep pattern — the OLD lazy
+    // (where `\|` appears inside a quoted grep pattern -- the OLD lazy
     //  `[^\n;]*?` span was too permissive and couldn't reject the &&/|| case).
     pattern:
       /\bgrep\b(?:\s+-[A-Za-z]+)*\s+(?:['"][^'"]*['"]\s+)?(?:src|server|lib)\/[A-Za-z0-9_\-./]*/,
@@ -125,7 +152,7 @@ export const AC_LINT_RULES: AcLintRule[] = [
   {
     id: "F36-raw-rg",
     description:
-      "raw `rg` (ripgrep) invocation — portability risk and source-inspection anti-pattern",
+      "raw `rg` (ripgrep) invocation -- portability risk and source-inspection anti-pattern",
     // Q0.5/A2 MINOR-3 fix: also match bare-word arguments
     // (`rg pattern server/`), not just quoted-or-flag forms. Negative
     // lookahead allows `rg --help` / `rg --version` through (those are
@@ -136,10 +163,24 @@ export const AC_LINT_RULES: AcLintRule[] = [
     wrongExample: "rg 'class UserCache' server/",
     rightExample: "curl localhost:3000/api/classes | jq '.UserCache'",
   },
+
+  {
+    id: "F57-cd-basename",
+    description: `${AC_CWD_POLICY_BASENAME_TOKEN} && ... prefix (${AC_CWD_POLICY_MARKER}; re-entering produces basename/basename/ and fails)`,
+    // Matches `cd <single-segment> && <cmd>` where the segment contains no
+    // `/` -- that is, a project-root basename re-entry. Subdirectory cd
+    // (`cd packages/foo && ...`) is fine and intentionally NOT flagged
+    // because the path token contains a `/`. The pattern requires the cd
+    // to be a standalone command token (start-of-line, or after `|`/`;`/`&`/`(`).
+    pattern: /(?:^|[|;&(]\s*)cd\s+[A-Za-z0-9._-]+\s*&&\s*\S/,
+    severity: "suspect",
+    wrongExample: `${AC_CWD_POLICY_WRONG_EXAMPLE} --noEmit`,
+    rightExample: "npx tsc --noEmit",
+  },
 ];
 
 /**
- * Q0.5/A3-bis — Stable hash over the live rule surface. Used by `lint-audit`
+ * Q0.5/A3-bis -- Stable hash over the live rule surface. Used by `lint-audit`
  * to detect rule-set drift since an exemption was last reviewed. Cached for
  * the process lifetime: the underlying constants are module-frozen, so the
  * hash cannot change after the first call.

--- a/server/validation/ac-lint.test.ts
+++ b/server/validation/ac-lint.test.ts
@@ -96,6 +96,53 @@ describe("lintAcCommand — WRONG patterns (must flag)", () => {
   });
 });
 
+describe("F57-cd-basename — #343 (cwd is ALREADY the project root)", () => {
+  it("flags the canonical WRONG example (cd my-project && npx tsc)", () => {
+    const cmd = "cd my-project && npx tsc --noEmit";
+    const r = lintAcCommand(cmd);
+    expect(r.suspect).toBe(true);
+    expect(r.findings.some((f) => f.ruleId === "F57-cd-basename")).toBe(true);
+  });
+
+  it("flags `cd monday-bot && npm install` (provenance case)", () => {
+    const cmd = "cd monday-bot && npm install";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F57-cd-basename")).toBe(true);
+  });
+
+  it("flags single-segment cd followed by any command", () => {
+    const cmd = "cd foo && echo bar";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F57-cd-basename")).toBe(true);
+  });
+
+  it("does NOT flag subdirectory cd (cd packages/foo && ... is allowed)", () => {
+    const cmd = "cd packages/foo && npm run build";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F57-cd-basename")).toBe(false);
+  });
+
+  it("does NOT flag `cd server/lib && grep -l x .` (multi-segment subdir)", () => {
+    const cmd = "cd server/lib && ls";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F57-cd-basename")).toBe(false);
+  });
+
+  it("does NOT flag the RIGHT example (no cd prefix at all)", () => {
+    const cmd = "npx tsc --noEmit";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F57-cd-basename")).toBe(false);
+  });
+
+  it("does NOT flag a bare `cd foo` without && chain", () => {
+    // cd alone (no && follow-on) is not the doubled-cd anti-pattern this
+    // rule targets; the anti-pattern is specifically cd + chained command.
+    const cmd = "cd my-project";
+    const r = lintAcCommand(cmd);
+    expect(r.findings.some((f) => f.ruleId === "F57-cd-basename")).toBe(false);
+  });
+});
+
 describe("lintAcCommand — Q0.5/A2 MAJOR-2/MINOR-3/4/5 additions", () => {
   // MAJOR-2 false-positive regressions — each was falsely SKIPPED by A1's regex.
   it("MAJOR-2 FP-a: grep + && + url containing 'src' must NOT flag F36", () => {
@@ -166,7 +213,7 @@ describe("AC_LINT_RULES structure (Q0.5/A2 typed-export contract)", () => {
     }
   });
 
-  it("exports exactly the 5 rules A1 shipped (no accidental drops)", () => {
+  it("exports exactly the 6 rules currently shipped (5 from A1 + F57 from #343)", () => {
     const ids = AC_LINT_RULES.map((r) => r.id).sort();
     expect(ids).toEqual([
       "F36-raw-rg",
@@ -174,6 +221,7 @@ describe("AC_LINT_RULES structure (Q0.5/A2 typed-export contract)", () => {
       "F55-passed-grep",
       "F55-vitest-count-grep",
       "F56-multigrep-pipe",
+      "F57-cd-basename",
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Fourth bundle of the v0.34.x polish sweep — **acceptance-wrapper hygiene**. Six small sloppy-detail bugs in wrappers shipped in v0.32.x–v0.33.x, plus a missing mechanical lint rule for the `cd <project-basename> &&` anti-pattern.

**Fixes:**
- **#338** — Contiguous AC numbering in \`corrector-crash-fix-acceptance.sh\`.
- **#340** — \`typeof d.numFailedTests === "number"\` type guard in two wrappers (defeats vacuous undefined>0 pass).
- **#341** — Relocate all \`/tmp/ac*.log\` refs (23 total) to project-relative \`tmp/\` across 3 wrappers.
- **#343** — Add \`F57-cd-basename\` rule to \`AC_LINT_RULES\` + unit test coverage.
- **#344** — \`server/lib/prompts/shared/ac-subprocess-rules.ts\` now fully ASCII (13 em-dashes removed).
- **#345** — Extract five cwd-policy prose tokens as \`AC_CWD_POLICY_*\` shared constants; \`planner.test.ts\` imports by name instead of re-spelling.

**Deferred (not in this PR):** #327 (AST-based JSDoc counter — enhancement-only), #370 (upstream plan-template guidance, not forge-harness code).

**Plan hardening:** drafted → \`/coherent-plan\` (3 MAJOR fixes) → \`/double-critique\` (3 rounds + post-loop hotfix, 2 CRITICAL logic bugs caught). Full Critique Log in the plan file.

## Test plan

- [x] AC-1 — corrector wrapper AC labels contiguous 1..N (comment-filtered)
- [x] AC-2 — corrector wrapper type-guards \`numFailedTests\`
- [x] AC-3 — default-max-tokens wrapper type-guards \`numFailedTests\`
- [x] AC-4 — 0 \`/tmp/ac*\` refs across 3 wrappers (per-file grep with explicit exit-code discrimination)
- [x] AC-5 — \`F57-cd-basename\` rule object in \`AC_LINT_RULES\`
- [x] AC-6 — F57 vitest filter passes (JSON reporter + \`numPassedTests >= 1\` assertion)
- [x] AC-7 — \`ac-subprocess-rules.ts\` fully ASCII (Node byte-level check, no \`grep -P\` locale trap)
- [x] AC-8 — 5 cwd-policy tokens single-sourced behind \`AC_CWD_POLICY_*\` constants
- [x] AC-9 — Full vitest: \`numPassedTests=799\`, \`numFailedTests=0\` (floor >=793)
- [x] AC-10 — \`npm run lint\` exits 0
- [x] AC-11 — \`npm run build\` exits 0
- [x] AC-12 — \`scripts/v034-3-acceptance.sh\` exists and exits 0 end-to-end
- [x] AC-13 — Branch diff only touches allowlisted paths

All 13 ACs PASS locally via \`bash scripts/v034-3-acceptance.sh\`.

Fixes #338, fixes #340, fixes #341, fixes #343, fixes #344, fixes #345

---
plan-refresh: no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)