### PR TITLE
docs(anthropic): correct OAuth fallback comment on direct API call support

### DIFF
--- a/server/lib/anthropic.ts
+++ b/server/lib/anthropic.ts
@@ -67,8 +67,10 @@ export function getClient(): Anthropic {
   }
 
   // 2. Fall back to Claude OAuth token (Claude Code Max subscription).
-  //    Note: OAuth tokens only work when proxied through Claude Code's infrastructure.
-  //    Direct API calls with OAuth return 401 "OAuth authentication is currently not supported."
+  //    The OAuth access token from ~/.claude/.credentials.json is accepted by the
+  //    Anthropic SDK as authToken for direct API calls (no Claude Code proxy
+  //    required). Works for Max-plan users who haven't set ANTHROPIC_API_KEY.
+  //    Token expiry is handled by the cache eviction check above (5-min margin).
   const oauthCreds = readOAuthToken();
   if (oauthCreds) {
     console.error("forge: using Claude OAuth token for auth");


### PR DESCRIPTION
## Summary

The comment at `server/lib/anthropic.ts:69-73` claimed:
- OAuth tokens only work when proxied through Claude Code's infrastructure
- Direct API calls with OAuth return 401

Both statements contradicted the code two lines below them, which calls `new Anthropic({ authToken: oauthCreds.accessToken })` and makes direct SDK calls that succeed for Max-plan users without `ANTHROPIC_API_KEY` (verified by monday-bot's standalone forge-harness MCP setup — the OAuth fallback auto-kicks in from `~/.claude/.credentials.json` and works for direct API calls).

Rewrote the comment to accurately describe the behavior: the OAuth access token is accepted as `authToken` by the Anthropic SDK for direct API calls, and token expiry is handled by the cache eviction check at the top of `getClient()`.

Comment-only change. No runtime behavior, no tests touched.

Closes #113.

## Test plan

- [x] Diff is comment-only — 4 insertions, 2 deletions, no logic changed
- [x] Existing tests unaffected (no test file touched)
- [x] CI green
- [x] Stateless reviewer confirms no semantic change

---
plan-refresh: no-op