### PR TITLE
feat(dashboard): surface active story declarations in rendered HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.35.0] (2026-04-21)
+
+### Features
+
+- **Dashboard now surfaces active story declarations.** `.forge/dashboard.html` reads the `forge_declare_story` declaration store at render time and shows a "Declared US-XX" pill in the header whenever an agent has declared a story — independent of whether any tool is currently running. Closes the implementation-gap window: between `forge_generate`-complete and `forge_evaluate`-begin, the HTML on disk previously showed "idle" even though the declared story was still being implemented.
+- `DashboardRenderInput` grows an optional `declaration: StoryDeclaration | null` field (default null, no regression for existing callers). `renderDashboard` reads `getDeclaration()` synchronously alongside its existing `Promise.all` disk reads — mirrors the union pattern `forge_status` already uses in `buildActiveRun` (`server/tools/status.ts:242-276`).
+- Declaration pill hides entirely when no declaration is active (no placeholder strings, no false positives). CSS additions are minimal — a single `.declaration-pill` rule set.
+
+### Provenance
+
+- Field report from monday on 2026-04-21 in thread `v034-field-report-2026-04-21` after her first successful v0.34.0 US-04 end-to-end (PASS 6/6). She proposed three options (a, b, c); option (a) — "dashboard reads declarations" — was chosen because (b) conflated ephemeral activity signal with persistent declarations and (c) was overkill. Rationale in full in `.ai-workspace/plans/2026-04-21-v0-35-0-dashboard-declarations.md`.
+
+### Miscellaneous
+
+- New `scripts/v035-0-dash-acceptance.sh` wrapper runs AC-1..AC-8 sequentially; exit 0 iff all pass. Build step runs first (AC-2/AC-3 import from `dist/`).
+- Test count +7 (827 → 834); zero new failures. 12 tests now match the `/declaration/i` name filter (up from 5).
+
 ## [0.34.0](https://github.com/ziyilam3999/forge-harness/compare/v0.33.9...v0.34.0) (2026-04-21)
 
 ### Features

--- a/scripts/v035-0-dash-acceptance.sh
+++ b/scripts/v035-0-dash-acceptance.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Acceptance wrapper for v0.35.0 -- dashboard renders active story declarations.
+# Runs AC-1..AC-8 from
+#   .ai-workspace/plans/2026-04-21-v0-35-0-dashboard-declarations.md
+#
+# Usage: bash scripts/v035-0-dash-acceptance.sh
+# Prereqs: node, npm, git, bash, npx (vitest + tsc via devDeps). No jq (all
+# JSON parsing is done inline via `node -e`).
+#
+# Contract: aborts on first non-zero exit so the executor's self-check
+# matches the reviewer's script exactly. AC-1..AC-8 are independent, but
+# `npm run build` MUST run first because AC-2 and AC-3 import from `dist/`.
+
+set -euo pipefail
+
+# MSYS_NO_PATHCONV=1 disables Git Bash path mangling when any downstream step
+# uses `origin/master...HEAD` syntax in git diff (AC-8). Cheap insurance.
+export MSYS_NO_PATHCONV=1
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== v0.35.0 dashboard declarations acceptance ==="
+echo
+
+# ── Build prep ────────────────────────────────────────────────────────────
+# Must run BEFORE AC-2 and AC-3 — they import from ./dist/lib/dashboard-renderer.js.
+# Omitting this step causes AC-2/AC-3 to fail with ERR_MODULE_NOT_FOUND.
+echo "--- prep: npm run build ---"
+npm run build
+echo "  PASS  build"
+echo
+
+# ── AC-1: Type surface ────────────────────────────────────────────────────
+echo "--- AC-1: npx tsc --noEmit ---"
+npx tsc --noEmit
+echo "  PASS  AC-1"
+echo
+
+# ── AC-2: Declaration appears in HTML when active ─────────────────────────
+echo "--- AC-2: renderDashboardHtml surfaces storyId ---"
+node --input-type=module -e "
+  import('./dist/lib/dashboard-renderer.js').then(m => {
+    const html = m.renderDashboardHtml({
+      brief: null, activity: null, auditEntries: [],
+      renderedAt: '2026-04-21T09:00:00.000Z',
+      declaration: { storyId: 'US-UNIQUE-PROBE-999', phaseId: 'PH-UNIQUE-888', declaredAt: '2026-04-21T09:00:00.000Z' },
+    });
+    process.exit(html.includes('US-UNIQUE-PROBE-999') ? 0 : 1);
+  });
+"
+echo "  PASS  AC-2"
+echo
+
+# ── AC-3: Differential — renderer actually reads declaration ──────────────
+echo "--- AC-3: renderer differential probe ---"
+node --input-type=module -e "
+  import('./dist/lib/dashboard-renderer.js').then(m => {
+    const base = { brief: null, activity: null, auditEntries: [], renderedAt: '2026-04-21T09:00:00.000Z' };
+    const htmlA = m.renderDashboardHtml({ ...base, declaration: { storyId: 'US-PROBE-AAA', phaseId: null, declaredAt: '2026-04-21T09:00:00.000Z' } });
+    const htmlB = m.renderDashboardHtml({ ...base, declaration: { storyId: 'US-PROBE-BBB', phaseId: null, declaredAt: '2026-04-21T09:00:00.000Z' } });
+    const ok = htmlA.includes('US-PROBE-AAA') && !htmlA.includes('US-PROBE-BBB')
+            && htmlB.includes('US-PROBE-BBB') && !htmlB.includes('US-PROBE-AAA');
+    process.exit(ok ? 0 : 1);
+  });
+"
+echo "  PASS  AC-3"
+echo
+
+# ── AC-4: Named vitest test exists and passes ─────────────────────────────
+echo "--- AC-4: named test 'renderDashboard surfaces active declaration end-to-end' ---"
+npx vitest run -t "renderDashboard surfaces active declaration end-to-end" --reporter=json 2>/dev/null | node -e "
+  let s=''; process.stdin.on('data',d=>s+=d);
+  process.stdin.on('end',()=>{
+    const r=JSON.parse(s);
+    const matches = r.testResults.flatMap(f=>f.assertionResults||[])
+      .filter(a => (a.fullName||a.title||'').includes('renderDashboard surfaces active declaration end-to-end'));
+    const ok = r.numFailedTests===0 && matches.length>=1 && matches.every(m=>m.status==='passed');
+    process.exit(ok ? 0 : 1);
+  });
+"
+echo "  PASS  AC-4"
+echo
+
+# ── AC-5: Existing renderer suite unaffected ──────────────────────────────
+echo "--- AC-5: server/lib/dashboard-renderer.test.ts ---"
+npx vitest run server/lib/dashboard-renderer.test.ts --reporter=json 2>/dev/null | node -e "
+  let s=''; process.stdin.on('data',d=>s+=d);
+  process.stdin.on('end',()=>{
+    const r=JSON.parse(s);
+    process.exit(r.numFailedTests===0 ? 0 : 1);
+  });
+"
+echo "  PASS  AC-5"
+echo
+
+# ── AC-6: Net test growth + declaration-name filter ≥ 3 ───────────────────
+echo "--- AC-6: full suite green + ≥ 3 tests named /declaration/i ---"
+npx vitest run --reporter=json 2>/dev/null | node -e "
+  let s=''; process.stdin.on('data',d=>s+=d);
+  process.stdin.on('end',()=>{
+    const r=JSON.parse(s);
+    const names = r.testResults.flatMap(f=>f.assertionResults||[]).map(a=>(a.fullName||a.title||''));
+    const decls = names.filter(n => /declaration/i.test(n));
+    process.exit((r.numFailedTests===0 && decls.length>=3) ? 0 : 1);
+  });
+"
+echo "  PASS  AC-6"
+echo
+
+# ── AC-7 is THIS wrapper's exit 0. Nothing to invoke inline. ──────────────
+echo "--- AC-7: this wrapper exits 0 iff AC-1..AC-6 and AC-8 all pass ---"
+echo "  (implicit — validated by the final 'all passed' check below)"
+echo
+
+# ── AC-8: No drive-by edits outside the allowlist ─────────────────────────
+echo "--- AC-8: diff allowlist against origin/master...HEAD ---"
+git diff --name-only origin/master...HEAD | node -e "
+  let s=''; process.stdin.on('data',d=>s+=d);
+  process.stdin.on('end',()=>{
+    const allowedExact = new Set([
+      'server/lib/dashboard-renderer.ts',
+      'server/lib/declaration-store.ts',
+      'server/tools/declare-story.ts',
+      'server/tools/declare-story.test.ts',
+      'CHANGELOG.md',
+      'scripts/v035-0-dash-acceptance.sh',
+      'package.json',
+      'package-lock.json',
+    ]);
+    const allowedTestPrefixes = ['server/lib/dashboard-renderer', 'server/lib/declaration'];
+    const files = s.trim().split('\n').filter(Boolean);
+    const offenders = files.filter(f =>
+      !allowedExact.has(f) && !(allowedTestPrefixes.some(p => f.startsWith(p)) && f.endsWith('.test.ts'))
+    );
+    if (offenders.length > 0) {
+      console.error('AC-8 offenders:', offenders);
+    }
+    process.exit(offenders.length===0 ? 0 : 1);
+  });
+"
+echo "  PASS  AC-8"
+echo
+
+echo "=== All AC passed ==="

--- a/server/lib/dashboard-renderer-declarations.test.ts
+++ b/server/lib/dashboard-renderer-declarations.test.ts
@@ -1,0 +1,158 @@
+/**
+ * v0.35.0 — dashboard surfaces active story declarations (field report from
+ * monday, 2026-04-21 thread `v034-field-report-2026-04-21`).
+ *
+ * Covers AC-2 (positive probe — storyId appears in HTML), AC-3 (differential
+ * — renderer actually reads the field), AC-4 (end-to-end disk render picks
+ * up the declaration), plus a Goal-invariant-2 negative test (no placeholder
+ * strings when declaration is null).
+ *
+ * Test names all include "declaration" so AC-6's declaration-name filter
+ * sees ≥ 3 matches.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  renderDashboardHtml,
+  renderDashboard,
+  type DashboardRenderInput,
+} from "./dashboard-renderer.js";
+import { setDeclaration, clearDeclaration } from "./declaration-store.js";
+
+function baseInput(
+  extra: Partial<DashboardRenderInput> = {},
+): DashboardRenderInput {
+  return {
+    brief: null,
+    activity: null,
+    auditEntries: [],
+    renderedAt: "2026-04-21T09:00:00.000Z",
+    ...extra,
+  };
+}
+
+describe("renderDashboardHtml — active story declaration surfaces in HTML (AC-2)", () => {
+  it("emits the declared storyId literal when a declaration is present", () => {
+    const html = renderDashboardHtml(
+      baseInput({
+        declaration: {
+          storyId: "US-UNIQUE-PROBE-999",
+          phaseId: "PH-UNIQUE-888",
+          declaredAt: "2026-04-21T09:00:00.000Z",
+        },
+      }),
+    );
+    expect(html).toContain("US-UNIQUE-PROBE-999");
+  });
+
+  it("also surfaces the phaseId when the declaration carries one", () => {
+    const html = renderDashboardHtml(
+      baseInput({
+        declaration: {
+          storyId: "US-WITH-PHASE",
+          phaseId: "PH-12",
+          declaredAt: "2026-04-21T09:00:00.000Z",
+        },
+      }),
+    );
+    expect(html).toContain("US-WITH-PHASE");
+    expect(html).toContain("PH-12");
+  });
+});
+
+describe("renderDashboardHtml — differential: renderer actually reads the declaration field (AC-3)", () => {
+  it("two renders with different storyIds produce different HTML where each only contains its own id", () => {
+    const base = baseInput();
+    const htmlA = renderDashboardHtml({
+      ...base,
+      declaration: {
+        storyId: "US-PROBE-AAA",
+        phaseId: null,
+        declaredAt: "2026-04-21T09:00:00.000Z",
+      },
+    });
+    const htmlB = renderDashboardHtml({
+      ...base,
+      declaration: {
+        storyId: "US-PROBE-BBB",
+        phaseId: null,
+        declaredAt: "2026-04-21T09:00:00.000Z",
+      },
+    });
+
+    expect(htmlA).toContain("US-PROBE-AAA");
+    expect(htmlA).not.toContain("US-PROBE-BBB");
+    expect(htmlB).toContain("US-PROBE-BBB");
+    expect(htmlB).not.toContain("US-PROBE-AAA");
+    expect(htmlA).not.toEqual(htmlB);
+  });
+});
+
+describe("renderDashboardHtml — no declaration ⇒ no placeholder strings (Goal invariant 2)", () => {
+  // NOTE: `.declaration-pill` always appears as a literal in the stylesheet
+  // block (the CSS selectors live inline in the rendered HTML), so asserting
+  // on the bare class name would false-positive. Instead assert against the
+  // `data-story-id="..."` attribute, which is only emitted by the actual
+  // rendered pill element — not by the stylesheet.
+  it("omits the rendered declaration-pill element when declaration is null", () => {
+    const html = renderDashboardHtml(baseInput({ declaration: null }));
+    expect(html).not.toMatch(/<div class="declaration-pill"/);
+    expect(html).not.toContain('data-story-id=');
+  });
+
+  it("omits the declaration pill when declaration field is absent from input", () => {
+    // Belt-and-braces: the field is optional, so callers can simply not set
+    // it. Renderer must treat `undefined` identically to `null`.
+    const html = renderDashboardHtml(baseInput());
+    expect(html).not.toMatch(/<div class="declaration-pill"/);
+    expect(html).not.toContain('data-story-id=');
+  });
+});
+
+describe("renderDashboard — surfaces active declaration end-to-end", () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), "forge-dashboard-decl-"));
+    // Clear any module-level state leaked from prior tests in the same vitest
+    // worker. declaration-store is a module-scoped singleton, so a stray
+    // declaration from an earlier test could otherwise bleed into this one.
+    clearDeclaration();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    clearDeclaration();
+    vi.restoreAllMocks();
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("renderDashboard surfaces active declaration end-to-end", async () => {
+    // This is the named test AC-4 greps for. Its title must stay exactly
+    // "renderDashboard surfaces active declaration end-to-end".
+    setDeclaration("US-E2E-PROBE-777", "PH-777");
+    await renderDashboard(tmpRoot);
+
+    const html = await readFile(join(tmpRoot, ".forge", "dashboard.html"), "utf-8");
+    expect(html).toContain("US-E2E-PROBE-777");
+  });
+
+  it("renderDashboard with no declaration active emits no rendered declaration pill", async () => {
+    // Isolation test for the null path: if declaration-store is empty, the
+    // on-disk HTML must NOT contain any declaration pill markers. Check the
+    // `<div class="declaration-pill"` opening tag and the `data-story-id`
+    // attribute — the class name alone appears in the stylesheet, so it's
+    // not a reliable marker. Protects the invariant that stale state from a
+    // prior process can't leak into a fresh render.
+    clearDeclaration();
+    await renderDashboard(tmpRoot);
+
+    const html = await readFile(join(tmpRoot, ".forge", "dashboard.html"), "utf-8");
+    expect(html).not.toMatch(/<div class="declaration-pill"/);
+    expect(html).not.toContain('data-story-id=');
+  });
+});

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -37,6 +37,7 @@ import type {
   StoryStatus,
 } from "../types/coordinate-result.js";
 import type { Activity } from "./activity.js";
+import { getDeclaration, type StoryDeclaration } from "./declaration-store.js";
 
 // ── Activity liveness helper ──────────────────────────────────────────────
 
@@ -195,6 +196,18 @@ export interface DashboardRenderInput {
   auditEntries: ReadonlyArray<AuditFeedEntry>;
   /** ISO timestamp of this render — used for staleness banner. */
   renderedAt: string;
+  /**
+   * Active story declaration (from `forge_declare_story`), or null when no
+   * agent has declared a story in this MCP process. When non-null, the
+   * dashboard header surfaces a "Declared: US-XX" pill so operators can see
+   * the active story during the implementation gap window — the period
+   * between `forge_generate`-complete and `forge_evaluate`-begin when
+   * `.forge/activity.json` is idle but an agent is still writing code.
+   *
+   * Optional-with-default-null so existing callers (renderer tests that build
+   * `DashboardRenderInput` literals) don't need to thread a new field.
+   */
+  declaration?: StoryDeclaration | null;
 }
 
 // ── Format helpers ────────────────────────────────────────────────────────
@@ -223,7 +236,29 @@ function formatTimeOfDay(iso: string): string {
 
 // ── HTML builders ─────────────────────────────────────────────────────────
 
-function renderHeader(brief: PhaseTransitionBrief | null): string {
+/**
+ * Render the active-story declaration pill, or "" when no declaration is
+ * active. The pill surfaces `forge_declare_story`'s state into the header
+ * so the declaration is visible during the implementation gap window
+ * (between `forge_generate`-complete and `forge_evaluate`-begin) when
+ * `.forge/activity.json` is idle.
+ *
+ * Returns empty string when `declaration === null` (Goal invariant 2 — no
+ * placeholder strings when nothing is declared).
+ */
+function renderDeclarationPill(declaration: StoryDeclaration | null | undefined): string {
+  if (!declaration) return "";
+  const phaseSuffix = declaration.phaseId
+    ? ` <span class="decl-phase">(${escapeHtml(declaration.phaseId)})</span>`
+    : "";
+  return `<div class="declaration-pill" data-story-id="${escapeHtml(declaration.storyId)}"><span class="decl-label">Declared</span> <span class="decl-story-id">${escapeHtml(declaration.storyId)}</span>${phaseSuffix}</div>`;
+}
+
+function renderHeader(
+  brief: PhaseTransitionBrief | null,
+  declaration: StoryDeclaration | null | undefined,
+): string {
+  const declarationHtml = renderDeclarationPill(declaration);
   if (!brief) {
     return `
 <div class="top-bar">
@@ -231,6 +266,7 @@ function renderHeader(brief: PhaseTransitionBrief | null): string {
     <div class="logo">Hive Mind <span>Forge</span><span class="logo-divider">/</span><span class="logo-sub">Coordinate</span></div>
     <div class="phase-tag">no brief</div>
     <div class="phase-status-pill">waiting</div>
+    ${declarationHtml}
   </div>
   <div class="top-bar-right">
     <span class="liveness-banner green" id="liveness-banner">initializing...</span>
@@ -261,6 +297,7 @@ function renderHeader(brief: PhaseTransitionBrief | null): string {
     <div class="logo">Hive Mind <span>Forge</span><span class="logo-divider">/</span><span class="logo-sub">Coordinate</span></div>
     <div class="phase-tag">${escapeHtml(brief.status)}</div>
     <div class="phase-status-pill ${escapeHtml(brief.status)}">${escapeHtml(brief.status)}</div>
+    ${declarationHtml}
   </div>
   <div class="top-bar-right">
     <span class="liveness-banner green" id="liveness-banner">initializing...</span>
@@ -424,6 +461,10 @@ body { font-family: var(--font-ui); line-height: 1.5; background: var(--off-whit
 .phase-status-pill.complete { background: var(--green-bg); color: var(--green); }
 .phase-status-pill.needs-replan, .phase-status-pill.halted { background: var(--red-bg); color: var(--red); }
 .phase-status-pill.in-progress { background: var(--amber-bg); color: var(--amber); }
+.declaration-pill { font-size: 12px; font-weight: 600; padding: 3px 10px; border-radius: 10px; background: var(--green-bg); color: var(--green); display: inline-flex; align-items: center; gap: 6px; }
+.declaration-pill .decl-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); font-weight: 700; }
+.declaration-pill .decl-story-id { font-family: var(--font-mono); font-weight: 700; }
+.declaration-pill .decl-phase { font-family: var(--font-mono); color: var(--text-secondary); font-weight: 500; }
 .liveness-banner { font-size: 12px; font-weight: 600; padding: 4px 12px; border-radius: 6px; display: inline-flex; align-items: center; gap: 6px; }
 .liveness-banner.green { background: var(--green-bg); color: var(--green); }
 .liveness-banner.amber { background: var(--amber-bg); color: var(--amber); }
@@ -483,6 +524,11 @@ body { font-family: var(--font-ui); line-height: 1.5; background: var(--off-whit
 
 export function renderDashboardHtml(input: DashboardRenderInput): string {
   const { brief, activity, auditEntries, renderedAt } = input;
+  // Declaration is optional on the input (default null) so the wide universe
+  // of renderer tests that build `DashboardRenderInput` literals keep working
+  // untouched. When absent, `renderDeclarationPill` emits "" — no false
+  // positives in the rendered HTML (Goal invariant 2).
+  const declaration = input.declaration ?? null;
 
   const lastUpdate = activity?.lastUpdate ?? renderedAt;
   const activityStarted = activity?.startedAt ?? renderedAt;
@@ -509,7 +555,7 @@ export function renderDashboardHtml(input: DashboardRenderInput): string {
 </head>
 <body>
 <div class="dashboard">
-${renderHeader(brief)}
+${renderHeader(brief, declaration)}
 ${renderReplanningNotes(brief)}
 ${renderBoard(brief, activity)}
 ${renderFeed(auditEntries)}
@@ -844,11 +890,19 @@ export async function renderDashboard(
       readActivity(projectPath),
       readAuditFeed(projectPath),
     ]);
+    // Declaration is a synchronous in-memory read — deliberately NOT bundled
+    // into the Promise.all above because there's no I/O to overlap. Reading
+    // at render time (same pattern forge_status uses via buildActiveRun in
+    // server/tools/status.ts:242) lets this render pick up declarations made
+    // AFTER the renderer's last invocation without any additional coupling
+    // between `forge_declare_story` and the dashboard write path.
+    const declaration = getDeclaration();
     const html = renderDashboardHtml({
       brief,
       activity,
       auditEntries,
       renderedAt: new Date().toISOString(),
+      declaration,
     });
     await writeDashboardHtml(projectPath, html, io);
     await maybeAutoOpenBrowser(projectPath);


### PR DESCRIPTION
## Summary

Closes the dashboard observability gap monday reported in her v0.34.0 US-04 field run (thread `v034-field-report-2026-04-21`). During the implementation window between `forge_generate`-complete and `forge_evaluate`-begin, `.forge/dashboard.html` was showing "idle" even though an agent was actively declared on a story via `forge_declare_story`. Root cause: the declaration store was invisible to the dashboard renderer.

**Fix shape (option a):** `renderDashboard` now reads `getDeclaration()` at render time and passes it through `DashboardRenderInput.declaration` into the HTML. Same union pattern `forge_status` already uses (`server/tools/status.ts:233-276`). No change to `.forge/activity.json` semantics — the two layers stay separate.

**Rejected alternatives:**
- Touching `.forge/activity.json` inside `forge_declare_story` (option b) — semantically conflates "tool running now" with "story declared", and doesn't even solve the gap window (next tool call overwrites activity.json).
- Periodic dashboard refresh tick (option c) — overkill for this gap; the ProgressReporter-driven re-render at `forge_generate`-complete already captures the declaration into persistent HTML.

## Test plan

- [x] 8/8 binary AC pass via `bash scripts/v035-0-dash-acceptance.sh` (exit 0 on planner side)
- [x] `npx tsc --noEmit` green
- [x] Full vitest suite: 827 → 834 (+7 new tests, 12 now match `/declaration/i`)
- [x] `server/lib/dashboard-renderer.test.ts` 35/35 pass (no regressions on the existing renderer suite)
- [x] Diff allowlist clean (4 files: renderer + new test file + wrapper + CHANGELOG)

## Files changed

- `server/lib/dashboard-renderer.ts` — `DashboardRenderInput.declaration` field + `.declaration-pill` element in top-bar
- `server/lib/dashboard-renderer-declarations.test.ts` — new, 7 tests
- `scripts/v035-0-dash-acceptance.sh` — new, executable wrapper
- `CHANGELOG.md` — new `## [0.35.0]` section above `## [0.34.0]`

---
plan-refresh: no-op