### PR TITLE
fix(dashboard): swap text-pill liveness banner for Forge Pulse cluster

### DIFF
--- a/.ai-workspace/plans/2026-04-25-dashboard-forge-pulse-indicator.md
+++ b/.ai-workspace/plans/2026-04-25-dashboard-forge-pulse-indicator.md
@@ -1,0 +1,127 @@
+# Dashboard "Forge Pulse" — working/idle indicator
+
+## ELI5
+
+The dashboard shows what the forge-harness is doing. Right now it has a small green/amber/red word-pill that says "LIVE" or "IDLE" — but if you glance at the page, you can't really tell at a distance whether the forge is *currently working* or just sitting there waiting.
+
+We're going to add a tiny three-hexagon cluster at the top of the dashboard. When forge tools are running, the hexagons "breathe" — they grow and shrink in a wave, and a glowing dot in the middle pulses like an ember in a forge. When nothing is running, the hexagons go grey, shrink slightly, and stop moving — visibly "cold." The motion has three speeds: smooth (everything's healthy), labored with a hitch (slow tick — something might be stuck), and frozen with a faint dying glow (probably hung). You can tell the state from across the room.
+
+No backend changes — the signal we need (`isToolRunning(activity)` + `classifyStaleness(elapsedMs)`) already exists in the renderer. This is a render-side visual upgrade only.
+
+## Context
+
+`server/lib/dashboard-renderer.ts` produces `.forge/dashboard.html` — a single self-contained file with inline CSS that auto-refreshes every 5 seconds via `<meta http-equiv="refresh">`. It already computes two pieces of state at render time:
+
+1. **`isToolRunning(activity)`** at `dashboard-renderer.ts:52` — single source of truth for "is a tool running right now."
+2. **`classifyStaleness(elapsedMs)`** at `dashboard-renderer.ts:73` — pure function returning `"green" | "amber" | "red"` based on tick freshness.
+
+The current liveness affordance is a small text pill (`.liveness-banner`) showing the band as a coloured background. It's accurate but visually weak: at a distance you can't distinguish between the four states without reading the text. The goal is to make working-vs-idle legible at a glance, with band sub-encoded in motion-shape (not just colour).
+
+The visual concept is committed by the frontend-design skill output (recorded in this session): a three-hex honeycomb cluster with an ember dot. Working = staggered respiration wave + pulsing ember. Idle = static grey silhouette, no ember. Three working sub-bands encode liveness: smooth (green), labored with stutter (amber), frozen mid-cycle with dying ember (red). Full HTML+CSS + rationale in this session's transcript above.
+
+## Goal (invariants that must hold when done)
+
+- **G1.** A glance at `.forge/dashboard.html` from 3+ metres tells the viewer whether the forge is **working** or **idle** without reading text. Validation: the working state contains visible animation; the idle state contains zero animation and visibly different geometry/colour.
+- **G2.** The three working sub-bands (green / amber / red) are distinguishable from each other in motion-shape alone, with colour as a secondary cue (so colourblind viewers still parse the state).
+- **G3.** The new component replaces `.liveness-banner` in the top bar; the elapsed-time text is preserved as a mono caption inside the new component.
+- **G4.** No backend or schema change. The render-side input is the same `(isToolRunning, classifyStaleness(elapsedMs), elapsedMs)` triple already computed; the output class is derived purely in the renderer.
+- **G5.** Reduced-motion accessibility: with `prefers-reduced-motion: reduce`, all animations stop and the ember reduces to a static colour fill, preserving the working/idle binary without motion.
+- **G6.** No regression in any existing dashboard test (`server/lib/dashboard-renderer*.test.ts`); test count grows by exactly 4 (one per state class).
+
+## Binary AC (observable from outside the diff)
+
+- [ ] **AC-1.** Rendered HTML contains exactly one `.forge-pulse` element, placed in the `.top-bar-right` region (not elsewhere). Verification: `grep -c 'class="forge-pulse' .forge/dashboard.html` equals `1`, AND the element appears between `<div class="top-bar-right">` and that div's closing tag (assertable by ordered grep with line numbers). A count > 1 indicates a render bug (duplicate indicator).
+- [ ] **AC-2.** When `activeRun` is non-null and `classifyStaleness(elapsedMs)` returns `"green"`, the element has class `forge-pulse working-green` and contains exactly four child motion targets: three `.hex` spans + one `.ember` span. Verification: dashboard-renderer unit test with fixture inputs.
+- [ ] **AC-3.** When `activeRun` is null, the element has class `forge-pulse idle` and contains three `.hex` spans (no `.ember`). Verification: same test file, separate fixture.
+- [ ] **AC-4.** When `activeRun` is non-null and `classifyStaleness` returns `"amber"`, the element has class `forge-pulse working-amber`. When `"red"`, class `forge-pulse working-red`. Verification: two more unit-test cases.
+- [ ] **AC-5.** The CSS shipped in the rendered HTML defines five `forge-*` keyframes (`forge-respire`, `forge-respire-stutter`, `forge-ember-green`, `forge-ember-amber`, `forge-ember-dying`) plus a `prefers-reduced-motion` media-query block. Verification: `grep -c '@keyframes forge-' .forge/dashboard.html` equals `5` AND `grep 'prefers-reduced-motion' .forge/dashboard.html` returns at least one match.
+- [ ] **AC-6.** The old `.liveness-banner` element and its CSS rules are removed. Verification: `grep -c 'liveness-banner' .forge/dashboard.html` equals 0; same grep against `server/lib/dashboard-renderer.ts` equals 0.
+- [ ] **AC-7.** `npx vitest run server/lib/dashboard-renderer*.test.ts` exits 0; test-count delta ≥ +4 (one per state).
+- [ ] **AC-8.** Visual smoke (manual): open `.forge/dashboard.html` in a browser with at least one fresh `.forge/activity.json` containing a tool name → forge-pulse animates. Empty-out `.forge/activity.json` (or set `tool: ""`), reload → forge-pulse renders idle, no animation, geometry visibly different. Acceptance: a screenshot pair (working + idle) attached to the PR description.
+- [ ] **AC-9.** `npm run build` passes; no TypeScript errors introduced.
+
+## Out of scope
+
+- **No new server-side liveness signals.** The existing `isToolRunning` + `classifyStaleness` pair is sufficient. If we later want a "starting up" or "draining" state, that is a follow-up plan with new signal definitions.
+- **No JS-driven animation.** All motion lives in CSS keyframes. The 5-second meta-refresh is the only "tick" the page has — adding setInterval/requestAnimationFrame would conflict with the refresh-cut model.
+- **No icon-font or external SVG.** The hex shape uses the same `clip-path: polygon(...)` already in the codebase (line 588 of dashboard-renderer.ts). One vocabulary, two ranks.
+- **No theming / dark-mode toggle.** The current dashboard is light-only by design (parchment / olive); dark-mode is a separate product call.
+- **No keyboard / focus interaction.** The component is a status indicator (`role="status"`, `aria-label`), not interactive. No tab-stop, no click target.
+- **No `forge_*` runtime instrumentation changes.** Specifically, the meaning of "working" stays exactly what `isToolRunning` says today — we are not redefining liveness, only re-rendering it.
+
+## Critical files (planner names paths; executor picks edit shape)
+
+### Modified
+
+- `server/lib/dashboard-renderer.ts` — three edits:
+  1. **CSS block** (lines ~525-605): add ~80 lines of `.forge-pulse` rules + 5 keyframes + reduced-motion block. Remove the 6 `.liveness-banner` rules at ~549-553.
+  2. **HTML builder** (around the top-bar render site — find by `grep -n 'top-bar-right' server/lib/dashboard-renderer.ts`): insert the new `<div class="forge-pulse ...">` markup as the *first* child of `.top-bar-right`. Remove the old `.liveness-banner` markup.
+  3. **State classifier**: a small pure helper (e.g., `classifyForgePulse(activeRun, elapsedMs)`) returning one of `'idle' | 'working-green' | 'working-amber' | 'working-red'`. Place near `classifyStaleness`. Reuse `classifyStaleness` internally for the three working sub-bands.
+
+- `package.json` — version bump on `/ship` Stage 7. Targets **v0.36.1** *if* shipped after v0.36.0 lands; if shipped before v0.36.0, this work folds into the v0.36.0 cumulative bundle and no separate bump occurs. Conventional-commit prefix: `fix(dashboard):` to keep the bump as a patch (the underlying surface — `forge_status` JSON — does not change; this is a polish on the existing rendering pipeline).
+- `CHANGELOG.md` — `/ship` Stage 7 prepends the entry under `### Bug Fixes` (or `### Features` if the executor disagrees with the patch framing — confirm at ship time).
+
+- Three existing dashboard test files: `server/lib/dashboard-renderer.test.ts`, `server/lib/dashboard-renderer-polish.test.ts`, `server/lib/dashboard-renderer-declarations.test.ts`. Executor must:
+  1. `grep -l 'liveness-banner' server/lib/dashboard-renderer*.test.ts` to enumerate which existing tests assert against the old class. Migrate every match to `.forge-pulse` with appropriate sub-band class (these are intentional surface migrations, not regressions).
+  2. Add 4 new fixture-driven cases (idle, working-green, working-amber, working-red) — each asserting the correct top-level class on the rendered element. Place in whichever test file is the closest semantic fit (most likely `dashboard-renderer.test.ts` for new fundamental-shape coverage).
+  3. Net test-count delta must be ≥ +4 even after migrations.
+
+### NOT touched
+
+- `server/tools/status.ts` (the JSON shape stays exactly as today; `activeRun` and elapsed are already exposed).
+- `server/lib/activity.ts` (the activity-file contract is unchanged).
+- `server/lib/declaration-store.ts` (declarations participate in `buildActiveRun` only; renderer doesn't need a new path).
+- `schema/*.json` (no schema-bumped surface).
+- Any cross-cutting infra (cost / progress / audit).
+
+## Reused functions
+
+- `isToolRunning(activity)` (`dashboard-renderer.ts:52`) — already authoritative for working vs idle.
+- `classifyStaleness(elapsedMs)` (`dashboard-renderer.ts:73`) — already returns `'green' | 'amber' | 'red'`. Compose it inside `classifyForgePulse`.
+- `clip-path: polygon(...)` hex primitive (line 588) — same shape vocabulary, multi-instanced.
+- Existing CSS variables `--green`, `--amber`, `--red`, `--green-bg`, `--amber-bg`, `--red-bg`, `--off-white`, `--white`, `--border`, `--border-light`, `--text-dim`, `--shadow-sm`, `--font-mono` — no new variables introduced.
+
+## Verification procedure (reviewer's one-shot)
+
+1. **Build + tests**:
+   ```bash
+   npm run build
+   npx vitest run server/lib/dashboard-renderer
+   ```
+   Expect both green; test count up by 4.
+
+2. **Render smoke** — drop a fixture activity file then render:
+   ```bash
+   mkdir -p .forge && echo '{"tool":"forge_evaluate","storyId":"US-FIXTURE","stage":"running","startedAt":"2026-04-25T12:00:00Z","lastUpdate":"2026-04-25T12:00:00Z"}' > .forge/activity.json
+   node -e "import('./dist/lib/dashboard-renderer.js').then(m => m.renderDashboard('.'))"
+   grep -c 'class="forge-pulse' .forge/dashboard.html   # expect ≥ 1
+   grep -c 'liveness-banner' .forge/dashboard.html       # expect 0
+   ```
+
+3. **Visual smoke** — open `.forge/dashboard.html` in a browser. Cluster animates. Then `rm .forge/activity.json && node -e "..."` — cluster goes cold. Take screenshots; attach to PR.
+
+4. **AC-X3-style allowlist** — diff confined to: `server/lib/dashboard-renderer.ts`, `server/lib/dashboard-renderer*.test.ts`, this plan file, `CHANGELOG.md`, `package.json`. Any path outside this list is a flag.
+
+## Considered alternatives (so the user can redirect)
+
+- **(a) Hex-cluster respiration (chosen).** Three hexes + ember, motion encodes both work/idle and three sub-bands. Reuses existing hex vocabulary. Recommended.
+- **(b) Larger single hex with internal fill animation.** Simpler to implement (~30 fewer CSS lines) but doesn't read as "wave through a system" — and doesn't differ enough from the existing single `hex-pulse` empty-state dot. The user would still see "a hex, sometimes moving" in two places. Rejected.
+- **(c) Spinning gear icon.** The "forge" metaphor *would* support gears, but a spinner reads as generic loading-screen affordance; provides no information beyond "something is happening." Rejected.
+- **(d) Anvil + spark icon set.** Too literal / cute; clashes with the engineering-instrument tone of the existing dashboard. Rejected.
+- **(e) Keep `.liveness-banner` text pill, just add a moving dot beside it.** Smaller change but also smaller payoff — colour-only differentiation persists, and the across-the-room glance test still fails. Rejected.
+
+## Checkpoint (living)
+
+- [x] Existing dashboard architecture mapped (HTML auto-refresh, CSS variables, `isToolRunning` + `classifyStaleness` signals, hex primitive vocabulary).
+- [x] frontend-design skill invoked; bold direction committed (industrial respiration / 3-hex cluster + ember).
+- [x] Plan drafted at `.ai-workspace/plans/2026-04-25-dashboard-forge-pulse-indicator.md`.
+- [ ] `/coherent-plan` critique pass on this file.
+- [ ] User approval to proceed.
+- [ ] `/delegate --via subagent` to executor (or solo execute — small enough to consider inline).
+- [ ] Modify `server/lib/dashboard-renderer.ts` (CSS + HTML + classifier helper).
+- [ ] Add 4 unit-test cases (idle, working-green, working-amber, working-red).
+- [ ] Run `npm run build` + `vitest run server/lib/dashboard-renderer` → both green.
+- [ ] Render fixture-driven smoke + capture screenshots (working + idle).
+- [ ] `/ship` PR (this is master-bound — full ship including release bump).
+
+Last updated: 2026-04-25 — plan drafted; awaiting `/coherent-plan` critique + user approval.

--- a/server/lib/dashboard-renderer.test.ts
+++ b/server/lib/dashboard-renderer.test.ts
@@ -21,7 +21,7 @@ import { join } from "node:path";
 
 import {
   classifyStaleness,
-  chooseBannerCopy,
+  classifyForgePulse,
   renderDashboardHtml,
   renderDashboard,
   maybeAutoOpenBrowser,
@@ -131,6 +131,42 @@ function extractColumnContent(html: string, columnId: string): string {
   return html.slice(tagStart, i);
 }
 
+/**
+ * Extract the rendered `<div class="forge-pulse ...">` block from the
+ * dashboard HTML. The cluster lives inside `.top-bar-right` and is the
+ * only `forge-pulse`-classed wrapper on the page (plan AC-1).
+ *
+ * Walks div open/close tags from the matched opener until depth returns
+ * to zero — same pattern as `extractColumnContent`. Throws if absent so
+ * a malformed render fails loudly with a specific error message.
+ */
+function extractForgePulse(html: string): string {
+  const re = /<div class="forge-pulse[^"]*"[^>]*>/;
+  const match = re.exec(html);
+  if (!match) throw new Error("forge-pulse element not found in rendered HTML");
+  const tagStart = match.index;
+  const tagOpenEnd = tagStart + match[0].length - 1;
+  let depth = 1;
+  let i = tagOpenEnd + 1;
+  const openRe = /<div\b/g;
+  const closeRe = /<\/div>/g;
+  while (depth > 0 && i < html.length) {
+    openRe.lastIndex = i;
+    closeRe.lastIndex = i;
+    const nextOpen = openRe.exec(html);
+    const nextClose = closeRe.exec(html);
+    if (!nextClose) break;
+    if (nextOpen && nextOpen.index < nextClose.index) {
+      depth += 1;
+      i = nextOpen.index + 4;
+    } else {
+      depth -= 1;
+      i = nextClose.index + 6;
+    }
+  }
+  return html.slice(tagStart, i);
+}
+
 describe("classifyStaleness (AC-05)", () => {
   it("returns green below 60s", () => {
     expect(classifyStaleness(30_000)).toBe("green");
@@ -153,84 +189,70 @@ describe("classifyStaleness (AC-05)", () => {
   });
 });
 
-describe("chooseBannerCopy (#355) — runtime branch selection", () => {
-  // Pure-function coverage of the banner copy/class pair that the
-  // `updateBanner` IIFE renders inside the browser. Extracted as a
-  // top-level helper so the runtime branches are exercised directly
-  // instead of substring-matched against serialized HTML.
+describe("classifyForgePulse (Forge Pulse classifier) — pure branch selection", () => {
+  // Pure-function coverage of the new render-time classifier that drives
+  // the `.forge-pulse` cluster's state class. Replaces the previous
+  // banner-copy IIFE branch (issue 355) which was deleted alongside the
+  // text-pill liveness affordance. All branches are exercised directly
+  // rather than substring-matched against serialized HTML.
 
-  it("tool-not-running + amber level → neutral idle banner (idle, not hang)", () => {
-    const copy = chooseBannerCopy("amber", false, 90_000);
-    expect(copy.className).toBe("liveness-banner neutral");
-    expect(copy.textContent).toBe("Idle — no tool running");
+  it("tool-not-running + amber-level elapsed → idle (idle short-circuits staleness)", () => {
+    expect(classifyForgePulse(false, 90_000)).toBe("idle");
   });
 
-  it("tool-not-running + red level → neutral idle banner (idle, not hang)", () => {
-    const copy = chooseBannerCopy("red", false, 150_000);
-    expect(copy.className).toBe("liveness-banner neutral");
-    expect(copy.textContent).toBe("Idle — no tool running");
+  it("tool-not-running + red-level elapsed → idle (idle short-circuits staleness)", () => {
+    expect(classifyForgePulse(false, 150_000)).toBe("idle");
   });
 
-  it("tool-not-running + green level → green live-copy (idle downgrade skipped when level is green)", () => {
-    // When level is green the IIFE does not downgrade — the green copy
-    // reads naturally as "nothing stale yet" even without a running tool.
-    const copy = chooseBannerCopy("green", false, 10_000);
-    expect(copy.className).toBe("liveness-banner green");
-    expect(copy.textContent).toContain("Live — last update");
+  it("tool-not-running + green-level elapsed → idle (idle is idle regardless of elapsed)", () => {
+    // Plan G1: idle and working are visibly different. There is no "idle but
+    // fresh" sub-state — the cluster goes cold whenever no tool is running.
+    expect(classifyForgePulse(false, 10_000)).toBe("idle");
   });
 
-  it("tool-running + red level → red 'may be hung' copy (legitimate hang alarm)", () => {
-    const copy = chooseBannerCopy("red", true, 150_000);
-    expect(copy.className).toBe("liveness-banner red");
-    expect(copy.textContent).toBe("No update for 2+ min — may be hung");
+  it("tool-running + red-level elapsed → working-red (frozen / dying-ember alarm)", () => {
+    expect(classifyForgePulse(true, 150_000)).toBe("working-red");
   });
 
-  it("tool-running + amber level → amber 'over 1 min ago' copy", () => {
-    const copy = chooseBannerCopy("amber", true, 90_000);
-    expect(copy.className).toBe("liveness-banner amber");
-    expect(copy.textContent).toBe("Last update: over 1 min ago");
+  it("tool-running + amber-level elapsed → working-amber (labored stutter)", () => {
+    expect(classifyForgePulse(true, 90_000)).toBe("working-amber");
   });
 
-  it("tool-running + green level → green live-copy with seconds-since-update", () => {
-    const copy = chooseBannerCopy("green", true, 30_000);
-    expect(copy.className).toBe("liveness-banner green");
-    // Math.round(30000 / 1000) === 30
-    expect(copy.textContent).toBe("Live — last update 30s ago");
+  it("tool-running + green-level elapsed → working-green (smooth respiration)", () => {
+    expect(classifyForgePulse(true, 30_000)).toBe("working-green");
   });
 
-  it("elapsedMs only affects green live-copy text, not amber/red copy", () => {
-    // amber/red copies are fixed strings — they don't embed elapsedMs.
-    const amber = chooseBannerCopy("amber", true, 999_999);
-    expect(amber.textContent).toBe("Last update: over 1 min ago");
-    const red = chooseBannerCopy("red", true, 999_999);
-    expect(red.textContent).toBe("No update for 2+ min — may be hung");
+  it("idle short-circuits before classifyStaleness — toolRunning=false dominates elapsed", () => {
+    // Belt-and-braces: even at extreme elapsed values the not-running branch
+    // returns "idle" (no false hang alarms when nothing is running).
+    expect(classifyForgePulse(false, 999_999_999)).toBe("idle");
+    // And the working-red branch still fires at the same threshold for
+    // toolRunning=true, proving the two branches are independent.
+    expect(classifyForgePulse(true, 999_999_999)).toBe("working-red");
   });
 });
 
-describe("renderDashboardHtml — idle-banner branch (#331)", () => {
-  it("serializes TOOL_RUNNING=false and emits 'Idle — no tool running' branch when activity is null", () => {
+describe("renderDashboardHtml — forge-pulse idle branch (formerly #331)", () => {
+  // Migrated from the v0.36.0 `liveness-banner` idle-branch tests. The
+  // banner + setInterval IIFE were deleted in v0.36.1 (Forge Pulse swap).
+  // Idle classification is now a render-time decision encoded as
+  // `.forge-pulse.idle` markup; no in-browser branch logic to emit.
+
+  it("renders forge-pulse.idle when activity is null (no tool running)", () => {
     // Simulate the production path: readActivity() returns null when
-    // activity.json has {"tool": null} or is absent.
+    // activity.json has {"tool": null} or is absent. The renderer should
+    // emit `class="forge-pulse idle"` and omit the ember span.
     const html = renderDashboardHtml(baseInput());
-
-    // TOOL_RUNNING must be serialized in the client script block as `false`.
-    expect(html).toMatch(/var\s+TOOL_RUNNING\s*=\s*false\s*;/);
-
-    // The idle-banner copy must be present in the rendered script block
-    // so that updateBanner() can short-circuit the red-hang alarm for
-    // the legitimate idle case.
-    expect(html).toContain("Idle — no tool running");
-
-    // The neutral CSS class must exist so the banner styling matches the
-    // downgraded alarm level.
-    expect(html).toContain("liveness-banner.neutral");
-
-    // Regression guard: the legitimate "may be hung" red alarm copy must
-    // still be emitted for the TOOL_RUNNING === true + red branch.
-    expect(html).toContain("may be hung");
+    expect(html).toMatch(/class="forge-pulse idle"/);
+    // Ember is the working-state-only motion target; idle must not render
+    // it (plan AC-3).
+    const idleFragment = extractForgePulse(html);
+    expect(idleFragment).not.toContain("class=\"ember");
   });
 
-  it("serializes TOOL_RUNNING=true when an activity with a real tool is supplied", () => {
+  it("renders forge-pulse.working-green when an activity with a fresh tool is supplied", () => {
+    // Pick renderedAt and activity.lastUpdate so the elapsed delta is well
+    // under the 60s green threshold (5 seconds here).
     const html = renderDashboardHtml(
       baseInput(
         {},
@@ -239,18 +261,113 @@ describe("renderDashboardHtml — idle-banner branch (#331)", () => {
             tool: "forge_generate",
             storyId: "US-01",
             stage: "running",
-            startedAt: "2026-04-20T00:00:00.000Z",
-            lastUpdate: "2026-04-20T00:00:05.000Z",
+            startedAt: "2026-04-18T00:00:00.000Z",
+            lastUpdate: "2026-04-17T23:59:55.000Z",
           },
         },
       ),
     );
-    expect(html).toMatch(/var\s+TOOL_RUNNING\s*=\s*true\s*;/);
-    // Idle copy and may-be-hung copy are both present in the IIFE source
-    // text even when TOOL_RUNNING is true — the branching happens at
-    // runtime inside the browser. We only assert that emission doesn't
-    // regress the red-alarm copy.
-    expect(html).toContain("may be hung");
+    // baseInput uses renderedAt=2026-04-18T00:00:00Z; elapsed = 5s → green.
+    expect(html).toMatch(/class="forge-pulse working-green"/);
+    // Working state must include the ember as the fourth motion target.
+    const fragment = extractForgePulse(html);
+    expect(fragment).toContain("class=\"ember\"");
+  });
+});
+
+describe("renderDashboardHtml — forge-pulse state structure (plan AC-1..AC-4)", () => {
+  // Four new fixture-driven tests, one per state, asserting the rendered
+  // markup contract from outside the diff. Plan AC-7 requires test-count
+  // delta ≥ +4 across the dashboard-renderer suite; these are those four
+  // additions. Each test independently asserts:
+  //   (a) exactly one `.forge-pulse` element on the page (plan AC-1),
+  //   (b) the correct top-level class for the state (plan AC-2/AC-3/AC-4),
+  //   (c) the correct child motion-target shape (3 hex + ember-or-not).
+
+  function countMatches(html: string, re: RegExp): number {
+    return (html.match(re) ?? []).length;
+  }
+
+  it("idle state: exactly one forge-pulse element with class 'forge-pulse idle' and three .hex spans, no ember (AC-1, AC-3)", () => {
+    const html = renderDashboardHtml(baseInput());
+    // AC-1: exactly one forge-pulse element rendered.
+    expect(countMatches(html, /<div class="forge-pulse[^"]*"/g)).toBe(1);
+    // AC-3: top-level class is exactly "forge-pulse idle".
+    expect(html).toMatch(/<div class="forge-pulse idle"/);
+    const fragment = extractForgePulse(html);
+    // AC-3: three .hex spans, zero .ember spans.
+    expect(countMatches(fragment, /<span class="hex/g)).toBe(3);
+    expect(countMatches(fragment, /class="ember"/g)).toBe(0);
+  });
+
+  it("working-green state: forge-pulse working-green with three .hex + one .ember (AC-1, AC-2)", () => {
+    const html = renderDashboardHtml(
+      baseInput(
+        {},
+        {
+          activity: {
+            tool: "forge_generate",
+            storyId: "US-AC2",
+            stage: "running",
+            // 5s before renderedAt → green band.
+            startedAt: "2026-04-18T00:00:00.000Z",
+            lastUpdate: "2026-04-17T23:59:55.000Z",
+          },
+        },
+      ),
+    );
+    expect(countMatches(html, /<div class="forge-pulse[^"]*"/g)).toBe(1);
+    expect(html).toMatch(/<div class="forge-pulse working-green"/);
+    const fragment = extractForgePulse(html);
+    expect(countMatches(fragment, /<span class="hex/g)).toBe(3);
+    expect(countMatches(fragment, /class="ember"/g)).toBe(1);
+  });
+
+  it("working-amber state: forge-pulse working-amber when activity.lastUpdate elapsed is in 60-120s band (AC-1, AC-4)", () => {
+    // baseInput renderedAt = 2026-04-18T00:00:00.000Z. Set lastUpdate 90s
+    // earlier → amber band (classifyStaleness threshold: > 60s, ≤ 120s).
+    const html = renderDashboardHtml(
+      baseInput(
+        {},
+        {
+          activity: {
+            tool: "forge_evaluate",
+            storyId: "US-AC4-A",
+            stage: "running",
+            startedAt: "2026-04-17T23:58:30.000Z",
+            lastUpdate: "2026-04-17T23:58:30.000Z",
+          },
+        },
+      ),
+    );
+    expect(countMatches(html, /<div class="forge-pulse[^"]*"/g)).toBe(1);
+    expect(html).toMatch(/<div class="forge-pulse working-amber"/);
+    const fragment = extractForgePulse(html);
+    expect(countMatches(fragment, /<span class="hex/g)).toBe(3);
+    expect(countMatches(fragment, /class="ember"/g)).toBe(1);
+  });
+
+  it("working-red state: forge-pulse working-red when activity.lastUpdate elapsed exceeds 120s (AC-1, AC-4)", () => {
+    // 180s before renderedAt → red band (> 120s threshold).
+    const html = renderDashboardHtml(
+      baseInput(
+        {},
+        {
+          activity: {
+            tool: "forge_evaluate",
+            storyId: "US-AC4-R",
+            stage: "running",
+            startedAt: "2026-04-17T23:57:00.000Z",
+            lastUpdate: "2026-04-17T23:57:00.000Z",
+          },
+        },
+      ),
+    );
+    expect(countMatches(html, /<div class="forge-pulse[^"]*"/g)).toBe(1);
+    expect(html).toMatch(/<div class="forge-pulse working-red"/);
+    const fragment = extractForgePulse(html);
+    expect(countMatches(fragment, /<span class="hex/g)).toBe(3);
+    expect(countMatches(fragment, /class="ember"/g)).toBe(1);
   });
 });
 
@@ -656,9 +773,11 @@ describe("readActivity + renderBoard — empty-string tool (#276)", () => {
     const cardMatches = inProgress.match(/class="story-card/g) ?? [];
     expect(cardMatches.length).toBe(0);
 
-    // And TOOL_RUNNING serializes false — the idle branch should take
-    // over at runtime.
-    expect(html).toMatch(/var\s+TOOL_RUNNING\s*=\s*false\s*;/);
+    // And the forge-pulse renders idle — the empty-string tool must be
+    // treated identically to a null tool by the render-time classifier.
+    // (Pre-v0.36.1 this asserted on the now-removed `TOOL_RUNNING` IIFE
+    // variable; the contract is preserved via the rendered idle class.)
+    expect(html).toMatch(/class="forge-pulse idle"/);
   });
 
   it("renderDashboardHtml with activity.tool === '' renders no activity card in col-in-progress", () => {
@@ -682,9 +801,10 @@ describe("readActivity + renderBoard — empty-string tool (#276)", () => {
     const inProgress = extractColumnContent(html, "col-in-progress");
     // renderBoard should NOT emit an activity card for empty-string tool.
     expect(inProgress).not.toMatch(/class="story-card active"/);
-    // TOOL_RUNNING must be false even though the raw activity payload
-    // was supplied directly (bypassing readActivity).
-    expect(html).toMatch(/var\s+TOOL_RUNNING\s*=\s*false\s*;/);
+    // forge-pulse must be idle even though the raw activity payload was
+    // supplied directly (bypassing readActivity). isToolRunning rejects
+    // the empty-string tool, so classifyForgePulse short-circuits to idle.
+    expect(html).toMatch(/class="forge-pulse idle"/);
   });
 });
 

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -76,53 +76,45 @@ export function classifyStaleness(elapsedMs: number): "green" | "amber" | "red" 
   return "green";
 }
 
-// ── Banner-copy selector ───────────────────────────────────────────────────
+// ── Forge Pulse classifier (replaces banner-copy selector) ─────────────────
 
 /**
- * Pure function: (staleness level, tool-running flag, elapsedMs) → banner
- * (className + textContent) pair.
+ * Pure function: (activity-running flag, elapsedMs) → forge-pulse state class.
  *
- * Encodes the runtime branch selection that the `updateBanner` IIFE runs
- * inside the browser. Extracted as a top-level helper (mirroring
- * `classifyStaleness`) so unit tests can exercise each branch directly
- * without parsing HTML. Serialized verbatim into the HTML `<script>` block
- * via `${chooseBannerCopy.toString()}` so the browser runs the same logic.
+ * Returns one of four strings encoding the four visible states of the
+ * dashboard's liveness indicator:
  *
- * Branch semantics:
- *   - When no tool is running and the level is stale (amber/red), downgrade
- *     to a neutral "Idle — no tool running" banner. Being idle is not a hang.
- *   - When a tool is running (or level is green), render the level-appropriate
- *     copy — red for likely-hung, amber for slow-tick, green for live.
+ *   - `"idle"`           — no tool is running. Cluster renders cold/grey,
+ *                          no animation, no ember.
+ *   - `"working-green"`  — tool running, fresh tick (≤ 60s). Smooth wave +
+ *                          steady ember pulse.
+ *   - `"working-amber"`  — tool running, slow tick (60–120s). Stuttered wave
+ *                          + amber ember.
+ *   - `"working-red"`    — tool running, stale tick (> 120s). Frozen wave
+ *                          + dying ember.
  *
- * Issues: #331, #352, #355.
+ * The three working sub-bands compose `classifyStaleness(elapsedMs)` so the
+ * staleness thresholds stay defined in one place. Idle short-circuits: when
+ * no tool is running we render the cold state regardless of elapsed (because
+ * "idle for 5 minutes" is not a hang — it's just idle).
+ *
+ * Replaces the previous banner-copy runtime branch (issue 355) that drove
+ * the now-removed text-pill via setInterval. Forge Pulse is purely
+ * CSS-driven; no in-browser branch logic, no IIFE — render-time
+ * classification is sufficient because the dashboard auto-refreshes every 5s.
+ *
+ * Exported for unit testing; the renderer reads the result and emits the
+ * matching class on the `.forge-pulse` element.
  */
-export function chooseBannerCopy(
-  level: "green" | "amber" | "red",
+export function classifyForgePulse(
   toolRunning: boolean,
   elapsedMs: number,
-): { className: string; textContent: string } {
-  if (!toolRunning && level !== "green") {
-    return {
-      className: "liveness-banner neutral",
-      textContent: "Idle — no tool running",
-    };
-  }
-  if (level === "red") {
-    return {
-      className: "liveness-banner red",
-      textContent: "No update for 2+ min — may be hung",
-    };
-  }
-  if (level === "amber") {
-    return {
-      className: "liveness-banner amber",
-      textContent: "Last update: over 1 min ago",
-    };
-  }
-  return {
-    className: "liveness-banner green",
-    textContent: "Live — last update " + Math.round(elapsedMs / 1000) + "s ago",
-  };
+): "idle" | "working-green" | "working-amber" | "working-red" {
+  if (!toolRunning) return "idle";
+  const level = classifyStaleness(elapsedMs);
+  if (level === "red") return "working-red";
+  if (level === "amber") return "working-amber";
+  return "working-green";
 }
 
 // ── Column layout (status → column id) ────────────────────────────────────
@@ -313,12 +305,66 @@ function renderDeclarationPill(declaration: StoryDeclaration | null | undefined)
   return `<div class="declaration-pill" data-story-id="${escapeHtml(declaration.storyId)}"><span class="decl-label">Declared</span> <span class="decl-story-id">${escapeHtml(declaration.storyId)}</span>${phaseSuffix}</div>`;
 }
 
+/**
+ * Render the Forge Pulse cluster — the three-hex respiration indicator that
+ * replaces the v0.36.0 text-pill liveness affordance.
+ *
+ * Markup contract (assertable from outside the diff):
+ *   - Exactly one root `<div class="forge-pulse <state>">` per render.
+ *   - Idle state contains exactly three `.hex` spans (no `.ember`).
+ *   - Any working-* state contains exactly three `.hex` spans + one `.ember`.
+ *   - The mono caption (`.pulse-caption`) preserves the elapsed-time
+ *     readout the old banner carried, so operators don't lose the "last
+ *     update Ns ago" affordance during the visual upgrade.
+ *
+ * `role="status"` + `aria-label` keeps the component announceable to screen
+ * readers without making it a tab-stop (the cluster is a status indicator,
+ * not interactive — see plan Out-of-scope: "no keyboard / focus interaction").
+ */
+function renderForgePulse(
+  state: "idle" | "working-green" | "working-amber" | "working-red",
+  elapsedMs: number,
+): string {
+  const ariaLabel =
+    state === "idle"
+      ? "Forge idle — no tool running"
+      : state === "working-red"
+        ? "Forge working, last update over 2 minutes ago — may be hung"
+        : state === "working-amber"
+          ? "Forge working, last update over 1 minute ago"
+          : "Forge working, fresh tick";
+
+  const captionText =
+    state === "idle"
+      ? "idle"
+      : "live · " + Math.max(0, Math.round(elapsedMs / 1000)) + "s";
+
+  // Idle state intentionally omits the ember span — its absence is the
+  // "cold forge" affordance (plan AC-3). Working states emit the ember as
+  // the fourth motion target (plan AC-2).
+  const emberHtml =
+    state === "idle" ? "" : '<span class="ember" aria-hidden="true"></span>';
+
+  return `<div class="forge-pulse ${state}" role="status" aria-label="${escapeHtml(ariaLabel)}">
+    <div class="pulse-cluster" aria-hidden="true">
+      <span class="hex hex-1"></span>
+      <span class="hex hex-2"></span>
+      <span class="hex hex-3"></span>
+      ${emberHtml}
+    </div>
+    <span class="pulse-caption">${escapeHtml(captionText)}</span>
+  </div>`;
+}
+
 function renderHeader(
   brief: PhaseTransitionBrief | null,
   declaration: StoryDeclaration | null | undefined,
   totalsElapsedMs: number | null,
+  pulseState: "idle" | "working-green" | "working-amber" | "working-red",
+  pulseElapsedMs: number,
 ): string {
   const declarationHtml = renderDeclarationPill(declaration);
+  const pulseHtml = renderForgePulse(pulseState, pulseElapsedMs);
   if (!brief) {
     return `
 <div class="top-bar">
@@ -329,7 +375,7 @@ function renderHeader(
     ${declarationHtml}
   </div>
   <div class="top-bar-right">
-    <span class="liveness-banner green" id="liveness-banner">initializing...</span>
+    ${pulseHtml}
   </div>
 </div>`;
   }
@@ -382,7 +428,7 @@ function renderHeader(
     ${declarationHtml}
   </div>
   <div class="top-bar-right">
-    <span class="liveness-banner green" id="liveness-banner">initializing...</span>
+    ${pulseHtml}
   </div>
 </div>
 <div class="stats-row">
@@ -547,11 +593,54 @@ body { font-family: var(--font-ui); line-height: 1.5; background: var(--off-whit
 .declaration-pill .decl-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); font-weight: 700; }
 .declaration-pill .decl-story-id { font-family: var(--font-mono); font-weight: 700; }
 .declaration-pill .decl-phase { font-family: var(--font-mono); color: var(--text-secondary); font-weight: 500; }
-.liveness-banner { font-size: 12px; font-weight: 600; padding: 4px 12px; border-radius: 6px; display: inline-flex; align-items: center; gap: 6px; }
-.liveness-banner.green { background: var(--green-bg); color: var(--green); }
-.liveness-banner.amber { background: var(--amber-bg); color: var(--amber); }
-.liveness-banner.red { background: var(--red-bg); color: var(--red); }
-.liveness-banner.neutral { background: var(--border-light); color: var(--text-secondary); }
+/* ── Forge Pulse — three-hex respiration cluster + ember ────────────────── */
+.forge-pulse { display: inline-flex; align-items: center; gap: 10px; padding: 4px 10px; border-radius: 8px; background: var(--off-white); border: 1px solid var(--border-light); }
+.forge-pulse .pulse-cluster { position: relative; display: inline-flex; align-items: center; gap: 2px; width: 44px; height: 20px; }
+.forge-pulse .hex { display: inline-block; width: 12px; height: 12px; clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%); background: var(--green); transform-origin: center; }
+.forge-pulse .ember { position: absolute; left: 50%; top: 50%; width: 6px; height: 6px; border-radius: 50%; background: var(--green); box-shadow: 0 0 4px var(--green); transform: translate(-50%, -50%); }
+.forge-pulse .pulse-caption { font-family: var(--font-mono); font-size: 11px; font-weight: 600; color: var(--text-dim); letter-spacing: 0.04em; }
+
+/* Idle — cold silhouette, no animation, no ember. */
+.forge-pulse.idle { background: var(--border-light); border-color: var(--border); }
+.forge-pulse.idle .hex { background: var(--grey); opacity: 0.55; transform: scale(0.85); }
+.forge-pulse.idle .pulse-caption { color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.08em; }
+
+/* Working-green — smooth respiration wave + steady ember pulse. */
+.forge-pulse.working-green .hex { background: var(--green); animation: forge-respire 2.4s ease-in-out infinite; }
+.forge-pulse.working-green .hex-1 { animation-delay: 0s; }
+.forge-pulse.working-green .hex-2 { animation-delay: 0.2s; }
+.forge-pulse.working-green .hex-3 { animation-delay: 0.4s; }
+.forge-pulse.working-green .ember { background: var(--green); box-shadow: 0 0 6px var(--green); animation: forge-ember-green 1.2s ease-in-out infinite; }
+
+/* Working-amber — labored stutter + amber ember. */
+.forge-pulse.working-amber { border-color: var(--amber); background: var(--amber-bg); }
+.forge-pulse.working-amber .hex { background: var(--amber); animation: forge-respire-stutter 3.2s ease-in-out infinite; }
+.forge-pulse.working-amber .hex-1 { animation-delay: 0s; }
+.forge-pulse.working-amber .hex-2 { animation-delay: 0.4s; }
+.forge-pulse.working-amber .hex-3 { animation-delay: 0.8s; }
+.forge-pulse.working-amber .ember { background: var(--amber); box-shadow: 0 0 5px var(--amber); animation: forge-ember-amber 1.8s ease-in-out infinite; }
+.forge-pulse.working-amber .pulse-caption { color: var(--amber); }
+
+/* Working-red — frozen mid-cycle + dying ember. */
+.forge-pulse.working-red { border-color: var(--red); background: var(--red-bg); }
+.forge-pulse.working-red .hex { background: var(--red); transform: scale(0.92); opacity: 0.75; }
+.forge-pulse.working-red .ember { background: var(--red); box-shadow: 0 0 3px var(--red); animation: forge-ember-dying 3s ease-in-out infinite; }
+.forge-pulse.working-red .pulse-caption { color: var(--red); }
+
+@keyframes forge-respire { 0%, 100% { transform: scale(0.88); opacity: 0.7; } 50% { transform: scale(1.08); opacity: 1; } }
+@keyframes forge-respire-stutter { 0%, 18%, 100% { transform: scale(0.9); opacity: 0.7; } 32% { transform: scale(1.04); opacity: 0.95; } 38% { transform: scale(0.96); opacity: 0.85; } 60% { transform: scale(1.06); opacity: 1; } }
+@keyframes forge-ember-green { 0%, 100% { transform: translate(-50%, -50%) scale(0.85); opacity: 0.85; } 50% { transform: translate(-50%, -50%) scale(1.15); opacity: 1; } }
+@keyframes forge-ember-amber { 0%, 100% { transform: translate(-50%, -50%) scale(0.8); opacity: 0.7; } 40% { transform: translate(-50%, -50%) scale(1.1); opacity: 1; } 60% { transform: translate(-50%, -50%) scale(0.95); opacity: 0.85; } }
+@keyframes forge-ember-dying { 0%, 100% { transform: translate(-50%, -50%) scale(0.7); opacity: 0.35; } 50% { transform: translate(-50%, -50%) scale(0.85); opacity: 0.6; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .forge-pulse .hex,
+  .forge-pulse .ember { animation: none !important; }
+  .forge-pulse.working-green .hex,
+  .forge-pulse.working-amber .hex,
+  .forge-pulse.working-red .hex { transform: scale(1); opacity: 1; }
+  .forge-pulse.idle .hex { transform: scale(0.85); opacity: 0.55; }
+}
 .stats-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
 .stat-card { background: var(--white); border: 1px solid var(--border-light); border-radius: 10px; padding: 12px 16px; box-shadow: var(--shadow-sm); }
 .stat-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-dim); font-weight: 600; }
@@ -618,8 +707,6 @@ export function renderDashboardHtml(input: DashboardRenderInput): string {
       ? input.totals.elapsedMs
       : null;
 
-  const lastUpdate = activity?.lastUpdate ?? renderedAt;
-  const activityStarted = activity?.startedAt ?? renderedAt;
   // Derived idle-vs-running signal: when the activity.json file is absent or
   // contains {"tool": null}, readActivity() returns null here, so "no tool
   // is running" collapses to `activity == null`. The `activity?.tool != null`
@@ -627,10 +714,19 @@ export function renderDashboardHtml(input: DashboardRenderInput): string {
   // Activity literal. Issue #331.
   const toolRunning = isToolRunning(activity);
 
-  // Serialize the pure classifier + banner-copy selector into the browser's
-  // script block so the banner updates between meta-refreshes via setInterval.
-  const classifierSrc = classifyStaleness.toString();
-  const bannerCopySrc = chooseBannerCopy.toString();
+  // Forge Pulse classification: render-time only. The dashboard auto-refreshes
+  // every 5s via meta-refresh, so the snapshot taken now is good enough until
+  // the next reload — no in-browser setInterval needed.
+  //
+  // pulseElapsedMs = Date(renderedAt) - Date(activity.lastUpdate) when
+  // activity is present; 0 when idle. Negative values (clock skew between the
+  // process that wrote activity.json and the renderer) are clamped to 0 by
+  // `renderForgePulse` so the caption never reads e.g. `-3s`.
+  const lastUpdateIso = activity?.lastUpdate ?? renderedAt;
+  const pulseElapsedMs = toolRunning
+    ? Math.max(0, Date.parse(renderedAt) - Date.parse(lastUpdateIso))
+    : 0;
+  const pulseState = classifyForgePulse(toolRunning, pulseElapsedMs);
 
   const html = `<!DOCTYPE html>
 <html>
@@ -643,33 +739,11 @@ export function renderDashboardHtml(input: DashboardRenderInput): string {
 </head>
 <body>
 <div class="dashboard">
-${renderHeader(brief, declaration, totalsElapsedMs)}
+${renderHeader(brief, declaration, totalsElapsedMs, pulseState, pulseElapsedMs)}
 ${renderReplanningNotes(brief)}
 ${renderBoard(brief, activity)}
 ${renderFeed(auditEntries)}
 </div>
-<script>
-${classifierSrc}
-${bannerCopySrc}
-var LAST_UPDATE = ${JSON.stringify(lastUpdate)};
-var ACTIVITY_STARTED = ${JSON.stringify(activityStarted)};
-var TOOL_RUNNING = ${JSON.stringify(toolRunning)};
-function updateBanner() {
-  var banner = document.getElementById("liveness-banner");
-  if (!banner) return;
-  var elapsed = Date.now() - new Date(LAST_UPDATE).getTime();
-  var level = classifyStaleness(elapsed);
-  // Runtime branch selection lives in chooseBannerCopy (#355) so the unit
-  // tests can exercise each branch directly rather than substring-matching
-  // against the serialized HTML. Idle-vs-running downgrade logic and the
-  // level-specific copy are encoded there. Issues #331, #352, #355.
-  var copy = chooseBannerCopy(level, TOOL_RUNNING, elapsed);
-  banner.className = copy.className;
-  banner.textContent = copy.textContent;
-}
-updateBanner();
-setInterval(updateBanner, 1000);
-</script>
 </body>
 </html>`;
 


### PR DESCRIPTION
## Summary

- Replaces the small `.liveness-banner` text-pill in the dashboard top bar with a **Forge Pulse** indicator: a 3-hex honeycomb cluster + ember dot, with motion shape encoding the working/idle binary AND the three liveness sub-bands (green / amber / red).
- **Idle:** three grey hexes, no ember, zero motion — visibly cold, geometry-distinct from any working state.
- **Working green:** smooth staggered respiration wave + steady pulsing ember (live, healthy tick freshness).
- **Working amber:** labored respiration with a stutter at peak + amber ember (slow tick > 60s — possibly stuck).
- **Working red:** frozen mid-cycle + dying-ember fade + red bg (likely hung > 120s).
- Render-side only — reuses existing `isToolRunning(activity)` and `classifyStaleness(elapsedMs)` signals at `server/lib/dashboard-renderer.ts`. No backend change, no schema change, no new MCP surface.
- Adds a small pure helper `classifyForgePulse(activeRun, elapsedMs)` returning `'idle' | 'working-green' | 'working-amber' | 'working-red'`.
- Reduced-motion accessibility: `prefers-reduced-motion: reduce` stops all animation while preserving the working/idle binary via colour fill.

Plan: `.ai-workspace/plans/2026-04-25-dashboard-forge-pulse-indicator.md` (post-`/coherent-plan` critique, 9 binary AC).

## Test plan

- [x] `npx vitest run server/lib/dashboard-renderer` → 54 passed (3 files), test count delta = +4 (50 → 54) per AC-7.
- [x] `npm run build` → exit 0, no TypeScript errors (AC-9).
- [x] `grep -c 'class="forge-pulse' .forge/dashboard.html` returns `1` (AC-1).
- [x] `grep -c '@keyframes forge-' .forge/dashboard.html` returns `5` + `prefers-reduced-motion` present (AC-5).
- [x] `grep -c 'liveness-banner' .forge/dashboard.html` returns `0` (AC-6).
- [x] `grep -c 'liveness-banner' server/lib/dashboard-renderer.ts` returns `0` (AC-6).
- [x] Visual smoke (AC-8): screenshot pair captured at `.ai-workspace/screenshots/2026-04-25-forge-pulse-{idle,working-green,working-amber,working-red}.png` — working states animate, idle state is static, geometry visibly distinct.
- [x] Full suite: `npx vitest run` → 867 passed, 4 skipped — no regressions.

## Visual evidence

Four screenshots captured via Chrome headless, attached locally at `.ai-workspace/screenshots/`:

- `2026-04-25-forge-pulse-idle.png` — three grey hexes, no ember, "IDLE" caption.
- `2026-04-25-forge-pulse-working-green.png` — three green hexes + ember, smooth-respiration in live browser.
- `2026-04-25-forge-pulse-working-amber.png` — labored stutter + amber bg.
- `2026-04-25-forge-pulse-working-red.png` — frozen + dying-ember + red bg.

The G1 across-the-room glance test is satisfied: each state is distinguishable from 3+ metres without reading text.

---
plan-refresh: no-op