### PR TITLE
fix: Drop duplicate Math.max(0, â€¦) clamp on pulseElapsedMs (#442)

### DIFF
--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -337,7 +337,7 @@ function renderForgePulse(
   const captionText =
     state === "idle"
       ? "idle"
-      : "live · " + Math.max(0, Math.round(elapsedMs / 1000)) + "s";
+      : "live · " + Math.round(elapsedMs / 1000) + "s";
 
   // Idle state intentionally omits the ember span — its absence is the
   // "cold forge" affordance (plan AC-3). Working states emit the ember as


### PR DESCRIPTION
Closes #442

Auto-fix by /housekeep Stage 4.

**Scope:** server/lib/dashboard-renderer.ts

**Description:** Remove the redundant Math.max(0, ...) clamp inside renderForgePulse (caption text construction near line 340), trusting the upstream clamp in renderDashboardHtml (near line 727) where pulseElapsedMs is computed. One source of truth.