### PR TITLE
fix(dashboard): self-reconcile against origin/master to clear post-merge staleness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- **Dashboard self-reconciles against `origin/master`.** `renderDashboard` now scans the most recent ~50 `origin/master` commits via a single `git log` invocation per render, extracts story IDs from conventional-commit subjects (`/\b(US-\d+)\b/gi`), and upgrades any matching brief story whose status is `pending | ready | ready-for-retry | failed | dep-failed` to `done`. This closes the post-merge staleness window where `coordinate-brief.json` lagged behind a freshly-landed PR — operators no longer need to call `forge_coordinate` after `/ship` to clear stale `Ready` cards. Squash-merge-safe: matches commit subject text, not `lastGitSha` reachability (which is broken by squash). Upward-only — never demotes existing `done` (revert protection). Graceful fallback on missing-git / missing-ref / detached-HEAD / no-remotes / timeout — empty set + warning, brief renders verbatim, dashboard never throws. Ref discovery probes `origin/master` → `origin/main` → `master` → `main`. Known limitation: the helper relies on local `origin/master` being current; if no `git fetch` has happened since the merge, the dashboard catches up on the next pull (which `/ship` Stage 7 performs automatically). New helper at `server/lib/git-master-stories.ts`; tests at `server/lib/git-master-stories.test.ts` and `server/lib/dashboard-renderer-reconciliation.test.ts`.
+
 ## [0.36.1](https://github.com/ziyilam3999/forge-harness/compare/v0.36.0...v0.36.1) (2026-04-25)
 
 ### Bug Fixes

--- a/server/lib/dashboard-renderer-reconciliation.test.ts
+++ b/server/lib/dashboard-renderer-reconciliation.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Renderer-integration tests for dashboard self-reconciliation.
+ *
+ * Covers the upstream plan's binary AC that operate at the
+ * `renderDashboard` / brief-mapper boundary:
+ *   - AC-1 happy-path squash-merge ends in the Done column
+ *   - AC-2 master-presence is the predicate (NOT forge_status agreement)
+ *   - AC-3 upward-only — existing `done` is never demoted
+ *   - AC-7 squash-merge regression — `lastGitSha` not on master, but
+ *     subject contains `US-NN` ⇒ story still classified as done
+ *
+ * AC-4..AC-6 + AC-8 live in `git-master-stories.test.ts` because they
+ * exercise the helper itself, not the renderer integration.
+ *
+ * Test strategy
+ * ─────────────
+ * Two layers:
+ *   1. Pure mapper tests against `__reconcileBriefStatusesWithMasterForTests`
+ *      — fast, no fixture, drives AC-1/2/3/7 directly via fabricated
+ *      `shippedStoryIds` sets.
+ *   2. End-to-end renderer test against a real temp git repo with one
+ *      squash-merge commit on `origin/master` and a brief that lists the
+ *      story as `ready`. Verifies the rendered HTML moves the card into
+ *      the `col-done` column without any operator intervention. This is
+ *      the "the bug is fixed" smoke check; it shells out to real git and
+ *      wires the actual `renderDashboard` end to end.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, readFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import {
+  __reconcileBriefStatusesWithMasterForTests as reconcile,
+  renderDashboard,
+} from "./dashboard-renderer.js";
+import { __resetCacheForTests } from "./git-master-stories.js";
+import type {
+  PhaseTransitionBrief,
+  StoryStatusEntry,
+} from "../types/coordinate-result.js";
+
+// ── Brief / story fixture factories ──────────────────────────────────────
+
+function makeStoryEntry(
+  storyId: string,
+  status: StoryStatusEntry["status"],
+  overrides: Partial<StoryStatusEntry> = {},
+): StoryStatusEntry {
+  return {
+    storyId,
+    status,
+    retryCount: 0,
+    retriesRemaining: 3,
+    priorEvalReport: null,
+    evidence: null,
+    ...overrides,
+  };
+}
+
+function makeBrief(
+  stories: StoryStatusEntry[],
+  overrides: Partial<PhaseTransitionBrief> = {},
+): PhaseTransitionBrief {
+  return {
+    status: "in-progress",
+    stories,
+    readyStories: [],
+    depFailedStories: [],
+    failedStories: [],
+    completedCount: stories.filter((s) => s.status === "done").length,
+    totalCount: stories.length,
+    budget: {
+      usedUsd: 0,
+      budgetUsd: null,
+      remainingUsd: null,
+      incompleteData: false,
+      warningLevel: "none",
+    },
+    timeBudget: { elapsedMs: 0, maxTimeMs: null, warningLevel: "none" },
+    replanningNotes: [],
+    recommendation: "",
+    configSource: {},
+    ...overrides,
+  };
+}
+
+// ── AC-1 — happy path: shipped story moves to Done ────────────────────────
+
+describe("AC-1 — story whose ID appears on master surfaces as done", () => {
+  it("brief shows US-05 ready; master has it; mapper upgrades to done + bumps completedCount", () => {
+    const brief = makeBrief([
+      makeStoryEntry("US-05", "ready"),
+      makeStoryEntry("US-06", "pending"),
+    ]);
+    const result = reconcile(brief, {
+      shippedStoryIds: new Set(["US-05"]),
+      warning: null,
+    });
+    const us05 = result.stories.find((s) => s.storyId === "US-05");
+    expect(us05?.status).toBe("done");
+    // STORIES x/y widget reads completedCount; verify bump.
+    expect(result.completedCount).toBe(1);
+    // Other stories untouched.
+    expect(result.stories.find((s) => s.storyId === "US-06")?.status).toBe("pending");
+  });
+
+  it("upgrade applied to all the eligible non-terminal states", () => {
+    const brief = makeBrief([
+      makeStoryEntry("US-01", "pending"),
+      makeStoryEntry("US-02", "ready"),
+      makeStoryEntry("US-03", "ready-for-retry"),
+      makeStoryEntry("US-04", "failed"),
+      makeStoryEntry("US-05", "dep-failed"),
+    ]);
+    const result = reconcile(brief, {
+      shippedStoryIds: new Set(["US-01", "US-02", "US-03", "US-04", "US-05"]),
+      warning: null,
+    });
+    expect(result.stories.every((s) => s.status === "done")).toBe(true);
+    expect(result.completedCount).toBe(5);
+  });
+});
+
+// ── AC-2 — gitSha-on-master is the predicate ─────────────────────────────
+
+describe("AC-2 — master-presence predicate, not forge_status agreement", () => {
+  it("story with PASS evalVerdict but NOT on master stays as-brief", () => {
+    // The brief reflects the absence-of-merge state: story is `ready`
+    // (forge_evaluate PASS, but no merge yet — `forge_status` would say
+    // `state: shipped`). Dashboard is stricter: no master-subject ⇒ no
+    // promotion to done.
+    const brief = makeBrief([makeStoryEntry("US-07", "ready")]);
+    const result = reconcile(brief, {
+      shippedStoryIds: new Set(),
+      warning: null,
+    });
+    expect(result.stories[0].status).toBe("ready");
+    expect(result.completedCount).toBe(0);
+  });
+});
+
+// ── AC-3 — upward-only ────────────────────────────────────────────────────
+
+describe("AC-3 — upward-only (no demote on missing master entry)", () => {
+  it("brief.done + master-empty ⇒ remains done (revert scenario protection)", () => {
+    const brief = makeBrief([makeStoryEntry("US-08", "done")]);
+    const result = reconcile(brief, {
+      shippedStoryIds: new Set(),
+      warning: null,
+    });
+    expect(result.stories[0].status).toBe("done");
+    expect(result.completedCount).toBe(1);
+  });
+
+  it("brief.done + master also has it ⇒ still done, no double-count", () => {
+    const brief = makeBrief([makeStoryEntry("US-08", "done")]);
+    const result = reconcile(brief, {
+      shippedStoryIds: new Set(["US-08"]),
+      warning: null,
+    });
+    expect(result.stories[0].status).toBe("done");
+    // upgradable set excludes "done", so no upgrade fires, so no bump.
+    expect(result.completedCount).toBe(1);
+  });
+
+  it("identity preserved when no upgrades happen (referential stability)", () => {
+    const brief = makeBrief([makeStoryEntry("US-09", "done")]);
+    const result = reconcile(brief, {
+      shippedStoryIds: new Set(["US-09"]),
+      warning: null,
+    });
+    // No upgrade ⇒ helper returns the original brief object so reference
+    // checks downstream stay stable.
+    expect(result).toBe(brief);
+  });
+});
+
+// ── Graceful-fallback path: warning present ──────────────────────────────
+
+describe("graceful fallback — helper warning short-circuits to verbatim brief", () => {
+  it("non-null warning ⇒ brief returned unchanged + stderr surfaces warning", () => {
+    const brief = makeBrief([makeStoryEntry("US-10", "ready")]);
+    const errSpy = (() => {
+      const calls: string[] = [];
+      const orig = console.error;
+      console.error = ((...args: unknown[]) => {
+        calls.push(args.map((a) => String(a)).join(" "));
+      }) as typeof console.error;
+      return {
+        calls,
+        restore: () => {
+          console.error = orig;
+        },
+      };
+    })();
+
+    try {
+      const result = reconcile(brief, {
+        shippedStoryIds: new Set(),
+        warning: "git binary not found on PATH",
+      });
+      expect(result.stories[0].status).toBe("ready");
+      expect(result.completedCount).toBe(0);
+      // Operator-facing warning landed.
+      expect(errSpy.calls.some((c) => c.includes("master-reconciliation degraded"))).toBe(true);
+      expect(errSpy.calls.some((c) => c.includes("git binary not found on PATH"))).toBe(true);
+    } finally {
+      errSpy.restore();
+    }
+  });
+});
+
+// ── AC-7 — squash-merge regression — end-to-end with real git ─────────────
+
+describe("AC-7 — squash-merge regression (lastGitSha NOT on master, subject still wins)", () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), "forge-dash-reconcile-"));
+    __resetCacheForTests();
+  });
+
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("end-to-end: brief says US-12 ready; master subject contains US-12; rendered HTML places US-12 in col-done", async () => {
+    // Initialise a real git repo with origin/master containing a
+    // conventional-commit squash-merge subject. The `lastGitSha`
+    // recorded in the RunRecord (simulated by NOT propagating the
+    // branch HEAD into master — the squash created a NEW SHA
+    // unrelated to lastGitSha) is irrelevant to the helper's lookup.
+    execFileSync("git", ["init", "-q", "-b", "master", tmpRoot]);
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tmpRoot });
+    execFileSync("git", ["config", "user.name", "test"], { cwd: tmpRoot });
+    await writeFile(join(tmpRoot, "README.md"), "# test\n");
+    execFileSync("git", ["add", "README.md"], { cwd: tmpRoot });
+    execFileSync("git", ["commit", "-q", "-m", "chore: init"], { cwd: tmpRoot });
+    // The squash-merge subject — contains US-12 in the conventional
+    // commit type/scope, exactly like /ship produces.
+    await writeFile(join(tmpRoot, "feature.ts"), "export const x = 1;\n");
+    execFileSync("git", ["add", "feature.ts"], { cwd: tmpRoot });
+    execFileSync("git", ["commit", "-q", "-m", "feat(US-12): knowledge service facade (#72)"], {
+      cwd: tmpRoot,
+    });
+    // Push to a bare clone so origin/master resolves locally.
+    const remote = `${tmpRoot}.remote.git`;
+    execFileSync("git", ["init", "-q", "--bare", "-b", "master", remote]);
+    execFileSync("git", ["remote", "add", "origin", remote], { cwd: tmpRoot });
+    execFileSync("git", ["push", "-q", "origin", "master"], { cwd: tmpRoot });
+
+    // Write a coordinate-brief that lists US-12 as `ready` — i.e. the
+    // bug-state where the brief is stale post-merge.
+    const briefDir = join(tmpRoot, ".forge");
+    await mkdir(briefDir, { recursive: true });
+    const brief: PhaseTransitionBrief = makeBrief(
+      [makeStoryEntry("US-12", "ready"), makeStoryEntry("US-13", "pending")],
+      { totalCount: 2, completedCount: 0 },
+    );
+    await writeFile(
+      join(briefDir, "coordinate-brief.json"),
+      JSON.stringify(brief),
+      "utf-8",
+    );
+
+    // Render. Production path; no mocks.
+    await renderDashboard(tmpRoot);
+    const html = await readFile(join(briefDir, "dashboard.html"), "utf-8");
+
+    // The col-done div should contain US-12 (was bug — it would have
+    // landed in col-ready). Use the same column-extraction strategy as
+    // dashboard-renderer.test.ts: anchor on the column wrapper div.
+    const colDoneRe = /<div class="kanban-column[^"]*" id="col-done">([\s\S]*?)<\/div>\s*<div class="kanban-column/;
+    const colReadyRe = /<div class="kanban-column[^"]*" id="col-ready">([\s\S]*?)<\/div>\s*<div class="kanban-column/;
+    const doneFragment = colDoneRe.exec(html)?.[1] ?? "";
+    const readyFragment = colReadyRe.exec(html)?.[1] ?? "";
+    expect(doneFragment).toContain("US-12");
+    expect(readyFragment).not.toContain("US-12");
+
+    // STORIES widget reflects the bump too — the value comes from
+    // brief.completedCount which was 0 in the stored brief, but the
+    // renderer reconciled +1 from the master scan, so it should read
+    // `1/2` (NOT `0/2`).
+    expect(html).toMatch(/Stories[\s\S]*?1\/2/);
+
+    // Cleanup the bare remote (tmpRoot itself is cleaned in afterEach).
+    await rm(remote, { recursive: true, force: true });
+  });
+});

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -38,6 +38,7 @@ import type {
 } from "../types/coordinate-result.js";
 import type { Activity } from "./activity.js";
 import { getDeclaration, type StoryDeclaration } from "./declaration-store.js";
+import { readShippedStoriesFromMaster } from "./git-master-stories.js";
 
 // ── Activity liveness helper ──────────────────────────────────────────────
 
@@ -1154,6 +1155,87 @@ export async function readActivityFeed(
   return merged.slice(0, 20);
 }
 
+/**
+ * Pure mapper — given a brief and the result of
+ * `readShippedStoriesFromMaster`, return a NEW brief whose `stories[].status`
+ * is upgraded to `"done"` for every story whose ID appears in the master
+ * shipped-set AND whose current status is one of the non-terminal kanban
+ * states (`pending`, `ready`, `ready-for-retry`, `failed`, `dep-failed`).
+ *
+ * Upward-only by design (plan AC-3): an existing `"done"` is never demoted
+ * even if the story is absent from the shipped-set. This protects against
+ * (a) the stale-fetch case where the operator hasn't pulled the merge yet,
+ * and (b) revert scenarios where the kanban shouldn't oscillate.
+ *
+ * Also bumps `brief.completedCount` so the STORIES x/y widget stays in
+ * sync with the kanban it labels (plan AC-1's grep checks `STORIES 5/13`
+ * style strings, not just column placement).
+ *
+ * Returns a new object — never mutates `brief`. The renderer test fixtures
+ * pass synthesized brief literals; mutating them would create cross-test
+ * leakage.
+ */
+function reconcileBriefStatusesWithMaster(
+  brief: PhaseTransitionBrief,
+  master: { shippedStoryIds: Set<string>; warning: string | null },
+): PhaseTransitionBrief {
+  // Empty result set + warning is the graceful-fallback path: the brief
+  // passes through verbatim. Surface the warning to stderr so operators
+  // can diagnose why reconciliation degraded (plan AC-4).
+  if (master.warning !== null) {
+    console.error(
+      `forge: dashboard master-reconciliation degraded — ${master.warning}`,
+    );
+  }
+  if (master.shippedStoryIds.size === 0) {
+    return brief;
+  }
+
+  // Status states from which an upgrade to `"done"` is permitted. `"done"`
+  // is excluded so we never re-write a terminal status (no-op + future-proof
+  // against demotion bugs); the value is held in a Set for O(1) lookup.
+  const upgradable = new Set<StoryStatus>([
+    "pending",
+    "ready",
+    "ready-for-retry",
+    "failed",
+    "dep-failed",
+  ]);
+
+  let upgrades = 0;
+  const stories = brief.stories.map((entry) => {
+    if (
+      master.shippedStoryIds.has(entry.storyId) &&
+      upgradable.has(entry.status)
+    ) {
+      upgrades += 1;
+      return { ...entry, status: "done" as StoryStatus };
+    }
+    return entry;
+  });
+
+  if (upgrades === 0) {
+    // Nothing changed — return original to keep object identity stable
+    // for any caller doing reference equality checks.
+    return brief;
+  }
+
+  return {
+    ...brief,
+    stories,
+    completedCount: brief.completedCount + upgrades,
+  };
+}
+
+/**
+ * Test seam: re-export the pure reconciliation mapper so unit tests can
+ * verify behaviour without spinning up a full renderer + temp-repo
+ * fixture. The renderer test file uses this directly to cover AC-1..AC-3
+ * and AC-7.
+ */
+export const __reconcileBriefStatusesWithMasterForTests =
+  reconcileBriefStatusesWithMaster;
+
 export async function renderDashboard(
   projectPath: string,
   io: DashboardIo = DEFAULT_IO,
@@ -1177,8 +1259,22 @@ export async function renderDashboard(
     // execution time, not wall-clock. Same semantics as forge_status.totals.
     const totals = await readTotalsFromRuns(projectPath);
 
+    // Self-reconciliation against `origin/master` — closes the post-merge
+    // staleness window where `coordinate-brief.json` lags behind a freshly
+    // landed PR. The helper runs ONE `git log` invocation, extracts story
+    // IDs from commit subjects via `/\b(US-\d+)\b/gi`, and returns a set
+    // the renderer can use to mark stories `done` upward-only. Failure
+    // returns an empty set + a warning string; the renderer falls back to
+    // the brief's verbatim status. Plan AC-1..AC-8.
+    const reconciled = brief
+      ? reconcileBriefStatusesWithMaster(
+          brief,
+          await readShippedStoriesFromMaster(projectPath),
+        )
+      : brief;
+
     const html = renderDashboardHtml({
-      brief,
+      brief: reconciled,
       activity,
       auditEntries,
       renderedAt: new Date().toISOString(),

--- a/server/lib/git-master-stories.test.ts
+++ b/server/lib/git-master-stories.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Unit tests for `readShippedStoriesFromMaster` — the master-branch story
+ * reconciliation helper that powers the dashboard's self-correcting kanban.
+ *
+ * Coverage map (against the upstream plan's binary AC):
+ *   - AC-4 graceful fallback (5 sub-tests):
+ *       missing-git, missing-ref, detached-HEAD, no-remotes, timeout
+ *   - AC-5 single git invocation regardless of story count
+ *   - AC-6 ref discovery (origin/main when no master ref exists)
+ *   - AC-8 multi-story commit subject (one commit, multiple US-IDs)
+ *
+ * AC-1, AC-2, AC-3, AC-7 are renderer-integration concerns and live in
+ * `dashboard-renderer-reconciliation.test.ts`.
+ *
+ * Tests use real `git` binaries against on-disk temp repos for the happy
+ * paths (matches the existing pattern in `evaluate-gitsha.test.ts`). The
+ * negative paths (missing-git, timeout, no-remotes) use injected `ref`
+ * options and PATH manipulation rather than mocking child_process — the
+ * helper's failure-mode coverage is more meaningful when failures come
+ * from the real OS surface, and the cost is well under a second per
+ * sub-test.
+ *
+ * MSYS path safety
+ * ────────────────
+ * Tests that pass `<rev>:<path>` syntax to git would normally need
+ * `MSYS_NO_PATHCONV=1` to avoid bash munging the colon. We don't use that
+ * syntax anywhere here; commit subjects + SHAs flow through `--format`,
+ * not via `git show <ref>:<path>`. So no MSYS wrapper required.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import {
+  readShippedStoriesFromMaster,
+  __resetCacheForTests,
+} from "./git-master-stories.js";
+
+// ── Test-fixture helpers ──────────────────────────────────────────────────
+
+/**
+ * Initialise a git repo with a configurable default branch and a single
+ * commit so HEAD exists. Returns the cwd of the new repo.
+ */
+async function initRepo(cwd: string, defaultBranch: string = "master"): Promise<void> {
+  execFileSync("git", ["init", "-q", "-b", defaultBranch], { cwd });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd });
+  execFileSync("git", ["config", "user.name", "test"], { cwd });
+  await writeFile(join(cwd, "README.md"), "# test\n");
+  execFileSync("git", ["add", "README.md"], { cwd });
+  execFileSync("git", ["commit", "-q", "-m", "chore: init"], { cwd });
+}
+
+/**
+ * Add a commit whose subject is exactly `subject`. Returns the resulting
+ * HEAD sha.
+ */
+function commitWithSubject(cwd: string, subject: string, fileBody: string): string {
+  const filename = `f-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`;
+  execFileSync("git", ["-C", cwd, "checkout", "-q", "HEAD"], {
+    /* no-op — keep cwd-on-branch */
+  });
+  execFileSync("bash", ["-c", `printf '%s' "$1" > "$2"`, "_", fileBody, join(cwd, filename)]);
+  execFileSync("git", ["add", filename], { cwd });
+  execFileSync("git", ["commit", "-q", "-m", subject], { cwd });
+  return execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf-8" }).trim();
+}
+
+/**
+ * Create an `origin` remote pointed at a *bare* clone of `cwd` and push
+ * the current branch so `origin/<branch>` exists locally. Returns the
+ * remote path so callers can clean it up.
+ */
+function setupOriginRemote(cwd: string, branch: string): string {
+  const remotePath = `${cwd}.remote.git`;
+  execFileSync("git", ["init", "-q", "--bare", "-b", branch, remotePath]);
+  execFileSync("git", ["remote", "add", "origin", remotePath], { cwd });
+  execFileSync("git", ["push", "-q", "origin", branch], { cwd });
+  return remotePath;
+}
+
+// ── Fixture lifecycle ─────────────────────────────────────────────────────
+
+let tmpRoot: string;
+let extraRemotes: string[];
+
+beforeEach(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), "forge-git-master-stories-"));
+  extraRemotes = [];
+  __resetCacheForTests();
+});
+
+afterEach(async () => {
+  for (const r of extraRemotes) {
+    await rm(r, { recursive: true, force: true });
+  }
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+// ── AC-5 — single git call regardless of story count ──────────────────────
+
+describe("AC-5 — single git log invocation per render", () => {
+  // Seeding 13 real commits via execFileSync on Windows costs ~5–10s, so
+  // the default 5s vitest timeout is too tight. Bump to 30s.
+  it("scans all commits in one shot — never one-per-story", { timeout: 30_000 }, async () => {
+    // Seed 13 stories' worth of squash-merge commits on master so the
+    // renderer would see all of them in one log.
+    await initRepo(tmpRoot, "master");
+    for (let i = 1; i <= 13; i++) {
+      const id = `US-${String(i).padStart(2, "0")}`;
+      commitWithSubject(tmpRoot, `feat(${id}): impl ${id} (#${100 + i})`, `body ${i}`);
+    }
+    const remote = setupOriginRemote(tmpRoot, "master");
+    extraRemotes.push(remote);
+
+    // The helper does NOT expose a spawn counter, but the contract is
+    // structural: it runs ONE `git log` (plus the one-time `rev-parse
+    // --verify` for ref discovery, which is cached). After the first
+    // invocation, a second invocation against the same projectPath must
+    // NOT re-probe — verifiable by removing the master ref between calls
+    // and confirming the second call still succeeds with the cached ref.
+    const first = await readShippedStoriesFromMaster(tmpRoot);
+    expect(first.warning).toBeNull();
+    expect(first.shippedStoryIds.size).toBe(13);
+
+    // Now break the ref discovery surface by force-deleting `origin/master`
+    // out from under the helper. If a second call re-probed, it would
+    // hit the same `ref-missing` path that AC-4's missing-ref sub-test
+    // exercises and warn. Because the cache holds the original ref
+    // string, the second call still finds the local commits.
+    execFileSync("git", ["update-ref", "-d", "refs/remotes/origin/master"], { cwd: tmpRoot });
+
+    const second = await readShippedStoriesFromMaster(tmpRoot);
+    // Cache hit means the helper is asking git to log a now-missing ref;
+    // git itself will still fail this call (the helper doesn't pretend
+    // the ref still exists). The point of the test is structural: the
+    // helper went straight to `git log` without an additional probe call,
+    // so the failure mode is `git log ... failed`, NOT `master ref
+    // discovery failed`. That distinction proves the cache short-circuits
+    // re-probing per-render.
+    expect(second.warning).not.toBeNull();
+    expect(second.warning).toMatch(/git log on origin\/master failed/);
+    expect(second.warning).not.toMatch(/master ref discovery failed/);
+  });
+});
+
+// ── AC-6 — ref discovery probes master then main ──────────────────────────
+
+describe("AC-6 — ref discovery falls through to origin/main when master is absent", () => {
+  it("repo with default branch `main` resolves origin/main and returns IDs", async () => {
+    await initRepo(tmpRoot, "main");
+    commitWithSubject(tmpRoot, "feat(US-09): only-main repo", "body");
+    const remote = setupOriginRemote(tmpRoot, "main");
+    extraRemotes.push(remote);
+
+    const result = await readShippedStoriesFromMaster(tmpRoot);
+    expect(result.warning).toBeNull();
+    expect(result.shippedStoryIds.has("US-09")).toBe(true);
+  });
+
+  it("repo with default branch `master` resolves origin/master (control case)", async () => {
+    await initRepo(tmpRoot, "master");
+    commitWithSubject(tmpRoot, "feat(US-10): default-master", "body");
+    const remote = setupOriginRemote(tmpRoot, "master");
+    extraRemotes.push(remote);
+
+    const result = await readShippedStoriesFromMaster(tmpRoot);
+    expect(result.warning).toBeNull();
+    expect(result.shippedStoryIds.has("US-10")).toBe(true);
+  });
+});
+
+// ── AC-8 — multi-story commit subject ─────────────────────────────────────
+
+describe("AC-8 — single commit subject with multiple story IDs", () => {
+  it("`US-01..US-04` range subject (US-01..US-04 idiom) — surfaces only the explicit IDs", async () => {
+    await initRepo(tmpRoot, "master");
+    // The plan's example: `chore: backfill US-01..US-04 (#67)`. The
+    // regex is word-bounded, so `US-01..US-04` produces matches for
+    // `US-01` and `US-04` (the dots are not word characters but the
+    // numbers between dots are not US-prefixed, so the implicit range
+    // is NOT expanded — the regex sees two literal IDs, which matches
+    // the operator's mental model that the commit "is for US-01 and
+    // US-04 specifically").
+    commitWithSubject(tmpRoot, "chore: backfill US-01..US-04 (#67)", "body");
+    const remote = setupOriginRemote(tmpRoot, "master");
+    extraRemotes.push(remote);
+
+    const result = await readShippedStoriesFromMaster(tmpRoot);
+    expect(result.warning).toBeNull();
+    expect(result.shippedStoryIds.has("US-01")).toBe(true);
+    expect(result.shippedStoryIds.has("US-04")).toBe(true);
+    // US-02 / US-03 are NOT in the literal subject — the helper does
+    // not expand the range. Documented in the regex comment in
+    // git-master-stories.ts.
+    expect(result.shippedStoryIds.has("US-02")).toBe(false);
+    expect(result.shippedStoryIds.has("US-03")).toBe(false);
+  });
+
+  it("explicit two-ID subject — both IDs land in the set", async () => {
+    await initRepo(tmpRoot, "master");
+    commitWithSubject(tmpRoot, "feat(US-11): pulls in US-12 helper too", "body");
+    const remote = setupOriginRemote(tmpRoot, "master");
+    extraRemotes.push(remote);
+
+    const result = await readShippedStoriesFromMaster(tmpRoot);
+    expect(result.warning).toBeNull();
+    expect(result.shippedStoryIds.has("US-11")).toBe(true);
+    expect(result.shippedStoryIds.has("US-12")).toBe(true);
+    // matches[] carries one entry per (id, sha) pair — useful for debug.
+    const ids = result.matches.map((m) => m.storyId).sort();
+    expect(ids).toEqual(["US-11", "US-12"]);
+  });
+
+  it("case-insensitive match upper-cases the captured ID", async () => {
+    await initRepo(tmpRoot, "master");
+    commitWithSubject(tmpRoot, "feat(us-13): lower-case subject", "body");
+    const remote = setupOriginRemote(tmpRoot, "master");
+    extraRemotes.push(remote);
+
+    const result = await readShippedStoriesFromMaster(tmpRoot);
+    expect(result.warning).toBeNull();
+    // Captured as `us-13` in the source; normalised to `US-13` in the set.
+    expect(result.shippedStoryIds.has("US-13")).toBe(true);
+    expect(result.shippedStoryIds.has("us-13")).toBe(false);
+  });
+
+  it("word-boundary rejects `US-05a` (partial match)", async () => {
+    await initRepo(tmpRoot, "master");
+    commitWithSubject(tmpRoot, "feat(US-05a): not a real story id", "body");
+    const remote = setupOriginRemote(tmpRoot, "master");
+    extraRemotes.push(remote);
+
+    const result = await readShippedStoriesFromMaster(tmpRoot);
+    expect(result.warning).toBeNull();
+    expect(result.shippedStoryIds.has("US-05")).toBe(false);
+    expect(result.shippedStoryIds.size).toBe(0);
+  });
+});
+
+// ── AC-4 — graceful fallback under git-side failure ──────────────────────
+
+describe("AC-4 — graceful fallback (5 failure modes)", () => {
+  it("missing-git: PATH without git binary → empty set + warning, never throws", async () => {
+    // Strip the system `git` from PATH for the duration of this call.
+    // execFile spawns with the parent process env unless overridden, so
+    // we mutate process.env.PATH and restore in finally.
+    const originalPath = process.env.PATH;
+    try {
+      // An empty PATH guarantees `execFile("git", ...)` returns ENOENT.
+      process.env.PATH = "";
+      // Pass an explicit `ref` so we don't blow up on the rev-parse probe;
+      // the real test is what happens when `git log` itself can't spawn.
+      // (Without an explicit ref, the same code path triggers via the
+      // probe — we test both implicitly.)
+      const result = await readShippedStoriesFromMaster(tmpRoot, { ref: "origin/master" });
+      expect(result.shippedStoryIds.size).toBe(0);
+      expect(result.matches).toHaveLength(0);
+      expect(result.warning).not.toBeNull();
+      expect(result.warning).toMatch(/git[- ]missing/);
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
+
+  it("missing-ref: no origin/master nor origin/main → probe falls through to local `main`", async () => {
+    // Initialise a repo with `main` as default but DON'T add any remote,
+    // so neither `origin/master` nor `origin/main` resolves. The probe
+    // order then falls through to `master` (absent) and finally `main`
+    // (present). This case proves the four-deep ref-discovery cascade
+    // works end-to-end. The truly-no-refs case is covered by the next
+    // test (empty repo with neither master nor main).
+    await initRepo(tmpRoot, "main");
+    commitWithSubject(tmpRoot, "feat(US-99): no-remote", "body");
+
+    const result = await readShippedStoriesFromMaster(tmpRoot);
+    expect(result.warning).toBeNull();
+    expect(result.shippedStoryIds.has("US-99")).toBe(true);
+  });
+
+  it("missing-ref: empty repo with NO refs at all → empty set + warning", async () => {
+    // Init a repo, switch to a branch that has no commits, and ensure
+    // none of master/main/origin/* exist. Achieved by initialising on
+    // a non-master/main branch and never committing.
+    execFileSync("git", ["init", "-q", "-b", "feature/empty", tmpRoot]);
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tmpRoot });
+    execFileSync("git", ["config", "user.name", "test"], { cwd: tmpRoot });
+
+    const result = await readShippedStoriesFromMaster(tmpRoot);
+    expect(result.shippedStoryIds.size).toBe(0);
+    expect(result.warning).not.toBeNull();
+    expect(result.warning).toMatch(/master ref discovery failed/);
+  });
+
+  it("detached-HEAD: scanning still works — origin/master continues to resolve", async () => {
+    await initRepo(tmpRoot, "master");
+    const headSha = commitWithSubject(tmpRoot, "feat(US-20): on-master", "body");
+    const remote = setupOriginRemote(tmpRoot, "master");
+    extraRemotes.push(remote);
+    // Detach HEAD by checking out the commit directly.
+    execFileSync("git", ["checkout", "-q", "--detach", headSha], { cwd: tmpRoot });
+
+    const result = await readShippedStoriesFromMaster(tmpRoot);
+    // Detached HEAD does not invalidate `origin/master`; the helper
+    // should still see the commit.
+    expect(result.warning).toBeNull();
+    expect(result.shippedStoryIds.has("US-20")).toBe(true);
+  });
+
+  it("no-remotes: repo without any `origin` remote → falls through to local master/main", async () => {
+    await initRepo(tmpRoot, "master");
+    commitWithSubject(tmpRoot, "feat(US-21): no-remote-yet", "body");
+    // Deliberately no `origin` remote.
+    const result = await readShippedStoriesFromMaster(tmpRoot);
+    // Local `master` resolves; the helper logs against it.
+    expect(result.warning).toBeNull();
+    expect(result.shippedStoryIds.has("US-21")).toBe(true);
+  });
+
+  it("timeout: child process killed by timeoutMs → empty set + warning, never throws", async () => {
+    // A `timeoutMs` of 1ms is reliably below any real git invocation,
+    // so the child gets SIGTERM-ed before stdout returns. Some builds of
+    // git on Windows are fast enough that 1ms is borderline; we use
+    // `--exec-path` (slow on cold cache) wrapped in a no-op log to make
+    // the timeout reproducible. Simpler approach: just use 1ms; if it
+    // happens to complete on a hot cache the result is still correct
+    // (warning null, IDs empty because there are no commits in the
+    // brand-new tmpRoot we never `git init`ed), and the test still
+    // passes structurally.
+    //
+    // To make this deterministic we DO `git init` so ref discovery
+    // succeeds (hits the cache after the probe) then issue the log
+    // with timeoutMs:1.
+    await initRepo(tmpRoot, "master");
+    for (let i = 1; i <= 5; i++) {
+      commitWithSubject(tmpRoot, `feat(US-${30 + i}): commit ${i}`, "body".repeat(1000));
+    }
+    const remote = setupOriginRemote(tmpRoot, "master");
+    extraRemotes.push(remote);
+    // Prime the cache so the probe doesn't eat the timeout budget.
+    await readShippedStoriesFromMaster(tmpRoot);
+    // Now the next call's only work under the budget is `git log`.
+    const result = await readShippedStoriesFromMaster(tmpRoot, { timeoutMs: 1 });
+    // Two acceptable outcomes:
+    //   1. Timeout fired → empty set + timeout warning.
+    //   2. Git completed under 1ms (hot cache, fast disk) → success.
+    // Either way the helper doesn't throw and returns a structured Result.
+    if (result.warning !== null) {
+      expect(result.warning).toMatch(/timeout/);
+      expect(result.shippedStoryIds.size).toBe(0);
+    } else {
+      // Fast path; just verify shape stayed intact.
+      expect(Array.isArray(result.matches)).toBe(true);
+    }
+  });
+});

--- a/server/lib/git-master-stories.ts
+++ b/server/lib/git-master-stories.ts
@@ -1,0 +1,313 @@
+/**
+ * Master-branch story reconciliation helper for the dashboard renderer.
+ *
+ * Why this exists
+ * ───────────────
+ * The forge dashboard previously rendered story statuses verbatim from
+ * `.forge/coordinate-brief.json`. That file is only rewritten by
+ * `forge_coordinate`, so after a story's PR squash-merges to master the
+ * brief stays frozen — the kanban shows that story in `Ready` for hours
+ * or days until someone manually re-runs `forge_coordinate`.
+ *
+ * Comparing each RunRecord's `lastGitSha` against the master commit graph
+ * (`git rev-list origin/master --contains <sha>`) does NOT work for the
+ * standard `/ship` flow because squash-merges produce a NEW commit on
+ * master whose SHA differs from the original branch HEAD. The squash SHA
+ * is unrelated to `lastGitSha`, so `--contains` returns nothing and the
+ * renderer never updates.
+ *
+ * The signal that survives squash-merging is the conventional-commit
+ * subject — `/ship` produces messages like
+ *   `feat(US-05): knowledge service facade (#72)`
+ * with the story ID embedded. This helper reads recent `origin/master`
+ * commit subjects and extracts the set of `US-NN` IDs that appear, so the
+ * renderer can mark those stories `done` regardless of the brief.
+ *
+ * Design constraints (from the upstream plan):
+ *   - Single git invocation per render (NOT per story). Plan AC-5.
+ *   - Robust to missing git binary, missing master ref, detached HEAD,
+ *     no remotes, child-process timeout. Plan AC-4.
+ *   - Robust to default-branch variation: probe `origin/master`,
+ *     `origin/main`, `master`, `main` in order. Plan AC-6.
+ *   - Multi-story commit subjects (`chore: backfill US-01..US-04 (#67)`)
+ *     surface every matched ID, not just the first. Plan AC-8.
+ *   - Never throws — failures return an empty set + a warning string so
+ *     the renderer falls back to the brief verbatim. Plan AC-4.
+ *   - Story-ID regex is case-insensitive (`US-05` and `us-05` both match)
+ *     but word-bounded (`US-05a` does not), and captured IDs are
+ *     normalized to upper-case before set insertion so dashboard
+ *     comparisons are case-stable.
+ *
+ * Caveat — stale `origin/master`
+ * ──────────────────────────────
+ * If the operator hasn't `git fetch`-ed since the merge, the local
+ * `origin/master` ref is behind the remote and the helper sees nothing.
+ * The dashboard never makes network calls; this is accepted. The
+ * dashboard catches up after the next fetch (which happens automatically
+ * during `/ship` Stage 7's `git pull`).
+ */
+
+import { execFile } from "node:child_process";
+
+// ── Public types ──────────────────────────────────────────────────────────
+
+export interface ReadShippedStoriesOpts {
+  /** Number of master commits to scan. Default 50. */
+  limit?: number;
+  /**
+   * Master ref to scan. When omitted, the helper probes
+   * `origin/master`, `origin/main`, `master`, `main` in order and uses
+   * the first one that resolves. Tests pass an explicit ref to bypass
+   * the probe.
+   */
+  ref?: string;
+  /** Soft timeout in ms for the git child process. Default 2000. */
+  timeoutMs?: number;
+}
+
+export interface ReadShippedStoriesResult {
+  /** Story IDs (upper-cased) that appear in at least one master subject. */
+  shippedStoryIds: Set<string>;
+  /**
+   * Per-match audit trail — useful for debug rendering and tests.
+   * Includes one entry per (storyId, sha) pair, so a single commit that
+   * mentions two IDs produces two entries.
+   */
+  matches: ReadonlyArray<{ storyId: string; sha: string; subject: string }>;
+  /**
+   * Surfaces fallback reason when the helper had to swallow a git error.
+   * `null` when the call succeeded normally (even if the result set is
+   * empty because no matching subjects were found).
+   */
+  warning: string | null;
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────
+
+/**
+ * Run a git command via `execFile`. Resolves with stdout on success;
+ * rejects with `{ kind, message }` on failure so callers can distinguish
+ * "git missing" from "ref missing" from "timed out" without re-parsing
+ * stderr strings.
+ */
+type GitFailureKind =
+  | "git-missing"
+  | "ref-missing"
+  | "no-remotes"
+  | "detached-head"
+  | "timeout"
+  | "other";
+
+interface GitFailure {
+  kind: GitFailureKind;
+  message: string;
+}
+
+function runGit(
+  cwd: string,
+  args: ReadonlyArray<string>,
+  timeoutMs: number,
+): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    execFile(
+      "git",
+      args as string[],
+      { cwd, timeout: timeoutMs, windowsHide: true, maxBuffer: 4 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (!err) {
+          resolve(stdout);
+          return;
+        }
+        const stderrStr: string = typeof stderr === "string" ? stderr : "";
+        const errnoCode = (err as NodeJS.ErrnoException).code;
+        // ENOENT on the spawn itself → git binary not on PATH.
+        if (errnoCode === "ENOENT") {
+          reject({ kind: "git-missing", message: "git binary not found on PATH" } satisfies GitFailure);
+          return;
+        }
+        // execFile timeout: child receives SIGTERM and `signal` is set.
+        const signal = (err as NodeJS.ErrnoException & { signal?: string }).signal;
+        if (signal === "SIGTERM" || (err as Error & { killed?: boolean }).killed === true) {
+          reject({ kind: "timeout", message: `git timed out after ${timeoutMs}ms` } satisfies GitFailure);
+          return;
+        }
+        // Heuristic stderr patterns for the no-remotes / unknown-ref failure modes.
+        const stderrLower = stderrStr.toLowerCase();
+        if (
+          stderrLower.includes("unknown revision") ||
+          stderrLower.includes("bad revision") ||
+          stderrLower.includes("ambiguous argument") ||
+          stderrLower.includes("not a valid object name")
+        ) {
+          reject({ kind: "ref-missing", message: stderrStr.trim() || "ref not found" } satisfies GitFailure);
+          return;
+        }
+        if (stderrLower.includes("not a git repository")) {
+          reject({ kind: "other", message: "not a git repository" } satisfies GitFailure);
+          return;
+        }
+        reject({
+          kind: "other",
+          message: stderrStr.trim() || (err instanceof Error ? err.message : String(err)),
+        } satisfies GitFailure);
+      },
+    );
+  });
+}
+
+/**
+ * Probe candidate refs in order; return the first one that resolves via
+ * `git rev-parse --verify <ref>`. Throws a `GitFailure` with kind
+ * `ref-missing` when none of the candidates resolve, or `git-missing` /
+ * `timeout` when the underlying invocation fails.
+ *
+ * The probe uses `rev-parse --verify` (not `show-ref`) because `--verify`
+ * is silent on the resolved object and exits non-zero with a clear
+ * "unknown revision" stderr when the ref is absent — easier to classify
+ * than `show-ref`'s "no output" success-but-empty mode.
+ */
+const REF_CANDIDATES = ["origin/master", "origin/main", "master", "main"] as const;
+
+async function discoverMasterRef(cwd: string, timeoutMs: number): Promise<string> {
+  let lastFailure: GitFailure | null = null;
+  for (const candidate of REF_CANDIDATES) {
+    try {
+      await runGit(cwd, ["rev-parse", "--verify", "--quiet", candidate], timeoutMs);
+      return candidate;
+    } catch (e) {
+      lastFailure = e as GitFailure;
+      // git-missing / timeout: bubble up immediately, no point probing further.
+      if (lastFailure.kind === "git-missing" || lastFailure.kind === "timeout") {
+        throw lastFailure;
+      }
+      // ref-missing / other: keep probing.
+    }
+  }
+  throw {
+    kind: "ref-missing" as const,
+    message: `none of ${REF_CANDIDATES.join(", ")} resolved on this repo (${lastFailure?.message ?? "no further detail"})`,
+  } satisfies GitFailure;
+}
+
+/**
+ * Per-projectPath cache for ref discovery. Lives for the process lifetime;
+ * per the plan, the renderer is invoked many times per second of operator
+ * polling and re-probing every render is wasteful. The cache key is
+ * `projectPath` so projects with different default branches stay isolated.
+ *
+ * Exported `__resetCacheForTests` lets the test suite clear it between
+ * cases without exposing the Map directly.
+ */
+const refCache = new Map<string, string>();
+
+export function __resetCacheForTests(): void {
+  refCache.clear();
+}
+
+// Story-ID regex: `US-` followed by one-or-more digits, word-bounded so
+// `US-05a` does not match. Case-insensitive: `us-05` matches and is
+// upper-cased before insertion. The `g` flag is required because we call
+// `.matchAll()` to extract every ID per subject (plan AC-8).
+const STORY_ID_RE = /\b(US-\d+)\b/gi;
+
+function extractStoryIds(subject: string): string[] {
+  const out: string[] = [];
+  for (const match of subject.matchAll(STORY_ID_RE)) {
+    out.push(match[1].toUpperCase());
+  }
+  return out;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Read shipped story IDs from recent `origin/master` commit subjects.
+ *
+ * Returns an empty set + a `warning` string on any git-side failure
+ * (missing binary, missing ref, detached HEAD, no remotes, timeout). The
+ * caller (renderer) falls back to brief-verbatim status; nothing throws.
+ *
+ * Performs ONE `git log` invocation regardless of how many stories are
+ * in the brief (plan AC-5).
+ */
+export async function readShippedStoriesFromMaster(
+  projectPath: string,
+  opts: ReadShippedStoriesOpts = {},
+): Promise<ReadShippedStoriesResult> {
+  const limit = typeof opts.limit === "number" && opts.limit > 0 ? opts.limit : 50;
+  const timeoutMs =
+    typeof opts.timeoutMs === "number" && opts.timeoutMs > 0 ? opts.timeoutMs : 2000;
+
+  // Resolve which ref to scan. Explicit `opts.ref` bypasses the probe;
+  // otherwise consult the per-projectPath cache, otherwise probe.
+  let ref: string;
+  try {
+    if (opts.ref) {
+      ref = opts.ref;
+    } else {
+      const cached = refCache.get(projectPath);
+      if (cached) {
+        ref = cached;
+      } else {
+        ref = await discoverMasterRef(projectPath, timeoutMs);
+        refCache.set(projectPath, ref);
+      }
+    }
+  } catch (e) {
+    const failure = e as GitFailure;
+    return emptyResult(`master ref discovery failed: ${failure.kind} (${failure.message})`);
+  }
+
+  // One `git log` call. `--first-parent` keeps the result deterministic
+  // when the master history contains octopus or unrelated merges; the
+  // `%x00` field separator is a NUL byte so commit subjects with spaces,
+  // colons, or parentheses parse without splitting heuristics.
+  let stdout: string;
+  try {
+    stdout = await runGit(
+      projectPath,
+      [
+        "log",
+        ref,
+        "--first-parent",
+        `-${limit}`,
+        "--no-decorate",
+        // %H = full sha, %s = subject. NUL-separated so subjects with
+        // arbitrary characters (including newlines via `\n`) are safe.
+        // Lines themselves are LF-separated, which is what `split('\n')`
+        // expects.
+        "--format=%H%x00%s",
+      ],
+      timeoutMs,
+    );
+  } catch (e) {
+    const failure = e as GitFailure;
+    return emptyResult(`git log on ${ref} failed: ${failure.kind} (${failure.message})`);
+  }
+
+  const shippedStoryIds = new Set<string>();
+  const matches: Array<{ storyId: string; sha: string; subject: string }> = [];
+
+  for (const line of stdout.split("\n")) {
+    if (!line) continue;
+    const sep = line.indexOf("\x00");
+    if (sep === -1) continue;
+    const sha = line.slice(0, sep);
+    const subject = line.slice(sep + 1);
+    if (!sha || !subject) continue;
+    for (const storyId of extractStoryIds(subject)) {
+      shippedStoryIds.add(storyId);
+      matches.push({ storyId, sha, subject });
+    }
+  }
+
+  return { shippedStoryIds, matches, warning: null };
+}
+
+function emptyResult(warning: string): ReadShippedStoriesResult {
+  return {
+    shippedStoryIds: new Set<string>(),
+    matches: [],
+    warning,
+  };
+}


### PR DESCRIPTION
## Summary

- The forge dashboard previously rendered story statuses verbatim from `.forge/coordinate-brief.json`. The brief is only rewritten by `forge_coordinate`, so after a story's PR squash-merged to master, the kanban kept showing that story in `Ready` for hours/days — operators had to manually re-run `forge_coordinate` to clear the stale card.
- This PR teaches `renderDashboard` to scan the most recent ~50 `origin/master` commits via a single `git log` invocation per render, extract story IDs from conventional-commit subjects (`/\b(US-\d+)\b/gi`), and upgrade any matching brief story to `done`. Squash-merge-safe: matches subject text, not `lastGitSha` reachability.
- Upward-only — never demotes existing `done` (revert protection). Graceful fallback on missing-git / missing-ref / detached-HEAD / no-remotes / timeout: empty set + warning, brief renders verbatim, dashboard never throws.

## What changed

- `server/lib/git-master-stories.ts` (new) — exports `readShippedStoriesFromMaster(projectPath, opts)` returning `{ shippedStoryIds, matches, warning }`. One `git log`, ref discovery cascades `origin/master` -> `origin/main` -> `master` -> `main`, ref-cached per-projectPath.
- `server/lib/dashboard-renderer.ts` — calls the helper between the existing `Promise.all` and `renderDashboardHtml`, runs the result through a pure mapper that upgrades upgradable statuses to `done` and bumps `completedCount`. Mapper also exported under a `__forTests` name for unit testability.
- `server/lib/git-master-stories.test.ts` (new, 13 tests) — covers AC-4 (5 failure modes), AC-5 (single git call + cache short-circuits re-probe), AC-6 (origin/main fallback), AC-8 (multi-story commit subjects, case-insensitive, word-boundary).
- `server/lib/dashboard-renderer-reconciliation.test.ts` (new, 8 tests) — covers AC-1 (happy-path), AC-2 (predicate, not forge_status agreement), AC-3 (upward-only, 3 sub-cases), AC-7 (end-to-end with real git repo).
- `CHANGELOG.md` — `## Unreleased` entry under `### Fixed`.

## Plan

`monday-bot/.ai-workspace/plans/2026-04-26-forge-dashboard-staleness-fix.md` (REV 2). 8 binary AC, all `allow-diff-inspection: test-driven`.

## Test plan

- [x] `npm test` (full suite) — 888 passed | 4 skipped, zero regressions
- [x] `npm run build` — tsc green
- [x] `npm run lint` — eslint green
- [x] AC-1..AC-8 mapped to named test cases (see tests/ for the AC-by-AC mapping)
- [ ] Post-merge: forge-plan dist cut bundling this fix
- [ ] Post-merge: monday-bot end-to-end verification (ship US-06 via `/ship`, verify dashboard regenerates without `forge_coordinate`)

## Known limitation

If the operator hasn't `git fetch`-ed since the remote merge, `origin/master` is local-stale and the helper sees nothing. The dashboard never makes network calls; it catches up on the next pull (which `/ship` Stage 7 performs automatically).