### PR TITLE
fix: B3 build-dedup uses resolveWindowsBashPath() instead of bare sh

### DIFF
--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 import { readFileSync, writeFileSync, readdirSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { platform } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
+import { resolveWindowsBashPath } from "../lib/executor.js";
 
 /**
  * Compute a deterministic `reverseFindings[].id` from its identifying fields.
@@ -310,7 +312,13 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
     const shared = detectSharedBuildPrefix(acCommands);
     if (shared) {
       try {
-        execFileSync("sh", ["-c", shared.prefixCommand], {
+        // v0.38.x — On Windows, `sh` is not on PATH; resolve Git-Bash absolute
+        // path the same way executor.ts does for per-AC commands. Without this,
+        // the up-front build throws ENOENT, falls through to per-AC builds, and
+        // B3's intended N→1 build savings is silently lost on Windows ships.
+        const shellPath =
+          platform() === "win32" ? resolveWindowsBashPath() : "sh";
+        execFileSync(shellPath, ["-c", shared.prefixCommand], {
           cwd: input.projectPath,
           stdio: ["ignore", "pipe", "pipe"],
         });


### PR DESCRIPTION
Closes #465

Auto-fix by /housekeep Stage 4.

B3 build-dedup now resolves Git-Bash absolute path on Windows via the existing `resolveWindowsBashPath()` (already exported from executor.ts) instead of invoking bare `sh`, which is not on PATH on a typical Windows host. Adds platform() import and resolveWindowsBashPath import to evaluate.ts; the execFileSync call uses resolveWindowsBashPath() on win32 and keeps 'sh' on POSIX. `tsc --noEmit` passes.