### PR TITLE
fix: shallow-copy warnings array in readStoryGroundingSignals

### DIFF
--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -262,7 +262,7 @@ export async function readStoryGroundingSignals(
     out.set(storyId, {
       storyId,
       affectedPaths,
-      warnings,
+      warnings: [...warnings],
       latestRunTimestamp: ts,
     });
   }


### PR DESCRIPTION
Closes #468

Auto-fix by /housekeep Stage 4.

Shallow-copies the warnings array (`[...warnings]`) at the StoryGroundingSignal boundary in readStoryGroundingSignals so JSON.parse output is no longer aliased into the dashboard Map; hardens against downstream mutation leaks if Map lifetime ever extends beyond a single render. `tsc --noEmit` passes.