### PR TITLE
test: expose activityStartedAt via test-only accessor

### DIFF
--- a/server/lib/progress.test.ts
+++ b/server/lib/progress.test.ts
@@ -176,6 +176,13 @@ describe("ProgressReporter", () => {
       for (let i = 0; i < 4; i += 1) {
         await new Promise((r) => setImmediate(r));
       }
+
+      // Direct invariant: after every begin has a matching complete, the
+      // private field must be null. Asserting it via the test-only accessor
+      // is wall-clock-independent (slow CI runners cannot make Date.now()
+      // collide across the second begin).
+      expect(reporter.getActivityStartedAtForTesting()).toBeNull();
+
       // Wait a tangible amount so a fresh Date.now() on the second
       // begin() yields a visibly-different ISO timestamp.
       await new Promise((r) => setTimeout(r, 15));

--- a/server/lib/progress.ts
+++ b/server/lib/progress.ts
@@ -154,6 +154,15 @@ export class ProgressReporter {
     }
   }
 
+  /**
+   * Test-only accessor for `activityStartedAt`. Lets tests assert the reset
+   * invariant directly (#377) instead of relying on a wall-clock gap between
+   * two `begin()` calls to detect re-seeding.
+   */
+  getActivityStartedAtForTesting(): string | null {
+    return this.activityStartedAt;
+  }
+
   /** Mark a stage as skipped (e.g., critique skipped in quick tier). */
   skip(stageName: string): void {
     this.results.push({ name: stageName, durationMs: 0, status: "skipped" });


### PR DESCRIPTION
Closes #377

Auto-fix by /housekeep Stage 4.

The #275 reset test previously detected re-seeding by comparing two ISO timestamps captured 15ms apart. On very slow CI runners with low Date.now() granularity, that gap could collapse and produce a false equality.

This change exposes `activityStartedAt` via a test-only getter and asserts `null` directly after the first `complete()`. The wall-clock-based `secondStartedAt` assertion is retained as a secondary check on the re-seed path.