### PR TITLE
fix: F57 anchor accepts leading whitespace too

### DIFF
--- a/server/lib/prompts/shared/ac-subprocess-rules.ts
+++ b/server/lib/prompts/shared/ac-subprocess-rules.ts
@@ -171,8 +171,9 @@ export const AC_LINT_RULES: AcLintRule[] = [
     // `/` -- that is, a project-root basename re-entry. Subdirectory cd
     // (`cd packages/foo && ...`) is fine and intentionally NOT flagged
     // because the path token contains a `/`. The pattern requires the cd
-    // to be a standalone command token (start-of-line, or after `|`/`;`/`&`/`(`).
-    pattern: /(?:^|[|;&(]\s*)cd\s+[A-Za-z0-9._-]+\s*&&\s*\S/,
+    // to be a standalone command token (start-of-line, after leading
+    // whitespace, or after `|`/`;`/`&`/`(`).
+    pattern: /(?:^|[|;&(\s]\s*)cd\s+[A-Za-z0-9._-]+\s*&&\s*\S/,
     severity: "suspect",
     wrongExample: `${AC_CWD_POLICY_WRONG_EXAMPLE} --noEmit`,
     rightExample: "npx tsc --noEmit",


### PR DESCRIPTION
Closes #386

Auto-fix by /housekeep Stage 4.

The F57-cd-basename rule's structural anchor was `(?:^|[|;&(]\s*)`. A leading space before `cd` (e.g., `  cd my-project && cmd`) slipped through. Adds `\s` to the anchor character class so leading-whitespace variants are caught alongside start-of-line and pipe-after forms.

Real AC strings are single-line with no leading whitespace, so likelihood of a real-world miss was low — this is hardening.