### PR TITLE
fix(dashboard): render activity-feed timestamps in viewer-local timezone

### DIFF
--- a/.ai-workspace/plans/2026-04-27-fix-dashboard-timezone-display.md
+++ b/.ai-workspace/plans/2026-04-27-fix-dashboard-timezone-display.md
@@ -1,0 +1,65 @@
+# Fix dashboard timestamps to render in viewer-local timezone
+
+## ELI5
+
+The dashboard's activity feed shows timestamps in a clock that lives in London (UTC), but the user's laptop clock is 8 hours ahead. So the dashboard says "2:54 AM" when the user's actual clock says "10:54 AM" — confusing. We're going to teach the page to translate those London times into whatever timezone the viewer actually lives in, so the numbers match the wall clock the user is staring at. We do this in the *browser*, not on the server, so two viewers in different timezones can each see their own correct time without us having to know which timezone the server is in.
+
+## Context
+
+`server/lib/dashboard-renderer.ts:449-462` defines `formatTimeOfDay(iso)` which renders ISO timestamps as `YYYY-MM-DD HH:MM:SS` using `getUTC*` getters. This was a deliberate choice in v0.35.1 (AC-5) to keep server-side HTML deterministic — the existing `dashboard-renderer-polish.test.ts` AC-5 test (`/2026-04-20.{0,200}13:10:43/`) and `dashboard-renderer.test.ts` AC-08 test both assert the literal UTC tokens in the rendered HTML, which only holds if `getUTC*` is used.
+
+The trade-off: human viewers see UTC regardless of where they live. Reporter is at UTC+8 — every audit-feed row reads 8 hours behind their wall clock. Screenshot evidence: `forge_generate` row shows `02:54:21` while the laptop's clock reads `10:54 AM`.
+
+Two approaches:
+- **(A) Replace `getUTC*` with `get*` (server-side local).** Smaller diff but breaks both tests on any non-UTC CI runner. Also brittle — server's TZ ≠ viewer's TZ in any deployment that isn't single-machine.
+- **(B) Server emits UTC, browser converts via `data-iso` attribute + inline `<script>`.** Server-side HTML stays deterministic (tests pass with a tiny regex tweak that doesn't change the *content* assertion); each viewer sees their own local time on their own browser. Hover reveals the original UTC for cross-machine comparison.
+
+Choosing (B). It's the same pattern GitHub, Slack, etc. use for activity feeds.
+
+## Goal (invariants that must hold when done)
+
+- **G1.** Activity feed timestamps render in the viewer's browser-local timezone.
+- **G2.** Server-side rendered HTML still contains the UTC `YYYY-MM-DD HH:MM:SS` tokens — preserves test determinism on any CI runner regardless of its TZ.
+- **G3.** A user can recover the original UTC value from a feed row (tooltip via `title` attribute) so cross-machine debugging stays possible.
+- **G4.** No new dependencies. No `Intl.DateTimeFormat` reliance — Date.prototype's no-prefix getters return local time and are universally supported.
+- **G5.** Full test suite stays green (only the two regexes that asserted on `<span class="feed-time">` shape are widened to allow extra attributes).
+
+## Binary AC
+
+- **AC-1.** `<span class="feed-time">` tags emitted by `renderFeed` carry a `data-iso="<raw-iso>"` attribute. Reviewer command: `grep -c 'class="feed-time" data-iso=' dist/lib/dashboard-renderer.js` returns ≥1.
+- **AC-2.** The dashboard HTML contains an inline `<script>` block that selects `[data-iso]` and rewrites text content using local-time `Date` getters. Reviewer command: `grep -c 'data-iso' dist/lib/dashboard-renderer.js` returns ≥2 (one for the attribute write, one for the script's selector).
+- **AC-3.** Server-rendered HTML still contains UTC tokens for the existing fixture timestamps. Existing tests `dashboard-renderer-polish.test.ts:AC-5` and `dashboard-renderer.test.ts:AC-08` pass without changing their content assertions (only the regex outer shape is updated to `<span class="feed-time"[^>]*>` to allow extra attributes).
+- **AC-4.** Tooltip preserves UTC: each `[data-iso]` element has `title="UTC: <iso>"` after the script runs. Verifiable in DevTools after page load.
+- **AC-5.** `npm test` exits 0 (full suite green; the previously flaky `run-record.test.ts:112` is a pre-existing concurrency flake unrelated to this change — passes 12/12 in isolation).
+
+## Out of scope
+
+- Localizing other timestamps (header `renderedAt`, story freshness chips, etc.). The audit feed is the user-reported issue; other surfaces stay UTC for this PR.
+- Adding a TZ selector or user-preference store. Browser-local is sufficient.
+- Switching to `Intl.DateTimeFormat`. The `pad`-and-concatenate approach has zero locale ambiguity and matches the server's format byte-for-byte.
+- Touching activity.json schema or any storage format.
+
+## Verification procedure
+
+1. `npx vitest run server/lib/dashboard-renderer.test.ts server/lib/dashboard-renderer-polish.test.ts` → 47/47 pass.
+2. `npm test` → exits 0 (modulo the pre-existing run-record concurrency flake noted above; it passes in isolation).
+3. `npm run build` → exits 0; `dist/lib/dashboard-renderer.js` contains both `data-iso=` and `Localize feed timestamps`.
+4. After session restart + a forge_* tool call to trigger a render: open the dashboard, confirm a row that was `02:54:21` now reads `10:54:21` (UTC+8 viewer), hover the row to confirm tooltip shows `UTC: 2026-04-27T02:54:21.xxxZ`.
+
+## Critical files
+
+- `server/lib/dashboard-renderer.ts` — adds `data-iso=` attribute to feed-time span (line 867); injects inline script before `</body>` (line 1109); updates `formatTimeOfDay` doc to reflect the new architecture.
+- `server/lib/dashboard-renderer-polish.test.ts` — widens AC-5 regex from `<span class="feed-time">` to `<span class="feed-time"[^>]*>` so it tolerates the new attribute. Content assertion unchanged.
+- `server/lib/dashboard-renderer.test.ts` — same widening for the AC-08 ordering regex.
+
+## Checkpoint
+
+- [x] Cause located: `formatTimeOfDay` uses `getUTC*` deliberately for test determinism (line 449-462).
+- [x] Approach picked: browser-side conversion via `data-iso` + inline `<script>`.
+- [x] Source edited (3 files).
+- [x] Renderer suites green (47/47).
+- [x] Full suite measured (965/970 + 4 skipped + 1 pre-existing flake confirmed unrelated).
+- [x] Dist rebuilt; both markers present.
+- [ ] /ship pipeline (this turn).
+
+Last updated: 2026-04-27.

--- a/server/lib/dashboard-renderer-polish.test.ts
+++ b/server/lib/dashboard-renderer-polish.test.ts
@@ -164,7 +164,7 @@ describe("AC-5 — feed-time format carries date prefix", () => {
     // Regex from the plan: the HTML must match /2026-04-20.{0,200}13:10:43/
     expect(html).toMatch(/2026-04-20.{0,200}13:10:43/);
     // And both tokens must appear in the feed-time span.
-    const feedTimeRe = /<span class="feed-time">([^<]+)<\/span>/;
+    const feedTimeRe = /<span class="feed-time"[^>]*>([^<]+)<\/span>/;
     const match = feedTimeRe.exec(html);
     expect(match).not.toBeNull();
     expect(match![1]).toContain("2026-04-20");

--- a/server/lib/dashboard-renderer.test.ts
+++ b/server/lib/dashboard-renderer.test.ts
@@ -479,7 +479,7 @@ describe("renderDashboardHtml — audit feed count + ordering (AC-08)", () => {
     // (date prefix added so cross-day rows don't look chronologically
     // scrambled). Regex updated to accept the new shape; the ordering
     // assertion below is unchanged.
-    const tsRe = /<span class="feed-time">(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})<\/span>/g;
+    const tsRe = /<span class="feed-time"[^>]*>(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})<\/span>/g;
     const feedTimestamps: string[] = [];
     let m;
     while ((m = tsRe.exec(html)) !== null) feedTimestamps.push(m[1]);

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -431,20 +431,13 @@ export function formatElapsed(ms: number): string {
 }
 
 /**
- * v0.35.1 AC-5 — format an ISO timestamp as `YYYY-MM-DD HH:MM:SS` (UTC).
+ * Format an ISO timestamp as `YYYY-MM-DD HH:MM:SS` in UTC.
  *
- * Pre-v0.35.1 this only rendered `HH:MM:SS`, which made cross-day rows in
- * the activity feed look chronologically scrambled (all rows showed the
- * same time-of-day band with no date distinction). The date prefix is
- * emitted ahead of the time so the Regex AC (`/YYYY-MM-DD.*HH:MM:SS/`)
- * can match within one feed row.
- *
- * UTC getters (`getUTCFullYear`, etc.) guarantee the rendered date matches
- * the ISO input's date component regardless of the host timezone — avoids
- * the edge case where a machine east/west of UTC would show a one-day-off
- * label near midnight UTC. The Reviewer AC fixture uses a mid-afternoon
- * UTC timestamp, but making this timezone-stable costs nothing and prevents
- * flakiness on CI runners in any TZ.
+ * UTC is deliberate on the server: it keeps rendered HTML deterministic so
+ * tests assert literal tokens regardless of the runner's TZ. The viewer
+ * never sees this value — the inline `<script>` at the end of the page
+ * rewrites every `[data-iso]` element to the browser's local TZ on load.
+ * If JS is disabled, this UTC fallback is still readable (just shifted).
  */
 function formatTimeOfDay(iso: string): string {
   try {
@@ -864,7 +857,7 @@ function renderFeed(auditEntries: ReadonlyArray<AuditFeedEntry>): string {
   }
   const rows = auditEntries.map((e) =>
     `<div class="feed-entry">
-  <span class="feed-time">${escapeHtml(formatTimeOfDay(e.timestamp))}</span>
+  <span class="feed-time" data-iso="${escapeHtml(e.timestamp)}">${escapeHtml(formatTimeOfDay(e.timestamp))}</span>
   <span class="feed-tool"><span class="hex-dot"></span>${escapeHtml(e.tool)}</span>
   <span class="feed-stage">${escapeHtml(e.stage)}</span>
   <span class="feed-decision">(decision: ${escapeHtml(e.decision)})</span>
@@ -1106,6 +1099,26 @@ ${renderReplanningNotes(brief)}
 ${renderBoard(brief, activity, groundingSignals, projectPath, masterMergedIds)}
 ${renderFeed(auditEntries)}
 </div>
+<script>
+// Localize feed timestamps. Server emits UTC for CI/test determinism; the
+// browser converts to the viewer's TZ on every meta-refresh load. Original
+// UTC ISO is kept as the element's title attribute so hovering reveals it.
+(function () {
+  function pad(n) { return String(n).padStart(2, "0"); }
+  var nodes = document.querySelectorAll("[data-iso]");
+  for (var i = 0; i < nodes.length; i++) {
+    var el = nodes[i];
+    var iso = el.getAttribute("data-iso");
+    if (!iso) continue;
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) continue;
+    el.textContent =
+      d.getFullYear() + "-" + pad(d.getMonth() + 1) + "-" + pad(d.getDate()) +
+      " " + pad(d.getHours()) + ":" + pad(d.getMinutes()) + ":" + pad(d.getSeconds());
+    el.title = "UTC: " + iso;
+  }
+})();
+</script>
 </body>
 </html>`;
 


### PR DESCRIPTION
## Summary

The dashboard's audit-feed timestamps were rendering in UTC for every viewer regardless of their timezone. A viewer at UTC+8 saw `02:54:21` when their wall clock read `10:54`. Cause: `formatTimeOfDay` in `server/lib/dashboard-renderer.ts` deliberately uses `getUTC*` so the AC-5 test fixture (`/2026-04-20.{0,200}13:10:43/`) matches deterministically on any CI runner — but that determinism leaked into the user-visible value.

Fix: server keeps emitting UTC (test stability preserved), browser converts. Each `<span class="feed-time">` now carries `data-iso="<raw-iso>"` plus an inline `<script>` at end-of-body that rewrites the visible text to the browser's local timezone on every page load. The dashboard's existing 5s `<meta http-equiv="refresh">` triggers the script on every reload, so no `DOMContentLoaded` listener is needed. Original UTC ISO is kept as the element's `title` attribute, so hovering reveals the source-of-truth value for cross-machine debugging.

The two test regexes that pinned `<span class="feed-time">` to an exact attribute layout are widened to `<span class="feed-time"[^>]*>` so they tolerate the new `data-iso` attribute. The captured *content* assertion is unchanged — server-rendered HTML still contains the UTC tokens.

## Test plan

- [x] `npx vitest run server/lib/dashboard-renderer.test.ts server/lib/dashboard-renderer-polish.test.ts` → 47/47 pass
- [x] `npm test` → 965/970 pass + 4 skipped + 1 pre-existing concurrency flake (`run-record.test.ts:112`) confirmed unrelated; passes 12/12 in isolation
- [x] `npm run build` → exits 0; `dist/lib/dashboard-renderer.js` contains both `data-iso=` and `Localize feed timestamps`
- [ ] Post-merge: open the dashboard in a browser, confirm a row that was `02:54:21` UTC now reads `10:54:21` local at UTC+8, hover to confirm tooltip shows `UTC: 2026-04-27T02:54:21.xxxZ`

## Plan

Saved at `.ai-workspace/plans/2026-04-27-fix-dashboard-timezone-display.md`.

---
plan-refresh: no-op