### PR TITLE
fix(dashboard): delete unused .card-warning-chip.error CSS rule

### DIFF
--- a/server/lib/dashboard-renderer-grounding.test.ts
+++ b/server/lib/dashboard-renderer-grounding.test.ts
@@ -165,9 +165,9 @@ describe("dashboard grounding signals — v0.38.0 (I1+I2+I3+I7)", () => {
   it("AC-4: stripped-unknown-identifier renders amber chip with data-severity=warning (v0.39.2 B12 fix)", () => {
     // v0.39.2 AC-1/B12 — every spec-generator warning now renders amber.
     // The previous "error" severity painted a non-fatal warning red, the
-    // colour reserved for actual failures. The CSS class
-    // `.card-warning-chip.error` continues to exist (G1 invariant) but no
-    // chip-emitting site uses it at this revision.
+    // colour reserved for actual failures. (The unused `.card-warning-chip.error`
+    // CSS rule was removed in v0.39.3; if a future error-surface rendering path
+    // is added, it will ship its own CSS rule.)
     const brief = makeBrief({
       stories: [makeStoryEntry("US-02", "done")],
       completedCount: 1,

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -389,14 +389,11 @@ function renderWarningChips(warnings: SpecGeneratorWarning[]): string {
     // v0.39.2 AC-1/B12 — every spec-generator warning is amber. The earlier
     // hardcoded `kind === "stripped-unknown-identifier" → "error"` mapping
     // painted a non-fatal warning red, the colour reserved for actual
-    // failures. The `.card-warning-chip.error` CSS class continues to exist
-    // (G1) — it is reserved for a future error-surface rendering path that
-    // would consume `generatedDocs.errors[]`. No chip-emitting site uses it
-    // at this revision. The literal `card-warning-chip warning` is inlined
-    // (rather than `card-warning-chip ${severity}` with a hoisted const) so
-    // the dist also carries the literal string; AC-8's dist grep is the
-    // observable contract that no future commit silently re-introduces a
-    // dynamic severity branch here.
+    // failures. The literal `card-warning-chip warning` is inlined (rather
+    // than `card-warning-chip ${severity}` with a hoisted const) so the dist
+    // also carries the literal string; AC-8's dist grep is the observable
+    // contract that no future commit silently re-introduces a dynamic
+    // severity branch here.
     const label = kind === "no-vocabulary" ? "no vocabulary" : kind === "stripped-unknown-identifier" ? "unknown identifier" : kind;
     const countLabel = count > 1 ? ` ×${count}` : "";
     chips.push(
@@ -1185,7 +1182,6 @@ body { font-family: var(--font-ui); line-height: 1.5; background: var(--off-whit
 .story-card .card-warnings { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
 .story-card .card-warning-chip { display: inline-block; font-size: 10px; font-weight: 600; padding: 2px 6px; border-radius: 4px; font-family: var(--font-mono); }
 .story-card .card-warning-chip.warning { background: var(--amber-bg); color: var(--amber); border: 1px solid var(--amber); }
-.story-card .card-warning-chip.error { background: var(--red-bg); color: var(--red); border: 1px solid var(--red); }
 .story-card .master-merged-badge { display: inline-block; font-size: 10px; font-weight: 600; padding: 2px 6px; border-radius: 4px; background: var(--green-bg); color: var(--green); border: 1px solid var(--green); margin-top: 4px; }
 .story-card .card-non-fatal-warnings { display: flex; flex-direction: column; gap: 2px; margin-top: 6px; }
 .story-card .card-non-fatal-warning { font-size: 11px; color: var(--amber); font-style: italic; }


### PR DESCRIPTION
## Summary
- Deletes the unused `.story-card .card-warning-chip.error` CSS rule from `server/lib/dashboard-renderer.ts`. Post-v0.39.2 every chip-emit site routes through the amber `.warning` class (B12 audit fix).
- Trims the rationale comment block in `renderWarningChips` that was justifying keeping the rule "for a future error-surface rendering path." Dead-code-for-future-use is forbidden by the user's "we never implement something we will not use" rule. If/when an error-surface path is added, it ships its own CSS rule.
- Updates a stale comment in `dashboard-renderer-grounding.test.ts` (AC-4) so it no longer claims the unused class still exists.

## Test plan
- `grep -c '.card-warning-chip.error' server/lib/dashboard-renderer.ts` returns 0 (rule removed at source)
- `grep -c '.card-warning-chip.warning' server/lib/dashboard-renderer.ts` returns 1 (amber rule preserved)
- `grep -c 'reserved for a future error-surface' server/lib/dashboard-renderer.ts` returns 0 (rationale removed)
- `npm run build` clean
- `grep -c 'card-warning-chip.error' dist/lib/dashboard-renderer.js` returns 0 post-build
- Full vitest suite (`npx vitest run`) — 980 passed / 4 skipped, no regressions
- The v0.39.2 `not.toContain('class="card-warning-chip error"')` assertions still hold; deleting the CSS doesn't change rendered HTML because no chip-emit site referenced it

---
plan-refresh: no-op