### PR TITLE
fix(dashboard): v0.39.5 — top-bar legibility cleanup

### DIFF
--- a/server/lib/dashboard-renderer-v039.test.ts
+++ b/server/lib/dashboard-renderer-v039.test.ts
@@ -4,9 +4,13 @@
  *
  *   AC-3 — `data-master-merged="true"` for stories the master-reconciler
  *          upgraded; `"false"` for everything else.
- *   AC-6 — `phase-status-pill in-progress` substring appears 0 times for
- *          briefs whose status is `in-progress`; the pill is non-empty;
- *          its visible text never contains "in progress" (case-insens).
+ *   AC-6 — phase-status pill renamed away from "in-progress" so its
+ *          class + visible text don't collide with the kanban "IN
+ *          PROGRESS" column heading. v0.39.5 retired the pill entirely
+ *          (the orange ACTIVE pill duplicated the green phase-tag); the
+ *          green phase-tag is now the canonical phase-status surface,
+ *          and the AC-6 collision invariants are satisfied vacuously
+ *          (no pill class exists at all).
  *   AC-7 — `nonFatalWarnings` reach the rendered HTML when present;
  *          empty array produces no warning markup.
  */
@@ -109,10 +113,10 @@ describe("AC-3 — data-master-merged attribute on story cards", () => {
   });
 });
 
-// ── AC-6 — top-bar pill rename ─────────────────────────────────────────────
+// ── AC-6 — top-bar pill collision (now retired in v0.39.5) ─────────────────
 
-describe("AC-6 — phase-status-pill no longer collides with the IN PROGRESS column", () => {
-  it("status='in-progress' brief produces 0 occurrences of 'phase-status-pill in-progress' in HTML", () => {
+describe("AC-6 — phase-status surface no longer collides with the IN PROGRESS column", () => {
+  it("status='in-progress' brief produces 0 occurrences of 'phase-status-pill' in HTML", () => {
     const brief = makeBrief("in-progress", [makeStoryEntry("US-01", "ready")]);
     const html = renderDashboardHtml({
       brief,
@@ -120,11 +124,11 @@ describe("AC-6 — phase-status-pill no longer collides with the IN PROGRESS col
       auditEntries: [],
       renderedAt: "2026-04-27T00:00:00.000Z",
     });
-    const occurrences = (html.match(/phase-status-pill in-progress/g) ?? []).length;
+    const occurrences = (html.match(/phase-status-pill/g) ?? []).length;
     expect(occurrences).toBe(0);
   });
 
-  it("pill markup is still emitted with non-empty visible text for in-progress briefs", () => {
+  it("phase-tag emits non-empty visible text for in-progress briefs without the ambiguous space-form", () => {
     const brief = makeBrief("in-progress", [makeStoryEntry("US-01", "ready")]);
     const html = renderDashboardHtml({
       brief,
@@ -132,10 +136,9 @@ describe("AC-6 — phase-status-pill no longer collides with the IN PROGRESS col
       auditEntries: [],
       renderedAt: "2026-04-27T00:00:00.000Z",
     });
-    // Some pill exists with non-empty visible text.
-    const pillMatch = /<div class="phase-status-pill[^"]*">([^<]+)<\/div>/.exec(html);
-    expect(pillMatch).not.toBeNull();
-    const visible = pillMatch?.[1] ?? "";
+    const tagMatch = /<div class="phase-tag">([^<]+)<\/div>/.exec(html);
+    expect(tagMatch).not.toBeNull();
+    const visible = tagMatch?.[1] ?? "";
     expect(visible.length).toBeGreaterThan(0);
     // Visible text MUST NOT contain "in progress" (case-insensitive, with
     // space). The literal "in-progress" with hyphen is fine — the AC
@@ -144,7 +147,7 @@ describe("AC-6 — phase-status-pill no longer collides with the IN PROGRESS col
     expect(/in\s+progress/i.test(visible)).toBe(false);
   });
 
-  it("status='complete' still classes the pill literally as 'complete'", () => {
+  it("status='complete' surfaces the literal token in the phase-tag", () => {
     const brief = makeBrief("complete", [makeStoryEntry("US-01", "done")]);
     const html = renderDashboardHtml({
       brief,
@@ -152,7 +155,7 @@ describe("AC-6 — phase-status-pill no longer collides with the IN PROGRESS col
       auditEntries: [],
       renderedAt: "2026-04-27T00:00:00.000Z",
     });
-    expect(html).toContain('phase-status-pill complete');
+    expect(html).toContain('<div class="phase-tag">complete</div>');
   });
 });
 

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -664,36 +664,6 @@ function buildGroundingDriftSummary(
   return lines.join("");
 }
 
-/**
- * v0.39.0 G4/AC-6 — top-bar phase-status pill, renamed away from
- * `in-progress` so its class + visible text no longer collide with the
- * "IN PROGRESS" kanban column heading.
- *
- * Mapping (status → class+label) — only the `in-progress` row changes
- * from the legacy renderer; every other status keeps its existing class
- * literal so the rest of the dashboard's CSS keeps working.
- *
- *   in-progress    →  class="active",  label="active"
- *   complete       →  class="complete", label="complete"
- *   needs-replan   →  class="needs-replan", label="needs-replan"
- *   halted         →  class="halted", label="halted"
- *   waiting        →  class="waiting", label="waiting"
- *   <anything else>→  pass-through (legacy parity)
- *
- * AC-6 invariants:
- *  - `phase-status-pill in-progress` substring appears 0 times.
- *  - The visible pill text never contains the substring `in progress`
- *    (case-insensitive).
- *  - Some non-empty pill markup announces the phase status for every
- *    brief whose status is `in-progress`.
- */
-function renderPhaseStatusPill(status: string): string {
-  if (status === "in-progress") {
-    return `<div class="phase-status-pill active">active</div>`;
-  }
-  return `<div class="phase-status-pill ${escapeHtml(status)}">${escapeHtml(status)}</div>`;
-}
-
 function renderHeader(
   brief: PhaseTransitionBrief | null,
   declaration: StoryDeclaration | null | undefined,
@@ -710,7 +680,6 @@ function renderHeader(
   <div class="top-bar-left">
     <div class="logo">Hive Mind <span>Forge</span><span class="logo-divider">/</span><span class="logo-sub">Coordinate</span></div>
     <div class="phase-tag">no brief</div>
-    <div class="phase-status-pill">waiting</div>
     ${declarationHtml}
   </div>
   <div class="top-bar-right">
@@ -766,7 +735,6 @@ function renderHeader(
   <div class="top-bar-left">
     <div class="logo">Hive Mind <span>Forge</span><span class="logo-divider">/</span><span class="logo-sub">Coordinate</span></div>
     <div class="phase-tag">${escapeHtml(brief.status)}</div>
-    ${renderPhaseStatusPill(brief.status)}
     ${declarationHtml}
   </div>
   <div class="top-bar-right">
@@ -1079,10 +1047,6 @@ body { font-family: var(--font-ui); line-height: 1.5; background: var(--off-whit
 .logo-divider { color: var(--border); margin: 0 2px; font-weight: 300; }
 .logo-sub { font-size: 13px; font-weight: 500; color: var(--text-secondary); }
 .phase-tag { font-family: var(--font-mono); font-size: 12px; font-weight: 600; color: var(--green); background: var(--green-bg); padding: 3px 10px; border-radius: 6px; }
-.phase-status-pill { font-size: 12px; font-weight: 600; padding: 3px 10px; border-radius: 10px; background: var(--border-light); color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em; }
-.phase-status-pill.complete { background: var(--green-bg); color: var(--green); }
-.phase-status-pill.needs-replan, .phase-status-pill.halted { background: var(--red-bg); color: var(--red); }
-.phase-status-pill.active { background: var(--amber-bg); color: var(--amber); }
 .declaration-pill { font-size: 12px; font-weight: 600; padding: 3px 10px; border-radius: 10px; background: var(--green-bg); color: var(--green); display: inline-flex; align-items: center; gap: 6px; }
 .declaration-pill .decl-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); font-weight: 700; }
 .declaration-pill .decl-story-id { font-family: var(--font-mono); font-weight: 700; }
@@ -1137,7 +1101,7 @@ body { font-family: var(--font-ui); line-height: 1.5; background: var(--off-whit
 .forge-pulse.working-red .pulse-caption { color: var(--red); }
 
 @keyframes forge-respire { 0%, 100% { transform: scale(0.88); opacity: 0.7; } 50% { transform: scale(1.08); opacity: 1; } }
-@keyframes forge-respire-idle { 0%, 100% { transform: scale(0.78); opacity: 0.4; filter: drop-shadow(0 0 0 rgba(138, 138, 138, 0)); } 50% { transform: scale(0.92); opacity: 0.78; filter: drop-shadow(0 0 4px rgba(138, 138, 138, 0.55)); } }
+@keyframes forge-respire-idle { 0%, 100% { transform: scale(0.78); opacity: 0.4; background-color: #3a3a3a; filter: drop-shadow(0 0 0 rgba(138, 138, 138, 0)); } 50% { transform: scale(0.92); opacity: 0.78; background-color: #c8c8c8; filter: drop-shadow(0 0 4px rgba(138, 138, 138, 0.55)); } }
 @keyframes forge-respire-stutter { 0%, 18%, 100% { transform: scale(0.9); opacity: 0.7; } 32% { transform: scale(1.04); opacity: 0.95; } 38% { transform: scale(0.96); opacity: 0.85; } 60% { transform: scale(1.06); opacity: 1; } }
 @keyframes forge-ember-green { 0%, 100% { transform: translate(-50%, -50%) scale(0.85); opacity: 0.85; } 50% { transform: translate(-50%, -50%) scale(1.15); opacity: 1; } }
 @keyframes forge-ember-amber { 0%, 100% { transform: translate(-50%, -50%) scale(0.8); opacity: 0.7; } 40% { transform: translate(-50%, -50%) scale(1.1); opacity: 1; } 60% { transform: translate(-50%, -50%) scale(0.95); opacity: 0.85; } }


### PR DESCRIPTION
## Summary

Two top-bar legibility fixes bundled in one PR:

1. **Drop the redundant orange ACTIVE pill.** The dashboard top bar was rendering both a green `phase-tag` and an orange `phase-status-pill`, both deriving from the same `brief.status` field. The orange pill was added in v0.39.0 (G4/AC-6) to dodge a CSS class-name collision with the kanban "IN PROGRESS" column heading by remapping `"in-progress"` → `"active"`. With the green phase-tag already announcing the phase-status, the orange pill was visual duplication. Removing the entire `renderPhaseStatusPill` function, its two call sites, and its four `.phase-status-pill*` CSS rules.

2. **Add a chroma axis to the idle Forge Pulse keyframe.** v0.39.4's idle hex respiration uses scale + opacity + halo — three axes all on the brightness perceptual channel. Adding a fourth axis on `background-color` (`#3a3a3a` at trough ↔ `#c8c8c8` at peak) widens the luminance swing on the fill itself, making the breath unmistakable at the native 12px render size. In-phase with the existing axes (all reach minimum at 0%/100% and maximum at 50%). The static base `background: var(--grey)` is unchanged so the `prefers-reduced-motion: reduce` fallback continues to render correctly.

## Test plan

- [x] `npx vitest run server/lib/dashboard-renderer-v039.test.ts server/lib/dashboard-renderer.test.ts server/lib/dashboard-renderer-v039-2.test.ts` — 55/55 pass.
- [x] `npx vitest run` — 974/974 unit pass.
- [x] `npx vitest run server/smoke/mcp-surface.test.ts` (after `npm run build`) — 6/6 pass.
- [x] Static markers in rendered HTML: 0 occurrences of `phase-status-pill` (down from 2 in v0.39.4); 2 occurrences of `phase-tag` (CSS rule + HTML element); both new `background-color` values present in the keyframe.
- [ ] Visual smoke at native 12px (deferred to /ship Stage 5 reviewer — `file://` and HTTP-server paths are blocked in this session's sandbox).
- [ ] Reviewer: confirm the breath is visibly multi-axis at native size with no kanban column collision.

## AC-6 invariant migration

The v0.39.0 AC-6 invariant ("phase-status-pill in-progress substring count == 0 in HTML") is now satisfied vacuously — no `phase-status-pill` class exists at all in v0.39.5. The collision risk that the original AC guarded against is structurally eliminated rather than dodged. Tests in `dashboard-renderer-v039.test.ts` are migrated to assert the green `phase-tag` is the canonical phase-status surface; the AC-6 collision invariant is preserved in spirit.

---
plan-refresh: no-op