### PR TITLE
fix: avoid empty-slice allocation in clipFeedTimestamps

### DIFF
--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -957,7 +957,7 @@ function renderBoard(
  */
 function clipFeedTimestamps(
   entries: ReadonlyArray<AuditFeedEntry>,
-): AuditFeedEntry[] {
+): ReadonlyArray<AuditFeedEntry> {
   let latestClose: string | null = null;
   for (const e of entries) {
     if (e.stage === "close") {
@@ -966,7 +966,7 @@ function clipFeedTimestamps(
       }
     }
   }
-  if (latestClose === null) return entries.slice();
+  if (latestClose === null) return entries;
   const close = latestClose;
   return entries.map((e) => {
     if (e.stage === "close") return e;


### PR DESCRIPTION
Closes #489

Auto-fix by /housekeep Stage 4.

In `clipFeedTimestamps` (server/lib/dashboard-renderer.ts), changed the return type from `AuditFeedEntry[]` to `ReadonlyArray<AuditFeedEntry>` and replaced `return entries.slice()` with `return entries` on the early-return path when `latestClose === null`. This avoids an unnecessary shallow copy on every renderer invocation when the audit feed contains no close envelope. The caller (`renderFeed`) only iterates the result via `.map()`, which is available on `ReadonlyArray`, so widening the type is safe. The non-null path still returns a new array via `entries.map()`, so no shared-mutation hazard is introduced.