### PR TITLE
fix(test): canonical regex-meta escape in keyframes lookup

### DIFF
--- a/server/lib/dashboard-renderer-v039-2.test.ts
+++ b/server/lib/dashboard-renderer-v039-2.test.ts
@@ -251,7 +251,7 @@ describe("AC-3 — idle pill animation (B11 + W4)", () => {
     //    other half of the link — without it the animation declaration is a
     //    dead reference and the idle pill would not actually pulse.
     const keyframesRegex = new RegExp(
-      `@keyframes\\s+${animationName.replace(/[-/\\^$*+?.()|[\\]{}]/g, "\\\\$&")}\\s*\\{`,
+      `@keyframes\\s+${animationName.replace(/[-/\\^$*+?.()|[\\]{}]/g, "\\$&")}\\s*\\{`,
     );
     expect(
       keyframesRegex.test(css),


### PR DESCRIPTION
Closes #490

Auto-fix by /housekeep Stage 4.

The `.replace(/[meta]/g, ...)` call used to escape an animation name before constructing the keyframes RegExp had `"\\$&"` (JS source) as the replacement string — that produces the runtime string `\$&`, putting `\<char>` into the regex source (an over-escape). Today's animation name `forge-respire-idle` only contains hyphens, so the over-escape happened to match identically; but the regex would silently break if a name ever picked up a meta-char like `\d` or `\w`.

Changed the JS source to `"\$&"`, which produces the canonical runtime replacement `\$&` and puts the standard `\<char>` escape into the regex source. Single-line change in `server/lib/dashboard-renderer-v039-2.test.ts:254`. All 9 vitest cases for the file still pass.