### PR TITLE
fix(adr-extractor): support YAML | and > block scalars (US-08 regression)

### DIFF
--- a/scripts/adr-backfill-acceptance.sh
+++ b/scripts/adr-backfill-acceptance.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Acceptance wrapper for forge-adr-backfill.mjs (W2 of US-08 regression fix).
+# Runs AC-5(a..c) from .ai-workspace/plans/2026-04-27-us08-adr-index-regression.md
+# Exits 0 iff all sub-cases pass.
+#
+# Usage: bash scripts/adr-backfill-acceptance.sh
+# Prereq: `npm run build` must have succeeded (dist/ populated).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+CLI="$REPO_ROOT/scripts/forge-adr-backfill.mjs"
+DIST="$REPO_ROOT/dist/lib/adr-extractor.js"
+
+if [ ! -f "$DIST" ]; then
+  echo "FAIL: dist/lib/adr-extractor.js missing — run \`npm run build\` first."
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+declare -a FAILURES
+
+check() {
+  local name="$1"
+  local description="$2"
+  local exit_code="$3"
+  if [ "$exit_code" -eq 0 ]; then
+    echo "  [PASS] $name — $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  [FAIL] $name — $description"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: $description")
+  fi
+}
+
+# Each scenario gets its own scratch project. tmp/ is gitignored.
+mkdir -p tmp
+SCRATCH_BASE="$(mktemp -d "${TMPDIR:-/tmp}/forge-adr-backfill-XXXXXX")"
+trap 'rm -rf "$SCRATCH_BASE"' EXIT
+
+echo "=== forge-adr-backfill acceptance ==="
+echo
+
+# ── AC-5(a) — PASS record + missing INDEX row → CLI adds the row ─────────
+PROJ_A="$SCRATCH_BASE/case-a"
+mkdir -p "$PROJ_A/.forge/runs" "$PROJ_A/.forge/staging/adr/US-08" "$PROJ_A/docs/decisions"
+
+# Stage a real ADR stub mirroring the US-08 format (multi-line `|` block scalars).
+cat > "$PROJ_A/.forge/staging/adr/US-08/add-slack-bolt-socket-mode.md" <<'EOF'
+---
+title: Adopt @slack/bolt with Socket Mode
+story: US-08
+context: |
+  US-08 introduces the Slack-facing surface of monday-bot.
+  We need a Slack SDK that supports Socket Mode.
+decision: |
+  Add @slack/bolt v4.x as a runtime dependency.
+consequences: |
+  Bundle gains @slack/bolt and transitive deps.
+alternatives: |
+  HTTP Receiver: rejected — requires public ingress.
+---
+
+body
+EOF
+
+# Write a PASS run record referencing US-08.
+cat > "$PROJ_A/.forge/runs/forge_evaluate-2026-04-27T00-00-00-abcdef.json" <<'EOF'
+{
+  "tool": "forge_evaluate",
+  "storyId": "US-08",
+  "evalVerdict": "PASS",
+  "verdict": "PASS",
+  "metrics": { "estimatedCostUsd": 0 }
+}
+EOF
+
+# Sanity: INDEX.md does not exist yet.
+[ ! -f "$PROJ_A/docs/decisions/INDEX.md" ] && AC5A_PRE=0 || AC5A_PRE=1
+check "AC-5(a)/pre" "INDEX.md absent before backfill" "$AC5A_PRE"
+
+# Run the CLI.
+node "$CLI" --project "$PROJ_A" > "$SCRATCH_BASE/case-a.log" 2>&1
+AC5A_EXIT=$?
+check "AC-5(a)/exit" "CLI exits 0 with stub on disk" "$AC5A_EXIT"
+
+# Assert: ADR file created with US-08 suffix.
+AC5A_ADR=1
+if compgen -G "$PROJ_A/docs/decisions/ADR-*-US-08.md" > /dev/null; then AC5A_ADR=0; fi
+check "AC-5(a)/adr" "ADR-NNNN-*-US-08.md file created" "$AC5A_ADR"
+
+# Assert: INDEX.md exists and contains a row for ADR-0001 + US-08.
+AC5A_INDEX=1
+if [ -f "$PROJ_A/docs/decisions/INDEX.md" ] && \
+   grep -qE '^\| ADR-0001 \| US-08 \|' "$PROJ_A/docs/decisions/INDEX.md"; then
+  AC5A_INDEX=0
+fi
+check "AC-5(a)/index" "INDEX.md contains row pointing at ADR-0001 + US-08" "$AC5A_INDEX"
+
+# Assert: staging dir cleared.
+AC5A_STAGE=1
+[ ! -d "$PROJ_A/.forge/staging/adr/US-08" ] && AC5A_STAGE=0
+check "AC-5(a)/staging" "staging dir cleared after canonicalisation" "$AC5A_STAGE"
+
+echo
+
+# ── AC-5(b) — re-running case (a) is a no-op (INDEX byte-identical) ──────
+INDEX_BEFORE_HASH=$(sha256sum "$PROJ_A/docs/decisions/INDEX.md" | awk '{print $1}')
+
+node "$CLI" --project "$PROJ_A" > "$SCRATCH_BASE/case-b.log" 2>&1
+AC5B_EXIT=$?
+check "AC-5(b)/exit" "CLI re-run exits 0" "$AC5B_EXIT"
+
+INDEX_AFTER_HASH=$(sha256sum "$PROJ_A/docs/decisions/INDEX.md" | awk '{print $1}')
+[ "$INDEX_BEFORE_HASH" = "$INDEX_AFTER_HASH" ] && AC5B_HASH=0 || AC5B_HASH=1
+check "AC-5(b)/idempotent" "INDEX.md byte-identical after re-run" "$AC5B_HASH"
+
+# Assert: still exactly one ADR file (no duplicate).
+ADR_COUNT_B=$(find "$PROJ_A/docs/decisions" -maxdepth 1 -name 'ADR-*.md' -type f | wc -l)
+[ "$ADR_COUNT_B" -eq 1 ] && AC5B_NODUP=0 || AC5B_NODUP=1
+check "AC-5(b)/nodup" "ADR file count remains 1 (no duplicate created), got $ADR_COUNT_B" "$AC5B_NODUP"
+
+echo
+
+# ── AC-5(c) — project with all rows already present → no-op ─────────────
+PROJ_C="$SCRATCH_BASE/case-c"
+mkdir -p "$PROJ_C/.forge/runs" "$PROJ_C/docs/decisions"
+
+# Pre-populate: one canonical ADR + matching INDEX, no staging.
+cat > "$PROJ_C/docs/decisions/ADR-0001-something-US-09.md" <<'EOF'
+---
+adr: 1
+status: "Accepted"
+story: "US-09"
+date: "2026-04-26"
+title: "Something"
+---
+
+# ADR-0001: Something
+
+## Context
+
+ctx
+
+## Decision
+
+dec
+
+## Consequences
+
+cons
+
+## Alternatives considered
+
+alts
+EOF
+
+# Write a PASS run record referencing US-09.
+cat > "$PROJ_C/.forge/runs/forge_evaluate-2026-04-26T00-00-00-cafe01.json" <<'EOF'
+{
+  "tool": "forge_evaluate",
+  "storyId": "US-09",
+  "evalVerdict": "PASS",
+  "verdict": "PASS",
+  "metrics": { "estimatedCostUsd": 0 }
+}
+EOF
+
+# Run once to materialise the INDEX (first-call effect — building the index
+# from the existing ADR file is expected; AC-5(c) measures stability against
+# RE-runs, not first-touch).
+node "$CLI" --project "$PROJ_C" > "$SCRATCH_BASE/case-c-priming.log" 2>&1
+INDEX_C_HASH_BEFORE=$(sha256sum "$PROJ_C/docs/decisions/INDEX.md" | awk '{print $1}')
+
+# Re-run: must be a byte-stable no-op.
+node "$CLI" --project "$PROJ_C" > "$SCRATCH_BASE/case-c.log" 2>&1
+AC5C_EXIT=$?
+check "AC-5(c)/exit" "CLI re-run on already-current project exits 0" "$AC5C_EXIT"
+
+INDEX_C_HASH_AFTER=$(sha256sum "$PROJ_C/docs/decisions/INDEX.md" | awk '{print $1}')
+[ "$INDEX_C_HASH_BEFORE" = "$INDEX_C_HASH_AFTER" ] && AC5C_HASH=0 || AC5C_HASH=1
+check "AC-5(c)/idempotent" "INDEX.md byte-identical across two consecutive re-runs" "$AC5C_HASH"
+
+# Assert: still no spurious 'no new decisions' row appended for US-09 (it has an ADR).
+NO_DEC_COUNT_C=$(grep -cE '^\| US-09 \| no new decisions \|' "$PROJ_C/docs/decisions/INDEX.md" || true)
+[ "$NO_DEC_COUNT_C" -eq 0 ] && AC5C_NODEC=0 || AC5C_NODEC=1
+check "AC-5(c)/no-spurious-row" "no 'no new decisions' row added when story already has an ADR" "$AC5C_NODEC"
+
+echo
+
+# ── Summary ──────────────────────────────────────────────────────────────
+echo "=== Summary ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "Failures:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+echo "All AC-5 sub-cases pass."
+exit 0

--- a/scripts/forge-adr-backfill.mjs
+++ b/scripts/forge-adr-backfill.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * forge-adr-backfill.mjs — re-run the ADR extractor against historical PASS
+ * run records to recover missing INDEX.md rows.
+ *
+ * Why: pre-v0.39.6 the extractor's stub-front-matter parser threw on YAML
+ * `|` literal block scalars (the natural form for multi-line ADR fields).
+ * The throw was silently swallowed by evaluate.ts, leaving INDEX.md without
+ * a row for any story whose PASS staged a multi-line stub. Consumers (e.g.
+ * monday-bot) need a way to recover without hand-editing INDEX.md.
+ *
+ * Mechanism: scan `<project>/.forge/runs/forge_evaluate-*.json` for PASS
+ * records, deduplicate by storyId, and call `processStory` from the built
+ * `dist/lib/adr-extractor.js` once per storyId. processStory rebuilds
+ * INDEX.md deterministically from disk on every call, so re-running on an
+ * already-current project is a byte-stable no-op (idempotency comes free).
+ *
+ * Reuses processStory rather than reimplementing — same canonicalisation
+ * rules, same numbering, same INDEX shape.
+ *
+ * Usage:
+ *   node scripts/forge-adr-backfill.mjs --project <path>
+ *   node scripts/forge-adr-backfill.mjs --help
+ *
+ * Exit codes:
+ *   0 — success (including no-op)
+ *   1 — input or runtime error (missing project, build missing, malformed record)
+ *   2 — usage error (missing/unknown flag)
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+
+const HELP = `forge-adr-backfill — re-run the ADR extractor against historical PASS records.
+
+Usage:
+  node scripts/forge-adr-backfill.mjs --project <path>
+  node scripts/forge-adr-backfill.mjs --help
+
+What it scans:
+  <project>/.forge/runs/forge_evaluate-*.json
+    PASS records with a 'storyId' field. One processStory call per unique storyId.
+
+What it writes:
+  <project>/docs/decisions/ADR-NNNN-*.md
+    For each storyId with remaining stubs at .forge/staging/adr/<storyId>/,
+    canonicalises them to numbered ADR files. (If staging was already cleared
+    by an earlier successful run, no new ADR files are written for that story.)
+  <project>/docs/decisions/INDEX.md
+    Rebuilt deterministically on every call from the on-disk ADR set.
+    Stories with no stubs and no existing ADR get a 'no new decisions' row.
+
+Idempotency:
+  Re-running on an already-current project is a no-op (INDEX.md byte-stable).
+
+Prerequisite:
+  The forge-harness build must be current: run \`npm run build\` in the
+  forge-harness repo before invoking this CLI. The CLI imports processStory
+  from dist/lib/adr-extractor.js.
+
+Exit codes:
+  0  success (including no-op)
+  1  input or runtime error (missing project path, build missing, malformed record)
+  2  usage error (missing required flag, unknown flag)
+`;
+
+function parseArgs(argv) {
+  let project = null;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--help" || a === "-h") return { help: true };
+    if (a === "--project") {
+      project = argv[++i];
+      if (!project || project.startsWith("--")) {
+        return { error: "Missing value for --project" };
+      }
+      continue;
+    }
+    return { error: `Unknown argument: ${a}` };
+  }
+  return { project };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    process.stdout.write(HELP);
+    process.exit(0);
+  }
+  if (args.error) {
+    process.stderr.write(`forge-adr-backfill: ${args.error}\n`);
+    process.stderr.write("Run with --help for usage.\n");
+    process.exit(2);
+  }
+  if (!args.project) {
+    process.stderr.write("forge-adr-backfill: missing required argument --project <path>\n");
+    process.stderr.write("Run with --help for usage.\n");
+    process.exit(2);
+  }
+
+  const projectPath = resolve(args.project);
+  if (!existsSync(projectPath) || !statSync(projectPath).isDirectory()) {
+    process.stderr.write(
+      `forge-adr-backfill: project path does not exist or is not a directory: ${projectPath}\n`,
+    );
+    process.exit(1);
+  }
+
+  // Load processStory from the built dist (sibling of this scripts/ dir).
+  const scriptPath = fileURLToPath(import.meta.url);
+  const repoRoot = resolve(dirname(scriptPath), "..");
+  const adrExtractorPath = join(repoRoot, "dist", "lib", "adr-extractor.js");
+  if (!existsSync(adrExtractorPath)) {
+    process.stderr.write(
+      `forge-adr-backfill: adr-extractor module not found at ${adrExtractorPath}\n`,
+    );
+    process.stderr.write("Run `npm run build` in the forge-harness repo first.\n");
+    process.exit(1);
+  }
+  const { processStory } = await import(pathToFileURL(adrExtractorPath).href);
+
+  // Scan run records for PASS storyIds.
+  const runsDir = join(projectPath, ".forge", "runs");
+  const storyIds = new Set();
+  if (existsSync(runsDir)) {
+    for (const name of readdirSync(runsDir)) {
+      if (!name.startsWith("forge_evaluate-") || !name.endsWith(".json")) continue;
+      let rec;
+      try {
+        rec = JSON.parse(readFileSync(join(runsDir, name), "utf-8"));
+      } catch (err) {
+        process.stderr.write(
+          `forge-adr-backfill: skipping malformed run record ${name}: ${err.message}\n`,
+        );
+        continue;
+      }
+      const verdict = rec.evalVerdict ?? rec.verdict;
+      if (verdict !== "PASS") continue;
+      if (typeof rec.storyId !== "string" || rec.storyId === "") continue;
+      storyIds.add(rec.storyId);
+    }
+  }
+
+  if (storyIds.size === 0) {
+    process.stdout.write("forge-adr-backfill: no PASS run records found. Nothing to backfill.\n");
+    process.exit(0);
+  }
+
+  const sorted = [...storyIds].sort();
+  process.stdout.write(
+    `forge-adr-backfill: ${sorted.length} stor${sorted.length === 1 ? "y" : "ies"} to process: ${sorted.join(", ")}\n`,
+  );
+
+  let newAdrCount = 0;
+  let noDecisionsAddedCount = 0;
+  for (const storyId of sorted) {
+    let result;
+    try {
+      result = processStory({ projectPath, storyId });
+    } catch (err) {
+      process.stderr.write(
+        `forge-adr-backfill: ${storyId} failed: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      process.exit(1);
+    }
+    newAdrCount += result.newAdrPaths.length;
+    if (result.appendedNoDecisionsRow) noDecisionsAddedCount++;
+    if (result.newAdrPaths.length > 0) {
+      process.stdout.write(
+        `  ${storyId}: created ${result.newAdrPaths.length} ADR file(s)\n`,
+      );
+    } else if (result.appendedNoDecisionsRow) {
+      process.stdout.write(`  ${storyId}: added no-decisions row\n`);
+    } else {
+      process.stdout.write(`  ${storyId}: no change\n`);
+    }
+  }
+  process.stdout.write(
+    `forge-adr-backfill: done. ${newAdrCount} ADR file(s) created, ${noDecisionsAddedCount} no-decisions row(s) added.\n`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  process.stderr.write(
+    `forge-adr-backfill: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/server/lib/adr-extractor.test.ts
+++ b/server/lib/adr-extractor.test.ts
@@ -178,7 +178,140 @@ describe("adr-extractor — duplicate-PASS idempotency (AC-C4 ADR dedup)", () =>
   });
 });
 
-// ── Test 4: malformed front-matter ───────────────────────────────────────
+// ── Test 4 (AC-1): YAML `|` literal block scalars ────────────────────────
+//
+// Reproduces the US-08 regression: subagents writing multi-line ADR fields
+// with YAML's `|` literal block scalar syntax (the natural way to express
+// multi-paragraph context/decision/consequences blocks). Before the W1 fix,
+// `parseStubFrontMatter` rejected any indented continuation line, throwing
+// at line 165-167 of adr-extractor.ts; the throw was silently swallowed by
+// evaluate.ts:442-446, leaving INDEX.md stale.
+
+describe("adr-extractor — YAML `|` literal block scalars (AC-1, real US-08 stub format)", () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "forge-adr-")); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("converts a stub with `|` block-scalar fields into a canonical ADR + INDEX row", () => {
+    // Mirrors monday-bot's actual US-08 stub format:
+    // .forge/staging/adr/US-08/add-slack-bolt-socket-mode.md
+    const dir = join(tmp, ".forge", "staging", "adr", "US-08");
+    mkdirSync(dir, { recursive: true });
+    const stubPath = join(dir, "add-slack-bolt-socket-mode.md");
+    writeFileSync(
+      stubPath,
+      [
+        "---",
+        "title: Adopt @slack/bolt with Socket Mode for the Slack adapter",
+        "story: US-08",
+        "context: |",
+        "  US-08 introduces the Slack-facing surface of monday-bot — handling @mention",
+        "  events and the /ask slash command, and posting Block Kit replies that include",
+        "  the answer text and per-citation source lines.",
+        "decision: |",
+        "  Add `@slack/bolt` (v4.x) as a runtime dependency and wire the adapter to use",
+        "  Socket Mode (`socketMode: true`, `appToken: <xapp-...>`).",
+        "consequences: |",
+        "  + Bundle gains `@slack/bolt` + transitive `@slack/web-api`, `@slack/socket-mode`.",
+        "  + Socket Mode means we never expose a public URL.",
+        "alternatives: |",
+        "  - `@slack/web-api` alone + a hand-rolled Socket Mode client: rejected.",
+        "  - HTTP Receiver (default Bolt): rejected — requires public ingress.",
+        "---",
+        "",
+        "(stub body — ignored by extractor)",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = processStory({
+      projectPath: tmp,
+      storyId: "US-08",
+      gitSha: "0123456789abcdef0123456789abcdef01234567",
+      today: "2026-04-27",
+    });
+
+    // (a) exactly one canonicalised ADR file
+    expect(result.newAdrPaths.length).toBe(1);
+    const adrPath = result.newAdrPaths[0];
+    expect(existsSync(adrPath)).toBe(true);
+    expect(adrPath).toMatch(/ADR-0001-adopt-slack-bolt-with-socket-mode-for-the-slack-adapter-US-08\.md$/);
+
+    // The canonical ADR's body preserves the multi-paragraph content as-is.
+    const adrText = readFileSync(adrPath, "utf-8");
+    expect(adrText).toContain("US-08 introduces the Slack-facing surface");
+    expect(adrText).toContain("Add `@slack/bolt` (v4.x) as a runtime dependency");
+    expect(adrText).toContain("Bundle gains `@slack/bolt`");
+    expect(adrText).toContain("HTTP Receiver (default Bolt): rejected");
+
+    // The validator approves it.
+    const v = validateAdr(adrPath);
+    expect(v.ok, v.output).toBe(true);
+
+    // (b) INDEX.md gains exactly one ADR row pointing at this story.
+    const indexText = readFileSync(result.indexPath, "utf-8");
+    const adrRows = indexText.split("\n").filter((l) => /^\| ADR-/.test(l));
+    expect(adrRows.length).toBe(1);
+    expect(adrRows[0]).toContain("ADR-0001");
+    expect(adrRows[0]).toContain("US-08");
+    expect(adrRows[0]).toContain("Adopt @slack/bolt with Socket Mode");
+
+    // (c) staging dir is gone.
+    expect(existsSync(join(tmp, ".forge", "staging", "adr", "US-08"))).toBe(false);
+
+    // (d) no spurious no-decisions row was appended on a story with stubs.
+    expect(result.appendedNoDecisionsRow).toBe(false);
+    const noDecRows = (indexText.match(/^\| US-08 \| no new decisions \|/gm) || []).length;
+    expect(noDecRows).toBe(0);
+  });
+
+  it("supports `>` folded block scalars (sibling form — joins lines with spaces)", () => {
+    const dir = join(tmp, ".forge", "staging", "adr", "US-09");
+    mkdirSync(dir, { recursive: true });
+    const stubPath = join(dir, "use-pgvector.md");
+    writeFileSync(
+      stubPath,
+      [
+        "---",
+        "title: Use pgvector for embeddings",
+        "story: US-09",
+        "context: >",
+        "  We need a vector store that lives next to relational data so we can",
+        "  filter by tenant id without crossing a network boundary.",
+        "decision: >",
+        "  Adopt pgvector v0.7 as a Postgres extension and store embeddings in a",
+        "  dedicated table.",
+        "consequences: >",
+        "  Adds a Postgres extension dependency; ops needs to install it on every",
+        "  environment.",
+        "alternatives: >",
+        "  Pinecone (rejected: separate infra, per-vector cost).",
+        "---",
+        "",
+        "body",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = processStory({
+      projectPath: tmp,
+      storyId: "US-09",
+      today: "2026-04-27",
+    });
+
+    expect(result.newAdrPaths.length).toBe(1);
+    const adrText = readFileSync(result.newAdrPaths[0], "utf-8");
+    // Folded scalar: continuation lines join with single spaces (no embedded newlines).
+    expect(adrText).toContain(
+      "We need a vector store that lives next to relational data so we can filter by tenant id without crossing a network boundary.",
+    );
+    expect(adrText).not.toContain("relational data so we can\nfilter");
+  });
+});
+
+// ── Test 5: malformed front-matter ───────────────────────────────────────
 
 describe("adr-extractor — malformed stub (AC-C6)", () => {
   let tmp: string;

--- a/server/lib/adr-extractor.ts
+++ b/server/lib/adr-extractor.ts
@@ -159,8 +159,14 @@ function parseStubFrontMatter(text: string, sourceLabel: string): StubFrontMatte
     );
   }
   const root: Record<string, string | number | null> = {};
-  for (const line of m[1].split("\n")) {
-    if (line.trim() === "" || line.trimStart().startsWith("#")) continue;
+  const fmLines = m[1].split("\n");
+  let i = 0;
+  while (i < fmLines.length) {
+    const line = fmLines[i];
+    if (line.trim() === "" || line.trimStart().startsWith("#")) {
+      i++;
+      continue;
+    }
     const indent = line.length - line.trimStart().length;
     if (indent !== 0) {
       throw new Error(`adr-extractor: stub ${sourceLabel} unexpected indented line: "${line}"`);
@@ -170,7 +176,46 @@ function parseStubFrontMatter(text: string, sourceLabel: string): StubFrontMatte
       throw new Error(`adr-extractor: stub ${sourceLabel} line missing ":" — "${line}"`);
     }
     const key = line.slice(0, colonIdx).trim();
-    root[key] = parseScalarValue(line.slice(colonIdx + 1).trim());
+    const rawValue = line.slice(colonIdx + 1).trim();
+
+    // YAML block scalar indicators: `|` (literal — preserves newlines) or
+    // `>` (folded — joins consecutive lines with a single space, blank lines
+    // become paragraph breaks). Optional chomp suffix (`+`/`-`) is accepted
+    // and treated as the default "clip" because every field is `.trim()`'d
+    // by `renderAdrFile` before emit, making chomp variants observationally
+    // identical for our use case.
+    const blockMatch = rawValue.match(/^([|>])([+-]?)$/);
+    if (blockMatch) {
+      const indicator = blockMatch[1];
+      i++;
+      const collected: string[] = [];
+      let blockIndent: number | null = null;
+      while (i < fmLines.length) {
+        const cont = fmLines[i];
+        if (cont.trim() === "") {
+          collected.push("");
+          i++;
+          continue;
+        }
+        const contIndent = cont.length - cont.trimStart().length;
+        if (contIndent === 0) break;
+        if (blockIndent === null) blockIndent = contIndent;
+        if (contIndent < blockIndent) break;
+        collected.push(cont.slice(blockIndent));
+        i++;
+      }
+      // Clip trailing blank lines (default chomp).
+      while (collected.length > 0 && collected[collected.length - 1] === "") {
+        collected.pop();
+      }
+      root[key] = indicator === "|"
+        ? collected.join("\n")
+        : foldFoldedScalar(collected);
+      continue;
+    }
+
+    root[key] = parseScalarValue(rawValue);
+    i++;
   }
   const required = ["title", "story", "context", "decision", "consequences", "alternatives"];
   for (const k of required) {
@@ -213,6 +258,29 @@ function parseStubFrontMatter(text: string, sourceLabel: string): StubFrontMatte
     out.supersededBy = v as number | null;
   }
   return out;
+}
+
+/**
+ * YAML folded scalar (`>`): join consecutive non-blank lines with a single
+ * space; blank lines become paragraph breaks. Mirrors libyaml's default fold
+ * behavior closely enough for our short prose fields.
+ */
+function foldFoldedScalar(lines: string[]): string {
+  const out: string[] = [];
+  let buf: string[] = [];
+  for (const l of lines) {
+    if (l === "") {
+      if (buf.length > 0) {
+        out.push(buf.join(" "));
+        buf = [];
+      }
+      out.push("");
+    } else {
+      buf.push(l);
+    }
+  }
+  if (buf.length > 0) out.push(buf.join(" "));
+  return out.join("\n");
 }
 
 function parseScalarValue(raw: string): string | number | null {

--- a/server/tools/evaluate-adr-emit.test.ts
+++ b/server/tools/evaluate-adr-emit.test.ts
@@ -1,0 +1,208 @@
+/**
+ * AC-2 integration test for the US-08 ADR-extractor regression (W1).
+ *
+ * Reproduces the bug end-to-end: when a story PASSes and a real ADR stub
+ * with multi-line YAML block scalars is staged, the post-PASS ADR-extractor
+ * must canonicalise it AND `RunRecord.generatedDocs.adrPaths` must carry the
+ * resulting path.
+ *
+ * Unlike `evaluate.test.ts`, this file deliberately does NOT mock
+ * `../lib/adr-extractor.js` — the real parser + processStory pipeline runs
+ * against a temp project on disk. Spec-generator IS mocked so the test
+ * doesn't depend on real LLM calls or `docs/generated/` writes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CallClaudeResult } from "../lib/anthropic.js";
+
+// Mock the evaluator: returns PASS for any storyId.
+vi.mock("../lib/evaluator.js", () => ({
+  evaluateStory: vi.fn(async (_plan: unknown, storyId: string) => ({
+    storyId,
+    verdict: "PASS" as const,
+    criteria: [{ id: "AC-01", status: "PASS" as const, evidence: "ok" }],
+  })),
+}));
+
+// Mock anthropic
+vi.mock("../lib/anthropic.js", () => ({
+  callClaude: vi.fn(),
+  extractJson: vi.fn((text: string) => JSON.parse(text)),
+}));
+
+// Mock codebase-scan
+vi.mock("../lib/codebase-scan.js", () => ({
+  scanCodebase: vi.fn(async () => "## Directory Structure\n```\nserver/\n```"),
+}));
+
+// Mock run-record: capture writes, keep helpers real.
+vi.mock("../lib/run-record.js", async () => {
+  const actual = await vi.importActual<typeof import("../lib/run-record.js")>(
+    "../lib/run-record.js",
+  );
+  return {
+    writeRunRecord: vi.fn(async () => {}),
+    canonicalizeEvalReport: actual.canonicalizeEvalReport,
+    computeSpecGenCostUsd: actual.computeSpecGenCostUsd,
+  };
+});
+
+// Mock spec-generator (real adr-extractor stays unmocked).
+vi.mock("../lib/spec-generator.js", () => ({
+  generateSpecForStory: vi.fn(
+    async (input: { projectPath: string; storyId: string }) => ({
+      specPath: `${input.projectPath}/docs/generated/TECHNICAL-SPEC.md`,
+      genTimestamp: "2026-04-27T00:00:00.000Z",
+      genTokens: { inputTokens: 0, outputTokens: 0 },
+      contracts: [],
+      bodyChanged: true,
+      warnings: [],
+    }),
+  ),
+}));
+
+// Mock run-context.
+vi.mock("../lib/run-context.js", async () => {
+  const { callClaude: mockedClaude } = await import("../lib/anthropic.js");
+
+  class MockRunContext {
+    _inputTokens = 0;
+    _outputTokens = 0;
+    cost = {
+      summarize: () => ({
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCostUsd: 0.001,
+        breakdown: [],
+        isOAuthAuth: false,
+      }),
+      recordUsage: vi.fn(),
+    };
+    progress = {
+      begin: vi.fn(),
+      complete: vi.fn(),
+      skip: vi.fn(),
+      fail: vi.fn(),
+      getResults: () => [],
+    };
+    audit = { log: vi.fn(async () => {}) };
+    toolName = "forge_evaluate";
+  }
+
+  return {
+    RunContext: MockRunContext,
+    trackedCallClaude: vi.fn(
+      async (
+        _ctx: unknown,
+        _stage: string,
+        _role: string,
+        options: unknown,
+      ): Promise<CallClaudeResult> => {
+        return await mockedClaude(
+          options as Parameters<typeof mockedClaude>[0],
+        );
+      },
+    ),
+  };
+});
+
+import { writeRunRecord } from "../lib/run-record.js";
+import { handleEvaluate } from "./evaluate.js";
+
+const mockedWriteRunRecord = vi.mocked(writeRunRecord);
+
+function makePlanJson(): string {
+  return JSON.stringify({
+    schemaVersion: "3.0.0",
+    stories: [
+      {
+        id: "US-08",
+        title: "Slack adapter",
+        acceptanceCriteria: [
+          { id: "AC-01", description: "Bot connects", command: "echo ok" },
+        ],
+      },
+    ],
+  });
+}
+
+describe("evaluate — post-PASS ADR-extractor integration (AC-2)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-evaluate-adr-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("populates RunRecord.generatedDocs.adrPaths when a story has a real multi-line stub staged", async () => {
+    // Arrange: stage a real ADR stub mirroring monday-bot's US-08 format
+    // (YAML `|` literal block scalars for multi-line fields).
+    const stagingDir = join(tmp, ".forge", "staging", "adr", "US-08");
+    mkdirSync(stagingDir, { recursive: true });
+    writeFileSync(
+      join(stagingDir, "add-slack-bolt-socket-mode.md"),
+      [
+        "---",
+        "title: Adopt @slack/bolt with Socket Mode for the Slack adapter",
+        "story: US-08",
+        "context: |",
+        "  US-08 introduces the Slack-facing surface of monday-bot.",
+        "  We need a Slack SDK that supports Socket Mode.",
+        "decision: |",
+        "  Add `@slack/bolt` (v4.x) as a runtime dependency.",
+        "consequences: |",
+        "  + Bundle gains `@slack/bolt` and transitive deps.",
+        "alternatives: |",
+        "  - HTTP Receiver: rejected — requires public ingress.",
+        "---",
+        "",
+        "body",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    // Act: run forge_evaluate against the temp project.
+    const result = await handleEvaluate({
+      storyId: "US-08",
+      planJson: makePlanJson(),
+      projectPath: tmp,
+    });
+
+    // Assert: the eval succeeded.
+    expect(result.isError).toBeUndefined();
+
+    // Assert: RunRecord was written with adrPaths populated.
+    expect(mockedWriteRunRecord).toHaveBeenCalledTimes(1);
+    const [recordedPath, record] = mockedWriteRunRecord.mock.calls[0];
+    expect(recordedPath).toBe(tmp);
+    expect(record.tool).toBe("forge_evaluate");
+    expect(record.evalVerdict).toBe("PASS");
+
+    // The bug: pre-W1 fix this would be `[]` because the parser threw on
+    // indented continuation lines and the catch at evaluate.ts:442-446
+    // silently swallowed it. Post-W1 fix: exactly one canonicalised ADR path.
+    expect(record.generatedDocs).toBeDefined();
+    expect(record.generatedDocs!.adrPaths).toHaveLength(1);
+    expect(record.generatedDocs!.adrPaths[0]).toMatch(
+      /ADR-0001-adopt-slack-bolt-with-socket-mode-for-the-slack-adapter-US-08\.md$/,
+    );
+
+    // Filesystem cross-check: the canonical ADR file exists, INDEX.md was
+    // written, and staging was cleaned up.
+    const decisionsDir = join(tmp, "docs", "decisions");
+    expect(existsSync(decisionsDir)).toBe(true);
+    const adrFiles = readdirSync(decisionsDir).filter((n) => /^ADR-\d{4}-/.test(n));
+    expect(adrFiles).toHaveLength(1);
+    expect(existsSync(join(decisionsDir, "INDEX.md"))).toBe(true);
+    expect(existsSync(stagingDir)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the regression that left `docs/decisions/INDEX.md` without a row for monday-bot's US-08 PASS run. The ADR-extractor's stub front-matter parser threw on YAML `|` (literal) and `>` (folded) block scalars — the natural form for multi-line decision/context/consequences fields. The throw was silently swallowed by `evaluate.ts`'s log-and-continue catch, so `RunRecord.generatedDocs.adrPaths` ended up empty and INDEX.md never got rebuilt with the new row.

**W1 — parser fix.** `parseStubFrontMatter` now recognises both block-scalar indicators:
- `|` literal — collect indented continuation lines, preserve newlines
- `>` folded — collect, then join consecutive non-blank lines with a single space (paragraph breaks at blank lines)

Both accept the optional chomp suffix (`+`/`-`); since `renderAdrFile` trims every field before emit, all chomp variants behave identically.

**W2 — backfill CLI.** New `scripts/forge-adr-backfill.mjs` lets consumers recover missed INDEX rows without hand-editing. It scans `<project>/.forge/runs/forge_evaluate-*.json` for PASS records, dedupes by storyId, and calls `processStory()` once per storyId. Idempotency comes free — `processStory` rebuilds INDEX deterministically from disk on every call.

## Test plan

- [x] `server/lib/adr-extractor.test.ts` — 2 new tests using the actual US-08 stub format (`|` literal) and sibling `>` folded form. Both fail pre-fix, pass post-fix.
- [x] `server/tools/evaluate-adr-emit.test.ts` (new) — end-to-end integration via `handleEvaluate` against a real temp project + real stub, asserts `record.generatedDocs.adrPaths.length === 1`.
- [x] `scripts/adr-backfill-acceptance.sh` — 11 sub-checks covering AC-5(a..c): PASS record + missing row → row added; re-run no-op; already-current project no-op.
- [x] `npm run test` — 977 unit/integration tests pass, 0 regressions.
- [x] `vitest run server/smoke/mcp-surface.test.ts` — 6 smoke tests pass.

Plan: [.ai-workspace/plans/2026-04-27-us08-adr-index-regression.md](https://github.com/ziyilam3999/forge-harness/blob/fix/us08-adr-index-regression/.ai-workspace/plans/2026-04-27-us08-adr-index-regression.md)

---
plan-refresh: no-op