### PR TITLE
fix: tighten extractCssRuleBody regex anchor against descendants

### DIFF
--- a/server/lib/dashboard-renderer.test.ts
+++ b/server/lib/dashboard-renderer.test.ts
@@ -1035,7 +1035,7 @@ describe("renderDashboardHtml — column-header gap (W7 / forge-harness #517)", 
     // selector concatenation regressions). Selector is followed by
     // optional whitespace then `{`.
     const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const re = new RegExp(`(^|[\\s,>+~])${escaped}\\s*\\{([^}]*)\\}`, "m");
+    const re = new RegExp(`(^|[\\n,>+~])${escaped}\\s*\\{([^}]*)\\}`, "m");
     const match = re.exec(css);
     if (!match) {
       throw new Error(`CSS rule for ${selector} not found in <style> block`);


### PR DESCRIPTION
Closes #519

Auto-fix by /housekeep Stage 4.

Tightened the left-anchor character class in `extractCssRuleBody` from `[\s,>+~]` to `[\n,>+~]`. Generic whitespace (`\s`) matched a literal space, which let descendant rules like `.story-card .col-count {` false-match when probing `.col-count` (the regex saw the space as a valid anchor). Restricting to newline keeps top-level rules matching (line-anchored in the inline stylesheet) and group-separator combinators (`,>+~`) intact, while descendant whitespace no longer counts as an anchor.