### PR TITLE
chore: release 0.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.40.1](https://github.com/ziyilam3999/forge-harness/compare/v0.40.0...v0.40.1) (2026-05-01)
+
+### Bug Fixes
+
+- set-e-safe exit-code capture in adr-backfill-acceptance.sh (#501) (#509)
+- dashboard column-header gap so count badges don't crowd labels (#517) (#518)
+- monday-bot W3+W4+W5 spec-generator fixes (#514, #515, #516) (#521)
+
 ## [0.40.0](https://github.com/ziyilam3999/forge-harness/compare/v0.39.6...v0.40.0) (2026-04-28)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-harness",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "type": "module",
   "description": "Composable AI primitives — plan, evaluate, generate, coordinate — as a local MCP server",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bumps `package.json` 0.40.0 → 0.40.1
- Prepends a v0.40.1 CHANGELOG entry (between the existing `## Unreleased` header and the `[0.40.0]` block) covering the three `fix:` commits since v0.40.0:
  - #509 — set-e-safe exit-code capture in adr-backfill-acceptance.sh
  - #518 — dashboard column-header gap so count badges don't crowd labels
  - #521 — monday-bot W3+W4+W5 spec-generator fixes

## Test plan

- [x] CHANGELOG follows the prior release format (compare-link header, `### Bug Fixes` section, three bullets matching merge-commit subjects)
- [x] package.json version matches CHANGELOG header
- [x] Diff is exactly two files (package.json + CHANGELOG.md) — pure metadata cut
- [ ] Tag `v0.40.1` + GitHub Release will be cut after this PR merges (Stage 8-9 of /ship)

## Context

Filed in response to monday-bot's audit mail `2026-05-01T0418-monday-to-forge-plan-v0401-tag-missing.md` catching three unreleased `fix:` commits sitting on top of v0.40.0 with no tag cut. forge-harness uses a manual `chore/release-X.Y.Z` PR pattern; there is no `release-please.yml`. The W3-W7 arc's executors each invoked `/ship` Stage 7 inside their own `fix:` PRs (which bumped within those PRs), but no second `chore: release` PR was opened to label master with a new tag — so master moved through `f3ebb6c → 029d113 → 6d4a176` while `package.json` stayed at `0.40.0`.

Plan: `.ai-workspace/plans/2026-05-01-v0401-release-tag-cut.md` (filed, /coherent-plan'd, user-approved).

---
plan-refresh: no-op