### PR TITLE
fix: obs: log corrupt run-record timestamps in readInProgressStoryIds

### DIFF
--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -342,7 +342,12 @@ export async function readInProgressStoryIds(
       typeof parsed.timestamp === "string" ? parsed.timestamp : "";
     if (!ts) continue;
     const tsMs = Date.parse(ts);
-    if (!Number.isFinite(tsMs)) continue;
+    if (!Number.isFinite(tsMs)) {
+      console.warn(
+        `forge: run-record ${file} has malformed timestamp ${JSON.stringify(ts)} (skipping)`,
+      );
+      continue;
+    }
     if (tsMs > briefMtimeMs) {
       out.add(storyId);
     }


### PR DESCRIPTION
Closes #491

Auto-fix by /housekeep Stage 4.

Added console.warn before the continue in readInProgressStoryIds, surfacing the file name + offending timestamp value when Number.isFinite(tsMs) is false.