### PR TITLE
fix: adr-backfill-acceptance.sh: drop dead 'mkdir -p tmp' line

### DIFF
--- a/scripts/adr-backfill-acceptance.sh
+++ b/scripts/adr-backfill-acceptance.sh
@@ -37,8 +37,6 @@ check() {
   fi
 }
 
-# Each scenario gets its own scratch project. tmp/ is gitignored.
-mkdir -p tmp
 SCRATCH_BASE="$(mktemp -d "${TMPDIR:-/tmp}/forge-adr-backfill-XXXXXX")"
 trap 'rm -rf "$SCRATCH_BASE"' EXIT
 


### PR DESCRIPTION
Closes #502

Auto-fix by /housekeep Stage 4.

Removed dead mkdir -p tmp line and the stale 'tmp/ is gitignored' comment. Scenarios use SCRATCH_BASE (mktemp -d).