### PR TITLE
fix(dashboard): host-aware auto-open marker (F2)

### DIFF
--- a/server/lib/dashboard-renderer.test.ts
+++ b/server/lib/dashboard-renderer.test.ts
@@ -895,8 +895,8 @@ describe("maybeAutoOpenBrowser — marker-on-spawn (#281)", () => {
     const calls: Array<{ op: string; args: unknown[] }> = [];
     const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     const io: AutoOpenIo = {
-      stat: async (p) => {
-        calls.push({ op: "stat", args: [p] });
+      readMarker: async (p) => {
+        calls.push({ op: "readMarker", args: [p] });
         throw enoent; // marker absent → proceed
       },
       openExternal: async (target) => {
@@ -906,6 +906,7 @@ describe("maybeAutoOpenBrowser — marker-on-spawn (#281)", () => {
       writeFile: async (p, d, e) => {
         calls.push({ op: "writeFile", args: [p, d, e] });
       },
+      hostnameOf: () => "test-host",
     };
 
     await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
@@ -919,9 +920,10 @@ describe("maybeAutoOpenBrowser — marker-on-spawn (#281)", () => {
     const calls: Array<{ op: string; args: unknown[] }> = [];
     const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     const io: AutoOpenIo = {
-      stat: async () => { throw enoent; },
+      readMarker: async () => { throw enoent; },
       openExternal: async (target) => { calls.push({ op: "openExternal", args: [target] }); },
       writeFile: async (p, d, e) => { calls.push({ op: "writeFile", args: [p, d, e] }); },
+      hostnameOf: () => "test-host",
     };
 
     await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
@@ -933,15 +935,16 @@ describe("maybeAutoOpenBrowser — marker-on-spawn (#281)", () => {
   });
 });
 
-describe("maybeAutoOpenBrowser — stat catch narrowing (#283 + #291)", () => {
+describe("maybeAutoOpenBrowser — marker read catch narrowing (#283 + #291)", () => {
   useAutoOpenEnvGate();
 
-  it("non-ENOENT stat error (e.g. EPERM) skips open and does NOT call openExternal or writeFile", async () => {
+  it("non-ENOENT marker-read error (e.g. EPERM) skips open and does NOT call openExternal or writeFile", async () => {
     const calls: Array<{ op: string }> = [];
     const io: AutoOpenIo = {
-      stat: async () => { throw Object.assign(new Error("EPERM"), { code: "EPERM" }); },
+      readMarker: async () => { throw Object.assign(new Error("EPERM"), { code: "EPERM" }); },
       openExternal: async () => { calls.push({ op: "openExternal" }); },
       writeFile: async () => { calls.push({ op: "writeFile" }); },
+      hostnameOf: () => "test-host",
     };
 
     await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
@@ -958,14 +961,15 @@ describe("maybeAutoOpenBrowser — stat catch narrowing (#283 + #291)", () => {
     // After the #291 widening (`if (code !== "ENOENT")`), undefined
     // also skips because undefined !== "ENOENT".
     const io: AutoOpenIo = {
-      stat: async () => { throw new Error("mystery stat failure"); },
+      readMarker: async () => { throw new Error("mystery read failure"); },
       openExternal: async () => { calls.push({ op: "openExternal" }); },
       writeFile: async () => { calls.push({ op: "writeFile" }); },
+      hostnameOf: () => "test-host",
     };
 
     await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
 
-    // No io other than stat must have been touched.
+    // No io other than readMarker must have been touched.
     expect(calls.length).toBe(0);
   });
 });
@@ -987,14 +991,141 @@ describe("maybeAutoOpenBrowser — env gate (#295)", () => {
   it("env var unset → no io calls at all (early return)", async () => {
     const calls: Array<{ op: string }> = [];
     const io: AutoOpenIo = {
-      stat: async () => { calls.push({ op: "stat" }); },
+      readMarker: async () => { calls.push({ op: "readMarker" }); return ""; },
       openExternal: async () => { calls.push({ op: "openExternal" }); },
       writeFile: async () => { calls.push({ op: "writeFile" }); },
+      hostnameOf: () => { calls.push({ op: "hostnameOf" }); return "test-host"; },
     };
 
     await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
 
     expect(calls.length).toBe(0);
+  });
+});
+
+describe("maybeAutoOpenBrowser — host-aware marker (F2)", () => {
+  // F2 fix (2026-05-08): the `.dashboard-opened` marker travels with `.forge/`
+  // when operators hand-copy state between machines. A bare-timestamp marker
+  // silently suppresses auto-open on the new host. The fix stamps the marker
+  // body with `host=<os.hostname()>` and gates suppression on host-match;
+  // legacy bare-timestamp markers are treated as foreign + rewritten in the
+  // new format. One structured stderr line per legacy-rewrite for telemetry.
+  useAutoOpenEnvGate();
+
+  it("AC-3 host-match: marker carrying current host suppresses auto-open (no openExternal call)", async () => {
+    const calls: Array<{ op: string }> = [];
+    const io: AutoOpenIo = {
+      readMarker: async () => "host=mac-current\nopened=2026-05-08T12:00:00.000Z\n",
+      openExternal: async () => { calls.push({ op: "openExternal" }); },
+      writeFile: async () => { calls.push({ op: "writeFile" }); },
+      hostnameOf: () => "mac-current",
+    };
+
+    await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
+
+    // Same-host marker — open MUST be suppressed (the historical behavior).
+    expect(calls.some((c) => c.op === "openExternal")).toBe(false);
+    expect(calls.some((c) => c.op === "writeFile")).toBe(false);
+  });
+
+  it("AC-4 host-mismatch: marker from a different host opens the dashboard AND rewrites the marker with current host", async () => {
+    const calls: Array<{ op: string; args: unknown[] }> = [];
+    const io: AutoOpenIo = {
+      readMarker: async () =>
+        "host=windows-old\nopened=2026-05-01T08:00:00.000Z\n",
+      openExternal: async (target) => { calls.push({ op: "openExternal", args: [target] }); },
+      writeFile: async (p, d, e) => { calls.push({ op: "writeFile", args: [p, d, e] }); },
+      hostnameOf: () => "mac-current",
+    };
+
+    await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
+
+    // Open AND rewrite, in that order.
+    const opOrder = calls.map((c) => c.op);
+    expect(opOrder).toEqual(["openExternal", "writeFile"]);
+
+    // The rewritten marker carries the CURRENT host (not the foreign one).
+    const writeArgs = calls.find((c) => c.op === "writeFile")!.args;
+    const writtenBody = String(writeArgs[1]);
+    expect(writtenBody).toContain("host=mac-current");
+    expect(writtenBody).not.toContain("host=windows-old");
+    // And it carries an `opened=` line with an ISO timestamp.
+    expect(writtenBody).toMatch(/opened=\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("AC-5 legacy-format: bare-timestamp marker (v0.40.2 and earlier) opens, rewrites, AND emits one structured stderr telemetry line", async () => {
+    const calls: Array<{ op: string; args: unknown[] }> = [];
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const legacyBody = "2026-05-01T08:00:00.000Z";
+    const io: AutoOpenIo = {
+      readMarker: async () => legacyBody,
+      openExternal: async (target) => { calls.push({ op: "openExternal", args: [target] }); },
+      writeFile: async (p, d, e) => { calls.push({ op: "writeFile", args: [p, d, e] }); },
+      hostnameOf: () => "mac-current",
+    };
+
+    await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
+
+    // Open + rewrite happened.
+    expect(calls.map((c) => c.op)).toEqual(["openExternal", "writeFile"]);
+
+    // The rewritten marker is in the new host-stamped format.
+    const writtenBody = String(calls.find((c) => c.op === "writeFile")!.args[1]);
+    expect(writtenBody).toContain("host=mac-current");
+    expect(writtenBody).toMatch(/opened=\d{4}-\d{2}-\d{2}T/);
+
+    // Exactly ONE structured telemetry line emitted, JSON-grep-friendly.
+    const telemetryCalls = errorSpy.mock.calls.filter((args) =>
+      typeof args[0] === "string" &&
+      (args[0] as string).startsWith("forge.dashboard.marker.legacy_rewrite:"),
+    );
+    expect(telemetryCalls).toHaveLength(1);
+    // Payload is parseable JSON with the expected keys.
+    const payloadText = (telemetryCalls[0][0] as string).slice(
+      "forge.dashboard.marker.legacy_rewrite: ".length,
+    );
+    const payload = JSON.parse(payloadText) as { oldTimestamp: string; newHost: string };
+    expect(payload.oldTimestamp).toBe(legacyBody);
+    expect(payload.newHost).toBe("mac-current");
+  });
+
+  it("F2 host-stamped marker on first open (cold start, no marker present) writes the new format with current host", async () => {
+    // ENOENT branch — marker absent → first open. Must write the new format,
+    // NOT the legacy bare-timestamp format. Guards against a regression where
+    // the writer drops `host=` for first-write-on-virgin-state.
+    const calls: Array<{ op: string; args: unknown[] }> = [];
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    const io: AutoOpenIo = {
+      readMarker: async () => { throw enoent; },
+      openExternal: async (target) => { calls.push({ op: "openExternal", args: [target] }); },
+      writeFile: async (p, d, e) => { calls.push({ op: "writeFile", args: [p, d, e] }); },
+      hostnameOf: () => "mac-current",
+    };
+
+    await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
+
+    const writtenBody = String(calls.find((c) => c.op === "writeFile")!.args[1]);
+    expect(writtenBody).toContain("host=mac-current");
+    expect(writtenBody).toMatch(/opened=\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("F2 cold-start (ENOENT) does NOT emit the legacy_rewrite telemetry line (only legacy bodies trigger it)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    const io: AutoOpenIo = {
+      readMarker: async () => { throw enoent; },
+      openExternal: async () => {},
+      writeFile: async () => {},
+      hostnameOf: () => "mac-current",
+    };
+
+    await maybeAutoOpenBrowser(FIXTURE_PROJECT_ROOT, io);
+
+    const telemetryCalls = errorSpy.mock.calls.filter((args) =>
+      typeof args[0] === "string" &&
+      (args[0] as string).startsWith("forge.dashboard.marker.legacy_rewrite:"),
+    );
+    expect(telemetryCalls).toHaveLength(0);
   });
 });
 

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -30,6 +30,7 @@
 
 import { writeFile, rename, mkdir, readFile, readdir, stat } from "node:fs/promises";
 import { spawn } from "node:child_process";
+import { hostname } from "node:os";
 import { join, basename } from "node:path";
 import type {
   PhaseTransitionBrief,
@@ -1528,15 +1529,24 @@ export async function writeDashboardHtml(
  * Injectable I/O seam for the auto-open path — separate from `DashboardIo`
  * so tests that mock the atomic-write contract don't have to stub the
  * auto-open-only fields. Production callers use `DEFAULT_AUTO_OPEN_IO`.
+ *
+ * `readMarker` returns the marker file body as a UTF-8 string OR throws an
+ * error with `code === "ENOENT"` when the marker is absent. The host-aware
+ * gate (F2) parses the body to extract the `host=` line; existence-only
+ * stat was insufficient because the marker body now carries hostname state.
+ *
+ * `hostnameOf` is a 0-arg getter (test seam) so unit tests can deterministically
+ * assert host-match vs host-mismatch behavior without mocking `node:os` globally.
  */
 export interface AutoOpenIo {
-  stat: (path: string) => Promise<void>;
+  readMarker: (path: string) => Promise<string>;
   openExternal: (target: string) => Promise<void>;
   writeFile: (path: string, data: string, encoding: "utf-8") => Promise<void>;
+  hostnameOf: () => string;
 }
 
 const DEFAULT_AUTO_OPEN_IO: AutoOpenIo = {
-  stat: (p) => stat(p).then(() => undefined),
+  readMarker: (p) => readFile(p, "utf-8"),
   openExternal: (target) =>
     new Promise<void>((resolve, reject) => {
       const child =
@@ -1552,10 +1562,46 @@ const DEFAULT_AUTO_OPEN_IO: AutoOpenIo = {
       child.once("error", (err) => reject(err));
     }),
   writeFile: (p, d, e) => writeFile(p, d, e),
+  hostnameOf: () => hostname(),
 };
 
 /**
- * Open the dashboard in the user's default browser — env-gated, one-shot.
+ * Parse the marker body and extract the host token (or `null` for legacy /
+ * malformed bodies). The marker format (F2, 2026-05-08+):
+ *
+ *     host=<os.hostname()>
+ *     opened=<iso-timestamp>
+ *
+ * Legacy markers (v0.40.2 and earlier) carried only the ISO timestamp on a
+ * single line. Those bodies have no `host=` prefix → returns `null` so the
+ * caller can treat them as foreign + rewrite in the new format.
+ *
+ * Whitespace-tolerant: leading/trailing whitespace on each line is stripped
+ * before the prefix check. Empty bodies → `null`.
+ */
+function parseMarkerHost(body: string): string | null {
+  for (const line of body.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("host=")) {
+      const value = trimmed.slice("host=".length).trim();
+      return value.length > 0 ? value : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the new-format marker body for a given host + ISO timestamp.
+ * Single locus per F66 — every writer goes through this helper so the
+ * format stays consistent across first-write + legacy-rewrite paths.
+ */
+function formatMarkerBody(host: string, openedIso: string): string {
+  return `host=${host}\nopened=${openedIso}\n`;
+}
+
+/**
+ * Open the dashboard in the user's default browser — env-gated, host-aware,
+ * one-shot per host.
  *
  * Gates (both must hold):
  *   1. `FORGE_DASHBOARD_AUTO_OPEN=1` in the environment (opt-in; default off
@@ -1563,16 +1609,33 @@ const DEFAULT_AUTO_OPEN_IO: AutoOpenIo = {
  *      spawn a browser). The env var is re-read on each invocation — toggling
  *      `FORGE_DASHBOARD_AUTO_OPEN` mid-process takes effect on the next call
  *      (per-invocation check, not a startup-time snapshot). Issue #303.
- *   2. Marker `.forge/.dashboard-opened` must be absent. First successful
- *      open writes the marker; subsequent renders are no-ops. Delete the
- *      marker to re-open the tab (e.g. after closing it accidentally).
+ *   2. Marker `.forge/.dashboard-opened` must be absent OR carry a `host=`
+ *      line that does NOT match `os.hostname()`. First successful open
+ *      writes the marker stamped with the current host; subsequent renders
+ *      on the same host are no-ops. Delete the marker to re-open the tab
+ *      (e.g. after closing it accidentally).
+ *
+ * Host-aware gate (F2, 2026-05-08+): the marker body now carries
+ * `host=<hostname>\nopened=<iso>\n` instead of a bare ISO timestamp. When
+ * the parsed host matches the current host the open is suppressed (the
+ * historical behavior for same-host renders). When the parsed host differs
+ * — or the marker uses the legacy ISO-only format with no `host=` line —
+ * the marker is treated as foreign, the dashboard opens, and the marker is
+ * rewritten in the new format. This unblocks operators who hand-copy
+ * `.forge/` between machines as part of cross-machine migration: the
+ * stale marker no longer suppresses auto-open on the new host.
+ *
+ * Legacy-format compatibility: markers without a `host=` line (the
+ * v0.40.2-and-earlier format) trigger one open + rewrite. A single
+ * structured stderr line `forge.dashboard.marker.legacy_rewrite: {...}`
+ * is emitted per legacy-rewrite for ops visibility (adoption telemetry).
  *
  * The marker is only written AFTER the child process emits its `"spawn"`
  * event — if the spawn fails (e.g. `xdg-open` missing on a headless box),
  * no marker lands and the next render re-attempts. Issue #281.
  *
- * The `stat` catch treats **only** `ENOENT` as "marker absent, proceed to
- * open". Any other error — including errors without a `code` property —
+ * The marker-read catch treats **only** `ENOENT` as "marker absent, proceed
+ * to open". Any other error — including errors without a `code` property —
  * is logged and the render skips auto-open for this tick. This prevents
  * EPERM/EIO (or a non-Node-FS rejection) from being silently re-interpreted
  * as "no marker yet" and re-opening a tab on every render. Issue #283 +
@@ -1594,9 +1657,25 @@ export async function maybeAutoOpenBrowser(
   if (process.env.FORGE_DASHBOARD_AUTO_OPEN !== "1") return;
 
   const markerPath = join(projectPath, ".forge", ".dashboard-opened");
+  const currentHost = io.hostnameOf();
+
+  // Tracks whether this open is a legacy-format rewrite — if so, emit one
+  // structured stderr telemetry line after the rewrite succeeds.
+  let legacyRewriteBody: string | null = null;
+
   try {
-    await io.stat(markerPath);
-    return;
+    const body = await io.readMarker(markerPath);
+    const markerHost = parseMarkerHost(body);
+    if (markerHost === currentHost) {
+      // Same-host marker — historical no-op path (open suppressed).
+      return;
+    }
+    if (markerHost === null) {
+      // Legacy ISO-only or malformed body — treat as foreign + rewrite.
+      // Stash the original body for the telemetry line below.
+      legacyRewriteBody = body;
+    }
+    /* host mismatch (foreign machine) OR legacy-format → open + rewrite */
   } catch (err) {
     // Defensive typeof guard per #300: a non-object throw (`throw "string"`,
     // `throw null`, or `throw 42`) must not trigger a property read on a
@@ -1612,7 +1691,7 @@ export async function maybeAutoOpenBrowser(
       // marker state safely; skip open". This matches the spirit of
       // #283 (#291 widening) + #300 (defensive typeof guard).
       console.error(
-        "forge: dashboard auto-open stat failed (continuing):",
+        "forge: dashboard auto-open marker read failed (continuing):",
         err instanceof Error ? err.message : String(err),
       );
       return;
@@ -1623,7 +1702,20 @@ export async function maybeAutoOpenBrowser(
   try {
     const dashboardPath = join(projectPath, ".forge", "dashboard.html");
     await io.openExternal(dashboardPath);
-    await io.writeFile(markerPath, new Date().toISOString(), "utf-8");
+    const openedIso = new Date().toISOString();
+    await io.writeFile(markerPath, formatMarkerBody(currentHost, openedIso), "utf-8");
+    if (legacyRewriteBody !== null) {
+      // Single structured stderr line per legacy-rewrite event for
+      // adoption telemetry. JSON-shaped payload so ops greppers can
+      // parse without ad-hoc regexes. The `oldTimestamp` field carries
+      // the legacy body verbatim (whitespace-trimmed) — typically the
+      // ISO timestamp from v0.40.2-and-earlier markers.
+      const payload = JSON.stringify({
+        oldTimestamp: legacyRewriteBody.trim(),
+        newHost: currentHost,
+      });
+      console.error(`forge.dashboard.marker.legacy_rewrite: ${payload}`);
+    }
   } catch (err) {
     console.error(
       "forge: dashboard auto-open failed (continuing):",


### PR DESCRIPTION
## Summary

Per plan `.ai-workspace/plans/2026-05-08-forge-harness-followups-from-macbook-monday.md` item **F2** — `.forge/.dashboard-opened` marker is project-scoped only. When operators hand-copy `.forge/` between machines (a documented cross-machine migration step), the stale marker travels with it and silently suppresses dashboard auto-open on the new host even when `FORGE_DASHBOARD_AUTO_OPEN=1` is correctly set.

**Fix shape** (matches operator's option A from the macbook-monday audit):

- **Marker body now host-stamped** — `host=<os.hostname()>\nopened=<iso>\n` instead of a bare ISO timestamp.
- **Read-side gate** — suppress auto-open ONLY when the parsed `host=` matches `os.hostname()`. Host mismatch OR legacy-format markers (no `host=` line) are treated as foreign: open + rewrite in the new format.
- **Legacy-format compatibility** — markers without a `host=` line (v0.40.2-and-earlier format) trigger one open + rewrite. No breaking change for existing operators.
- **Telemetry** — one structured stderr line per legacy-rewrite event: `forge.dashboard.marker.legacy_rewrite: {"oldTimestamp":"...","newHost":"..."}` (single line, JSON-grep-friendly).
- **Single-locus discipline (F66)** — host-gate logic lives in `maybeAutoOpenBrowser` + two colocated helpers (`parseMarkerHost`, `formatMarkerBody`) inside `dashboard-renderer.ts`.

`AutoOpenIo` seam grows a `readMarker` method (replaces `stat`) + `hostnameOf` (test-injectable hostname) so the host-gate logic is fully unit-testable without filesystem or `node:os` mocks.

## Test plan

Verified against the binary AC in the plan:

- [x] **AC-1** `npm run build` passes (clean tsc).
- [x] **AC-2** `npx vitest run server/lib/dashboard-renderer.test.ts` — **46 tests pass**.
- [x] **AC-3** (host-match suppresses) — new test asserts `openExternal` is NOT called when marker `host=` equals current hostname.
- [x] **AC-4** (host-mismatch opens + rewrites) — new test asserts `openExternal` then `writeFile` (in order), and the rewritten body carries the *current* host (not the foreign one).
- [x] **AC-5** (legacy-format opens + rewrites + telemetry) — new test asserts open + rewrite happen on a bare-ISO body AND exactly one `forge.dashboard.marker.legacy_rewrite:` stderr line is emitted with parseable JSON `{oldTimestamp, newHost}`.
- [x] **AC-6** No out-of-scope edits. `git diff origin/master -- 'server/tools/evaluate.ts' 'server/lib/run-record.ts' 'server/lib/generator.ts' 'server/lib/codebase-scan.ts' 'docs/'` is empty.
- [x] **AC-7** `npx vitest run` full suite — **1032/1032 pass**.

Two extra tests guard the cold-start (ENOENT) branch — confirms the new format is written on a virgin `.forge/` AND that the telemetry line fires only on legacy-rewrite (not on cold-start).

Existing `#281` / `#283` / `#291` / `#295` cases updated to the new `AutoOpenIo` shape.

## Cairn references

- 2026-05-05 windows-only-tier-b lesson — same class of bug (operator-managed cross-machine state needs host-awareness).
- F66 — single-CODE-locus discipline (host-gate logic stays in one symbol).