### PR TITLE
fix(evaluate): un-swallow spec-gen failures (F4)

### DIFF
--- a/server/lib/run-record.test.ts
+++ b/server/lib/run-record.test.ts
@@ -195,7 +195,33 @@ describe("GeneratedDocsSchema (AC-10) — warnings is a typed array, default []"
     const noVocab = { kind: "no-vocabulary", filesScanned: 0 };
     const parsed = SpecGeneratorWarningSchema.parse(noVocab);
     expect(parsed.kind).toBe("no-vocabulary");
-    expect(parsed.filesScanned).toBe(0);
+    if (parsed.kind === "no-vocabulary") {
+      expect(parsed.filesScanned).toBe(0);
+    }
+  });
+
+  it("parses a 'spec-gen-failed' warning (F4 — un-swallow)", () => {
+    const failed = {
+      kind: "spec-gen-failed",
+      message: "synthetic crash from generateSpecForStory",
+    };
+    const parsed = SpecGeneratorWarningSchema.parse(failed);
+    expect(parsed.kind).toBe("spec-gen-failed");
+    if (parsed.kind === "spec-gen-failed") {
+      expect(parsed.message).toBe("synthetic crash from generateSpecForStory");
+    }
+  });
+
+  it("parses a 'spec-gen-skipped-on-pass' warning (F4 — PASS-incomplete gate)", () => {
+    const skipped = {
+      kind: "spec-gen-skipped-on-pass",
+      message: "PASS verdict but spec-generator threw",
+    };
+    const parsed = SpecGeneratorWarningSchema.parse(skipped);
+    expect(parsed.kind).toBe("spec-gen-skipped-on-pass");
+    if (parsed.kind === "spec-gen-skipped-on-pass") {
+      expect(parsed.message).toBe("PASS verdict but spec-generator threw");
+    }
   });
 
   it("parses a generatedDocs whose warnings array carries a 'no-vocabulary' entry", () => {

--- a/server/lib/run-record.ts
+++ b/server/lib/run-record.ts
@@ -182,6 +182,17 @@ export interface RunRecord {
  *   - "no-vocabulary": grounding was lenient because no source vocabulary
  *     could be built (empty/unparseable affectedPaths). The spec was written
  *     verbatim without strips.
+ *   - "spec-gen-failed": the spec-generator call itself threw (LLM error,
+ *     filesystem write failure, schema-validation throw, etc). Was previously
+ *     swallowed silently to stderr — F4 fix surfaces it on both the run
+ *     record's `generatedDocs.warnings` AND the MCP top-level
+ *     `specGenWarnings`. `message` is the truncated `Error.message` for
+ *     consumer triage (no stack — error-class warning, not a debug payload).
+ *   - "spec-gen-skipped-on-pass": the run is structurally incomplete — PASS
+ *     verdict + synthesized-fallback `generatedDocs` (specPath:"" because
+ *     spec-gen failed but the ADR extractor produced canonical paths
+ *     downstream). Without this marker the consumer would see PASS + empty
+ *     specPath silently. F4 fix.
  */
 export type SpecGeneratorWarning =
   | {
@@ -199,6 +210,14 @@ export type SpecGeneratorWarning =
   | {
       kind: "no-vocabulary";
       filesScanned: number;
+    }
+  | {
+      kind: "spec-gen-failed";
+      message: string;
+    }
+  | {
+      kind: "spec-gen-skipped-on-pass";
+      message: string;
     };
 
 /**
@@ -224,6 +243,14 @@ export const SpecGeneratorWarningSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("no-vocabulary"),
     filesScanned: z.number().int().nonnegative(),
+  }),
+  z.object({
+    kind: z.literal("spec-gen-failed"),
+    message: z.string(),
+  }),
+  z.object({
+    kind: z.literal("spec-gen-skipped-on-pass"),
+    message: z.string(),
   }),
 ]);
 

--- a/server/tools/evaluate-grounding.test.ts
+++ b/server/tools/evaluate-grounding.test.ts
@@ -171,7 +171,7 @@ describe("forge_evaluate (story) — v0.38.0 grounding observability surface", (
     expect(record.generatedDocs!.warnings).toEqual(result.specGenWarnings);
   });
 
-  it("AC-6: spec-gen failure path still emits an empty specGenWarnings (field present)", async () => {
+  it("AC-6 / F4: spec-gen failure path surfaces typed warnings on the MCP top-level response", async () => {
     // Force spec-gen to fail.
     const spec = await import("../lib/spec-generator.js");
     vi.mocked(spec.generateSpecForStory).mockRejectedValueOnce(new Error("boom"));
@@ -185,7 +185,20 @@ describe("forge_evaluate (story) — v0.38.0 grounding observability surface", (
       planJson: planJsonNoBuildPrefix(),
       projectPath: "/some/path",
     });
-    expect(result.specGenWarnings).toEqual([]);
+
+    // F4 fix — previously this asserted `[]` (the silent-swallow path).
+    // Now the failure surfaces as `spec-gen-failed` + `spec-gen-skipped-on-pass`.
+    expect(result.specGenWarnings).toBeDefined();
+    expect(result.specGenWarnings!.length).toBeGreaterThanOrEqual(2);
+    const kinds = result.specGenWarnings!.map((w) => w.kind);
+    expect(kinds).toContain("spec-gen-failed");
+    expect(kinds).toContain("spec-gen-skipped-on-pass");
+
+    // Both surfaces carry the same warnings (P64).
+    expect(mockedWriteRunRecord).toHaveBeenCalledTimes(1);
+    const record = mockedWriteRunRecord.mock.calls[0][1];
+    expect(record.generatedDocs).toBeDefined();
+    expect(record.generatedDocs!.warnings).toEqual(result.specGenWarnings);
   });
 
   it("AC-9: detectSharedBuildPrefix is invoked + result is byte-stable across calls", async () => {

--- a/server/tools/evaluate.test.ts
+++ b/server/tools/evaluate.test.ts
@@ -468,7 +468,7 @@ describe("handleStoryEval — v0.36.0 Phase B spec-generator integration", () =>
     expect(mockedGenerateSpec).not.toHaveBeenCalled();
   });
 
-  it("swallows spec-generator failure and still writes the RunRecord (verdict not masked)", async () => {
+  it("F4 — surfaces spec-generator failure as typed warnings on BOTH the run record and the MCP top-level response (verdict not masked)", async () => {
     mockedGenerateSpec.mockRejectedValueOnce(new Error("synthetic spec-gen crash"));
     mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport({ verdict: "PASS" }));
 
@@ -478,13 +478,36 @@ describe("handleStoryEval — v0.36.0 Phase B spec-generator integration", () =>
       projectPath: "/some/path",
     });
 
+    // Eval verdict still surfaced — the doc-gen hiccup MUST NOT mask it.
     expect(result.isError).toBeUndefined();
     expect(mockedGenerateSpec).toHaveBeenCalledTimes(1);
     expect(mockedWriteRunRecord).toHaveBeenCalledTimes(1);
     const record = mockedWriteRunRecord.mock.calls[0][1];
-    // verdict still surfaced, generatedDocs absent
     expect(record.evalVerdict).toBe("PASS");
-    expect(record.generatedDocs).toBeUndefined();
+
+    // F4 fix — `generatedDocs` is now synthesised as a structurally-incomplete
+    // envelope (specPath:"") carrying the failure warnings. Previously this
+    // was silently `undefined` — the bug. The envelope is the on-disk surface
+    // for the warnings; the MCP top-level `specGenWarnings` is the parallel
+    // surface (P64 producer/consumer seam).
+    expect(record.generatedDocs).toBeDefined();
+    expect(record.generatedDocs!.specPath).toBe("");
+    expect(record.generatedDocs!.warnings).toHaveLength(2);
+
+    const onDiskKinds = record.generatedDocs!.warnings.map((w) => w.kind);
+    expect(onDiskKinds).toContain("spec-gen-failed");
+    expect(onDiskKinds).toContain("spec-gen-skipped-on-pass");
+
+    const failedWarning = record.generatedDocs!.warnings.find(
+      (w) => w.kind === "spec-gen-failed",
+    );
+    expect(failedWarning).toBeDefined();
+    if (failedWarning && failedWarning.kind === "spec-gen-failed") {
+      expect(failedWarning.message).toBe("synthetic spec-gen crash");
+    }
+
+    // P64 — the MCP top-level surface MUST carry the same warnings.
+    expect(result.specGenWarnings).toEqual(record.generatedDocs!.warnings);
   });
 });
 

--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -379,6 +379,15 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
     // `writeRunRecord`).
     let generatedDocs: NonNullable<RunRecord["generatedDocs"]> | undefined;
     if (report.verdict === "PASS") {
+      // F4 fix — when the spec-generator throws, mint typed warnings that
+      // surface on BOTH the on-disk run record's `generatedDocs.warnings`
+      // AND the MCP top-level `specGenWarnings` (P64 producer/consumer seam,
+      // P44 loud-failure). Previously the catch path here logged to stderr
+      // only, leaving consumers unable to distinguish "spec-gen ran cleanly"
+      // from "spec-gen exploded silently" — the bug macbook-monday filed
+      // against US-08+. The new warnings are appended to whatever the
+      // spec-generator itself produced (e.g. `no-vocabulary`,
+      // `stripped-unknown-identifier`).
       try {
         // v0.36.x grounding: surface the story's affectedPaths to the
         // spec-generator so it can extract a source-vocabulary and ground
@@ -400,14 +409,40 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
           contracts: spec.contracts,
           warnings: spec.warnings ?? [],
         };
-        // v0.38.0 I3: capture warnings reference for the top-level response.
-        // Same array as `generatedDocs.warnings` so the MCP top-level field
-        // is byte-identical to the on-disk record.
-        storyEvalSpecGenWarnings = generatedDocs.warnings;
       } catch (err) {
+        // F4 fix — un-swallow: previously this catch only logged to stderr,
+        // leaving `TECHNICAL-SPEC.md` silently stale on every PASS where
+        // generation threw. Now we mint a typed `spec-gen-failed` warning
+        // and synthesise a `generatedDocs` envelope to carry it on disk.
+        // The envelope is also a placeholder for the ADR extractor below
+        // (its `adrPaths` populates onto this same envelope). Consumers
+        // detect the failure via either (a) the typed warning kind on
+        // `generatedDocs.warnings` or (b) the structural marker
+        // (`specPath === ""` + spec-gen-failed warning).
+        const message = err instanceof Error ? err.message : String(err);
         console.error(
-          `forge_evaluate: spec-generator failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+          `forge_evaluate: spec-generator failed (continuing with warning surfaced): ${message}`,
         );
+        // Structural marker: PASS + specPath:"" + `spec-gen-failed` is an
+        // incomplete run record. The `spec-gen-skipped-on-pass` warning
+        // makes the structural-incompleteness explicit so consumers don't
+        // have to infer it from `specPath === ""`.
+        const failureWarnings: SpecGeneratorWarning[] = [
+          { kind: "spec-gen-failed", message },
+          {
+            kind: "spec-gen-skipped-on-pass",
+            message:
+              "PASS verdict but spec-generator threw; TECHNICAL-SPEC.md was NOT regenerated for this story",
+          },
+        ];
+        generatedDocs = {
+          specPath: "",
+          adrPaths: [], // populated below by Phase C's ADR extractor
+          genTimestamp: new Date().toISOString(),
+          genTokens: { inputTokens: 0, outputTokens: 0 },
+          contracts: [],
+          warnings: failureWarnings,
+        };
       }
 
       // v0.36.0 Phase C (AC-C1..C6): canonicalise any subagent-staged ADR
@@ -424,26 +459,19 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
         });
         if (generatedDocs) {
           generatedDocs.adrPaths = adr.newAdrPaths;
-        } else if (adr.newAdrPaths.length > 0) {
-          // spec-generator failed but ADR-extractor produced canonical files.
-          // Synthesise a minimal generatedDocs so the ADR work is still
-          // surfaced on the RunRecord. Empty adrPaths here means "nothing
-          // to record" — leave generatedDocs undefined so the existing
-          // contract holds (a spec-gen failure with no ADRs ⇒ no
-          // generatedDocs field).
-          generatedDocs = {
-            specPath: "",
-            adrPaths: adr.newAdrPaths,
-            genTimestamp: new Date().toISOString(),
-            genTokens: { inputTokens: 0, outputTokens: 0 },
-            contracts: [],
-            warnings: [],
-          };
         }
       } catch (err) {
         console.error(
           `forge_evaluate: adr-extractor failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
         );
+      }
+
+      // v0.38.0 I3 + F4 fix: capture warnings reference for the top-level
+      // response. Same array as `generatedDocs.warnings` so the MCP
+      // top-level field is byte-identical to the on-disk record. P64
+      // producer/consumer seam — both surfaces carry the same warning set.
+      if (generatedDocs) {
+        storyEvalSpecGenWarnings = generatedDocs.warnings;
       }
     }
 


### PR DESCRIPTION
## Summary

`forge_evaluate` was silently swallowing spec-generator failures on PASS-verdict story-mode runs. The exception was logged to stderr only; the synthesised fallback at the ADR-extractor branch hardcoded `{specPath:"", genTokens:{0,0}, contracts:[], warnings:[]}`, masking the failure on both the on-disk run record and the MCP top-level response. Result: `TECHNICAL-SPEC.md` quietly went stale on every PASS where generation threw — the bug macbook-monday filed against US-08+.

This PR un-swallows the failure with two new typed `SpecGeneratorWarning` variants and surfaces them on **both** observable surfaces.

## Fix shape — why warning, not re-throw

The plan offered two options: re-throw or attach an error-class warning. **Picked the warning shape.**

Reason: the existing doctrine in this code path (mirrored in `writeRunRecord`'s dashboard hooks) is "log + continue; never crash a cosmetic sub-step." A re-throw would have been a behaviour change that masked the underlying eval verdict — exactly what the original swallow was trying to avoid (just done correctly: surface, don't crash). The warning shape gives consumers full visibility (loud failure on both surfaces) while preserving the verdict-surface invariant. The "PASS + structurally-incomplete record" case is also covered explicitly via the new `spec-gen-skipped-on-pass` warning kind so consumers can detect it without inferring from `specPath === ""`.

## Changes

- **`server/lib/run-record.ts`** — extends `SpecGeneratorWarning` (type + Zod schema) with two new discriminated-union variants: `spec-gen-failed` (un-swallow) and `spec-gen-skipped-on-pass` (PASS-incomplete structural marker). Both carry a `message` field. Additive-optional per **P50** (existing run-record JSON files still parse cleanly).
- **`server/tools/evaluate.ts`** — when `generateSpecForStory()` throws on PASS, mints both warnings and synthesises a placeholder `generatedDocs` envelope. The envelope is the on-disk surface; the MCP top-level `specGenWarnings` is the parallel surface (P64 producer/consumer seam, P44 loud-failure). Eval verdict still surfaced unchanged.
- **Tests**: extends `run-record.test.ts` with parse coverage for the two new warning kinds; rewrites the existing "swallows spec-gen failure" test in `evaluate.test.ts` to assert the warnings surface on both observable surfaces; updates the AC-6 spec-gen-failure test in `evaluate-grounding.test.ts` to assert the new typed warnings instead of the old empty-array behaviour.

## Test plan

- [x] `npm run build` passes (TypeScript clean — AC-F1)
- [x] `npx vitest run server/tools/evaluate.test.ts server/lib/run-record.test.ts server/tools/evaluate-grounding.test.ts` — 69 tests pass (AC-F2)
- [x] AC-F3 load-bearing test added in `evaluate.test.ts`: with a synthesizer-throwing stub injected, the MCP top-level `specGenWarnings` contains `kind: "spec-gen-failed"` AND the on-disk `generatedDocs.warnings` contains the same warning (both surfaces verified)
- [x] AC-F4 — `git diff origin/master -- 'server/lib/dashboard-renderer.ts' 'server/lib/generator.ts' 'server/lib/codebase-scan.ts' 'docs/'` is empty (no out-of-scope edits)
- [x] AC-F5 — full `npx vitest run` suite passes: 1029 tests across 68 files

## Plan reference

`.ai-workspace/plans/2026-05-08-forge-harness-followups-from-macbook-monday.md` §F4