### PR TITLE
feat(evaluate): surface canonicalized ADR paths (I1+I4)

### DIFF
--- a/server/lib/adr-extractor.test.ts
+++ b/server/lib/adr-extractor.test.ts
@@ -90,6 +90,16 @@ describe("adr-extractor — happy path (AC-C1, AC-C2, AC-C3)", () => {
 
     // AC-C5 telemetry: no-decisions row was NOT appended on a story with stubs
     expect(result.appendedNoDecisionsRow).toBe(false);
+
+    // v0.40.x I1: canonicalized triple captures (from, to, adrId) for the
+    // calling agent. `from` points at the (now-deleted) staging stub; `to`
+    // mirrors `newAdrPaths[0]`; `adrId` is the four-digit identifier.
+    expect(result.canonicalized.length).toBe(1);
+    expect(result.canonicalized[0].from).toBe(
+      join(tmp, ".forge", "staging", "adr", "US-01", "use-sqlite.md"),
+    );
+    expect(result.canonicalized[0].to).toBe(adrPath);
+    expect(result.canonicalized[0].adrId).toBe("ADR-0001");
   });
 });
 
@@ -109,6 +119,8 @@ describe("adr-extractor — no-decisions story (AC-C1, AC-C4 INDEX dedup)", () =
     });
     expect(r1.newAdrPaths.length).toBe(0);
     expect(r1.appendedNoDecisionsRow).toBe(true);
+    // v0.40.x I1: no staging stubs ⇒ empty canonicalized triples.
+    expect(r1.canonicalized).toEqual([]);
 
     // INDEX.md has exactly one US-99 no-decisions row
     let indexText = readFileSync(r1.indexPath, "utf-8");

--- a/server/lib/adr-extractor.ts
+++ b/server/lib/adr-extractor.ts
@@ -133,6 +133,19 @@ export interface AdrExtractorResult {
   appendedNoDecisionsRow: boolean;
   /** Absolute path to the regenerated INDEX.md. */
   indexPath: string;
+  /**
+   * v0.40.x I1 — per-stub canonicalization triples surfaced to the
+   * MCP response so the calling agent can stage + commit the canonical
+   * ADR file as a follow-up without `git status`-discovering the path.
+   *
+   * - `from`: absolute path to the staging stub that was consumed.
+   * - `to`: absolute path to the canonicalized `docs/decisions/ADR-NNNN-*.md`.
+   * - `adrId`: the canonical `"ADR-NNNN"` identifier.
+   *
+   * Empty array when the call produced zero new ADRs (no staging stubs OR
+   * stubs already canonicalized in a prior call).
+   */
+  canonicalized: Array<{ from: string; to: string; adrId: string }>;
 }
 
 interface StubFrontMatter {
@@ -552,6 +565,7 @@ export function processStory(input: AdrExtractorInput): AdrExtractorResult {
   }
 
   const newAdrPaths: string[] = [];
+  const canonicalized: Array<{ from: string; to: string; adrId: string }> = [];
   if (stagingStubs.length > 0) {
     let nextNum = nextAdrNumber(decisionsDir);
     for (const stub of stagingStubs) {
@@ -562,6 +576,15 @@ export function processStory(input: AdrExtractorInput): AdrExtractorResult {
       const rendered = renderAdrFile({ adr, storyId, date: today, fm: stub.fm });
       writeFileSync(outPath, rendered, "utf-8");
       newAdrPaths.push(outPath);
+      // v0.40.x I1 — capture the (from → to) triple before the staging dir
+      // is removed below. `from` is the staging stub that was just consumed;
+      // `to` mirrors the canonical destination newAdrPaths got; `adrId` is
+      // the four-digit ADR-NNNN identifier (matches INDEX.md's first column).
+      canonicalized.push({
+        from: join(stagingDir, stub.filename),
+        to: outPath,
+        adrId: `ADR-${pad4(adr)}`,
+      });
     }
     // Delete staging files + the per-story dir. Leaves the parent
     // `.forge/staging/adr/` in place for other concurrent stories.
@@ -603,6 +626,7 @@ export function processStory(input: AdrExtractorInput): AdrExtractorResult {
     newAdrPaths,
     appendedNoDecisionsRow,
     indexPath,
+    canonicalized,
   };
 }
 

--- a/server/lib/generator.test.ts
+++ b/server/lib/generator.test.ts
@@ -3,6 +3,8 @@ import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  ADR_CAPTURE_INSTRUCTIONS,
+  buildAdrCapture,
   buildBrief,
   buildFixBrief,
   computeScore,
@@ -1047,5 +1049,37 @@ describe("persistGenerateBrief", () => {
     const content = JSON.parse(await readFile(join(briefsDir, files[0]), "utf-8"));
     expect(content.action).toBe("fix");
     expect(content.fixBrief.guidance).toBe("Fix the test");
+  });
+});
+
+// ── v0.40.x I4: ADR_CAPTURE_INSTRUCTIONS post-PASS canonicalization paragraph ──
+
+describe("ADR_CAPTURE_INSTRUCTIONS — v0.40.x I4 post-PASS canonicalization paragraph", () => {
+  it("references the I1 `adrCanonicalized` response field by name", () => {
+    expect(ADR_CAPTURE_INSTRUCTIONS).toContain("adrCanonicalized");
+  });
+
+  it("instructs the calling agent to commit the canonical ADR as a follow-up", () => {
+    // String-presence check on the post-PASS guidance — keeps the brief
+    // content stable without freezing the exact wording.
+    expect(ADR_CAPTURE_INSTRUCTIONS).toMatch(/follow-?up commit/i);
+  });
+
+  it("preserves the original four-field staging-stub instructions byte-identically before the new paragraph", () => {
+    // The original instructions paragraph must remain present as a contiguous
+    // substring — additive change, not a rewrite.
+    expect(ADR_CAPTURE_INSTRUCTIONS).toContain(
+      "Before declaring story complete, for each architectural decision matching one of the 4 triggers below, " +
+        "write a stub at `.forge/staging/adr/<storyId>/<short-slug>.md` with front-matter " +
+        "{title, story, context, decision, consequences, alternatives}. " +
+        "forge-harness's adr-extractor will canonicalize them on PASS. " +
+        "If you made no qualifying decisions, write nothing — that is a valid outcome.",
+    );
+  });
+
+  it("buildAdrCapture() forwards the updated instructions to the brief consumer", () => {
+    const guidance = buildAdrCapture();
+    expect(guidance.instructions).toBe(ADR_CAPTURE_INSTRUCTIONS);
+    expect(guidance.instructions).toContain("adrCanonicalized");
   });
 });

--- a/server/lib/generator.ts
+++ b/server/lib/generator.ts
@@ -55,7 +55,13 @@ export const ADR_CAPTURE_INSTRUCTIONS =
   "write a stub at `.forge/staging/adr/<storyId>/<short-slug>.md` with front-matter " +
   "{title, story, context, decision, consequences, alternatives}. " +
   "forge-harness's adr-extractor will canonicalize them on PASS. " +
-  "If you made no qualifying decisions, write nothing — that is a valid outcome.";
+  "If you made no qualifying decisions, write nothing — that is a valid outcome.\n\n" +
+  "If you wrote a staging ADR, the forge_evaluate PASS path canonicalizes it into " +
+  "`docs/decisions/ADR-NNNN-*.md` and deletes the staging stub. The canonical path is " +
+  "returned on the MCP response in the top-level `adrCanonicalized` field — an array of " +
+  "`{from, to, adrId}` triples, one per ADR created. Read that field after PASS, then " +
+  "stage the new ADR file(s) and commit them as a follow-up commit (the canonicalization " +
+  "happens AFTER your story's commit, so the new ADR is initially untracked).";
 
 export function buildAdrCapture(): AdrCaptureGuidance {
   return {

--- a/server/tools/evaluate-grounding.test.ts
+++ b/server/tools/evaluate-grounding.test.ts
@@ -49,7 +49,7 @@ vi.mock("../lib/spec-generator.js", () => ({
 }));
 
 vi.mock("../lib/adr-extractor.js", () => ({
-  processStory: vi.fn(() => ({ newAdrPaths: [], appendedNoDecisionsRow: false, indexPath: "" })),
+  processStory: vi.fn(() => ({ newAdrPaths: [], appendedNoDecisionsRow: false, indexPath: "", canonicalized: [] })),
 }));
 
 vi.mock("../lib/run-context.js", async () => {

--- a/server/tools/evaluate.test.ts
+++ b/server/tools/evaluate.test.ts
@@ -55,6 +55,7 @@ vi.mock("../lib/adr-extractor.js", () => ({
     newAdrPaths: [],
     appendedNoDecisionsRow: false,
     indexPath: `${input.projectPath}/docs/decisions/INDEX.md`,
+    canonicalized: [],
   })),
 }));
 
@@ -508,6 +509,114 @@ describe("handleStoryEval — v0.36.0 Phase B spec-generator integration", () =>
 
     // P64 — the MCP top-level surface MUST carry the same warnings.
     expect(result.specGenWarnings).toEqual(record.generatedDocs!.warnings);
+  });
+});
+
+// ── v0.40.x I1: surface canonicalized ADR triples on response ──
+
+import { processStory as processAdrStoryMock } from "../lib/adr-extractor.js";
+const mockedProcessAdrStory = vi.mocked(processAdrStoryMock);
+
+describe("handleStoryEval — v0.40.x I1 adrCanonicalized response field", () => {
+  it("populates `adrCanonicalized` on story-mode PASS when adr-extractor returned canonicalized triples", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport({ verdict: "PASS" }));
+    mockedProcessAdrStory.mockReturnValueOnce({
+      newAdrPaths: ["/some/path/docs/decisions/ADR-0007-some-slug-US-01.md"],
+      appendedNoDecisionsRow: false,
+      indexPath: "/some/path/docs/decisions/INDEX.md",
+      canonicalized: [
+        {
+          from: "/some/path/.forge/staging/adr/US-01/some-slug.md",
+          to: "/some/path/docs/decisions/ADR-0007-some-slug-US-01.md",
+          adrId: "ADR-0007",
+        },
+      ],
+    });
+
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.adrCanonicalized).toBeDefined();
+    expect(result.adrCanonicalized).toHaveLength(1);
+    expect(result.adrCanonicalized![0]).toEqual({
+      from: "/some/path/.forge/staging/adr/US-01/some-slug.md",
+      to: "/some/path/docs/decisions/ADR-0007-some-slug-US-01.md",
+      adrId: "ADR-0007",
+    });
+  });
+
+  it("populates `adrCanonicalized` as an empty array on story-mode PASS when no staging stubs existed", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport({ verdict: "PASS" }));
+    // Default mock returns canonicalized: [] — the no-staging-stubs case.
+
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.adrCanonicalized).toBeDefined();
+    expect(result.adrCanonicalized).toEqual([]);
+  });
+
+  it("omits `adrCanonicalized` on story-mode FAIL (adr-extractor not invoked)", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(
+      makeEvalReport({
+        verdict: "FAIL",
+        criteria: [{ id: "AC-01", status: "FAIL", evidence: "broken" }],
+      }),
+    );
+
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.adrCanonicalized).toBeUndefined();
+    // Sanity — adr-extractor should NOT have been called on a FAIL verdict.
+    expect(mockedProcessAdrStory).not.toHaveBeenCalled();
+  });
+
+  it("omits `adrCanonicalized` on coherence-mode responses (scope guard — story-mode-only)", async () => {
+    mockedCallClaude.mockResolvedValueOnce(
+      makeCallResult({ gaps: [], summary: "All aligned." }),
+    );
+
+    const result = await handleEvaluate({
+      evaluationMode: "coherence",
+      prdContent: "Build a thing",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.adrCanonicalized).toBeUndefined();
+  });
+
+  it("omits `adrCanonicalized` on divergence-mode responses (scope guard — story-mode-only)", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(
+      makeEvalReport({
+        verdict: "PASS",
+        criteria: [{ id: "AC-01", status: "PASS", evidence: "ok" }],
+      }),
+    );
+    mockedCallClaude.mockResolvedValueOnce(
+      makeCallResult({ reverse: [], summary: "No reverse divergences." }),
+    );
+
+    const result = await handleEvaluate({
+      evaluationMode: "divergence",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.adrCanonicalized).toBeUndefined();
   });
 });
 

--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -184,6 +184,26 @@ type McpResponse = {
    * Empty array when no warnings; absent on non-story modes.
    */
   specGenWarnings?: SpecGeneratorWarning[];
+  /**
+   * v0.40.x I1 — canonicalized ADR triples surfaced on story-mode PASS
+   * responses so the calling agent can stage + commit the canonical ADR
+   * file(s) without `git status`-discovering the path.
+   *
+   * Each entry carries:
+   *   - `from`: absolute path of the staging stub that was consumed
+   *     (`.forge/staging/adr/<storyId>/<short-slug>.md`).
+   *   - `to`: absolute path of the canonical
+   *     `docs/decisions/ADR-NNNN-*-<storyId>.md` produced this call.
+   *   - `adrId`: the canonical four-digit ADR identifier
+   *     (e.g. `"ADR-0007"`).
+   *
+   * Field is set ONLY in story-mode responses (the `processAdrStory` call
+   * site); coherence-mode and divergence-mode handlers do not populate it.
+   * Empty array when story-mode ran but produced zero new ADRs (no staging
+   * stubs or non-PASS verdict). Additive optional per P50 — backward-compat,
+   * no version bump.
+   */
+  adrCanonicalized?: Array<{ from: string; to: string; adrId: string }>;
 };
 
 // ── Shared helpers ────────────────────────────────────────
@@ -360,6 +380,14 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
   // v0.38.0 I3 — captured for the top-level MCP response field.
   let storyEvalSpecGenWarnings: SpecGeneratorWarning[] | undefined;
 
+  // v0.40.x I1 — captured for the top-level MCP response field. Populated
+  // ONLY by story-mode PASS runs that called `processAdrStory`. Stays
+  // `undefined` on non-PASS verdicts and when projectPath is missing — in
+  // both cases the field is omitted from the response (additive optional).
+  let storyEvalAdrCanonicalized:
+    | Array<{ from: string; to: string; adrId: string }>
+    | undefined;
+
   // Write run record with the four REQ-01 v1.1 additive fields populated.
   // canonicalizeEvalReport sorts criteria by (id, evidence) so two runs
   // with the same criteria in different input orders produce byte-identical
@@ -460,6 +488,13 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
         if (generatedDocs) {
           generatedDocs.adrPaths = adr.newAdrPaths;
         }
+        // v0.40.x I1 — surface the (from → to → adrId) triples on the MCP
+        // top-level response so the calling agent can stage + commit the
+        // canonical ADR file(s) as a follow-up. Always set (even when
+        // empty) so consumers can rely on field presence on story-mode PASS.
+        // The data is the same one-pass derivation `processStory` already
+        // built — no recomputation here.
+        storyEvalAdrCanonicalized = adr.canonicalized;
       } catch (err) {
         console.error(
           `forge_evaluate: adr-extractor failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
@@ -529,10 +564,20 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
   const specGenWarnings: SpecGeneratorWarning[] =
     storyEvalSpecGenWarnings ?? [];
 
-  return {
+  // v0.40.x I1 — surface the canonicalized ADR triples at the top level of
+  // the response when story-mode PASS ran the adr-extractor. Field is
+  // omitted (not set to []) on non-PASS verdicts so consumers can use
+  // field presence as a "did the canonicalizer run?" signal. Coherence-mode
+  // and divergence-mode handlers do NOT set this field — see McpResponse
+  // type doc.
+  const response: McpResponse = {
     content: [{ type: "text", text: JSON.stringify(report, null, 2) }],
     specGenWarnings,
   };
+  if (storyEvalAdrCanonicalized !== undefined) {
+    response.adrCanonicalized = storyEvalAdrCanonicalized;
+  }
+  return response;
 }
 
 // ── Coherence Mode Handler ────────────────────────────────

--- a/tests/fixtures/i1-baseline-master-diff.txt
+++ b/tests/fixtures/i1-baseline-master-diff.txt
@@ -1,0 +1,77 @@
+## I1+I4 Baseline against master (bfd68f7)
+
+Per P17 / Plan AC-2: capture exit code AND failure reason for each new test
+on master BEFORE the I1+I4 fix lands. Demonstrates the tests are
+delta-class — they fail on master, pass on the I1+I4 branch.
+
+Master baseline ref: `bfd68f7` (post-F4 merge — `fix(evaluate): un-swallow
+spec-gen failures and gate PASS-incomplete records (F4) (#537)`)
+
+Baseline run command: `npx vitest run server/tools/evaluate.test.ts -t "I1 adrCanonicalized"`
+Baseline exit code: 1 (test failures)
+
+────────────────────────────────────────────────────────────────────────────
+I1 — `handleStoryEval — v0.40.x I1 adrCanonicalized response field` (5 tests)
+────────────────────────────────────────────────────────────────────────────
+
+PASS on master (3 tests — sanity guards that hold pre-fix because they
+assert ABSENCE):
+  - omits `adrCanonicalized` on story-mode FAIL (adr-extractor not invoked)
+  - omits `adrCanonicalized` on coherence-mode responses (scope guard — story-mode-only)
+  - omits `adrCanonicalized` on divergence-mode responses (scope guard — story-mode-only)
+
+FAIL on master (2 tests — assert PRESENCE of the new field that doesn't yet exist):
+
+  1. populates `adrCanonicalized` on story-mode PASS when adr-extractor returned canonicalized triples
+     AssertionError: expected undefined to be defined
+       at server/tools/evaluate.test.ts:543:37
+       expect(result.adrCanonicalized).toBeDefined();
+
+  2. populates `adrCanonicalized` as an empty array on story-mode PASS when no staging stubs existed
+     AssertionError: expected undefined to be defined
+       at server/tools/evaluate.test.ts:563:37
+       expect(result.adrCanonicalized).toBeDefined();
+
+Master test totals: 2 failed | 3 passed | 47 skipped (52)
+
+────────────────────────────────────────────────────────────────────────────
+I4 — `ADR_CAPTURE_INSTRUCTIONS — v0.40.x I4 post-PASS canonicalization paragraph` (4 tests)
+────────────────────────────────────────────────────────────────────────────
+
+Baseline run command: `npx vitest run server/lib/generator.test.ts -t "I4 post-PASS canonicalization"`
+Baseline exit code: 1 (test failures)
+
+PASS on master (1 test — pre-existing four-field paragraph still byte-identically present):
+  - preserves the original four-field staging-stub instructions byte-identically before the new paragraph
+
+FAIL on master (3 tests — assert PRESENCE of the new instruction text):
+
+  1. references the I1 `adrCanonicalized` response field by name
+     AssertionError: expected '<orig-text>' to contain 'adrCanonicalized'
+       at server/lib/generator.test.ts:1059:38
+
+  2. instructs the calling agent to commit the canonical ADR as a follow-up
+     AssertionError: expected '<orig-text>' to match /follow-?up commit/i
+       at server/lib/generator.test.ts:1065:38
+
+  3. buildAdrCapture() forwards the updated instructions to the brief consumer
+     AssertionError: expected '<orig-text>' to contain 'adrCanonicalized'
+       at server/lib/generator.test.ts:1083:35
+
+Master test totals: 3 failed | 1 passed | 72 skipped (76)
+
+────────────────────────────────────────────────────────────────────────────
+Provenance
+────────────────────────────────────────────────────────────────────────────
+
+Captured 2026-05-08 by I1+I4 implementer subagent. Reproduce by:
+
+  git worktree add /tmp/i1-baseline bfd68f7
+  cp server/tools/evaluate.test.ts /tmp/i1-baseline/server/tools/
+  cp server/lib/generator.test.ts /tmp/i1-baseline/server/lib/
+  cd /tmp/i1-baseline && ln -s ../forge-harness/node_modules node_modules
+  npx vitest run server/tools/evaluate.test.ts -t "I1 adrCanonicalized"
+  npx vitest run server/lib/generator.test.ts -t "I4 post-PASS canonicalization"
+
+Both runs exit 1 with the failures above. After I1+I4 lands on the feature
+branch, both runs exit 0 — see AC-6 vitest-full output in the PR body.


### PR DESCRIPTION
## Summary

Co-shipped pair of additive-optional improvements to `forge_evaluate`'s
story-mode response and the `forge_generate` brief.

- **I1**: surface the canonicalized ADR paths on the `forge_evaluate` MCP
  top-level response so the calling agent knows which file
  `processAdrStory` just landed (without `git status`-discovering it).
- **I4**: append one paragraph to `ADR_CAPTURE_INSTRUCTIONS` (the string
  baked into every `forge_generate` brief) telling the calling agent the
  PASS path canonicalizes the staging stub, the canonical path is in the
  new `adrCanonicalized` field, and the new ADR needs a follow-up commit.

Co-shipped per the planning chain: I4's instruction text references the
I1 field by name, so shipping I4 standalone would create a transient
where the brief lies about a field that does not yet exist on the
response.

Plan: `.ai-workspace/plans/2026-05-08-forge-harness-followups-from-macbook-monday.md`
(I1 + I4 sections).

## Changes

- `server/lib/adr-extractor.ts` — extend `AdrExtractorResult` with
  `canonicalized: Array<{from, to, adrId}>`; populate inside `processStory`
  before staging dir is removed. No recomputation — derived from the same
  loop that builds `newAdrPaths`.
- `server/tools/evaluate.ts` — add `adrCanonicalized?` to `McpResponse`
  type; populate ONLY in the story-mode handler at the `processAdrStory`
  call site. Coherence-mode and divergence-mode handlers do not set it
  (omitted from response).
- `server/lib/generator.ts` — append one paragraph to
  `ADR_CAPTURE_INSTRUCTIONS` referencing the new field by name. Original
  four-field paragraph is byte-identically preserved.

## AC verifier output

### AC-1: build passes
`npm run build` exits 0 (tsc clean).

### AC-2: I1 baseline (test fails on master, passes on branch)
Captured at `tests/fixtures/i1-baseline-master-diff.txt`. Reproduced
against master `bfd68f7` (pre-F2-merge ref locked into the worktree
branch-from):

  Master baseline run: 2 failed | 3 passed | 47 skipped
    FAIL: populates `adrCanonicalized` on story-mode PASS — `expected undefined to be defined`
    FAIL: populates `adrCanonicalized` as an empty array on story-mode PASS — `expected undefined to be defined`

  Feature-branch run: 5 passed | 47 skipped (all 5 I1 tests pass)

### AC-3: scope guard (story-mode-only)
Two unit tests in `evaluate.test.ts` assert `adrCanonicalized` is
`undefined` on coherence-mode and divergence-mode responses, plus a
third asserting it's `undefined` on story-mode FAIL. All pass on the
feature branch.

### AC-4: I4 brief text presence
Three string-presence tests in `generator.test.ts`:
  - `ADR_CAPTURE_INSTRUCTIONS` contains `adrCanonicalized`
  - `ADR_CAPTURE_INSTRUCTIONS` matches `/follow-?up commit/i`
  - `buildAdrCapture().instructions === ADR_CAPTURE_INSTRUCTIONS`

  Master baseline run: 3 failed | 1 passed | 72 skipped
  Feature-branch run: 4 passed | 72 skipped

### AC-5: out-of-scope diff is empty
`git diff origin/master -- 'server/lib/dashboard-renderer.ts' 'server/lib/run-record.ts' 'docs/'` returns no output.

### AC-6: full vitest suite passes
`npx vitest run`: **1043 passed** (68 test files), up from 1034 on master
(adds 9 new tests — 5 I1 + 4 I4).

## Cairn references

- **P50 — Additive Optional Fields for Schema Evolution**: `adrCanonicalized?`
  is additive optional, no version bump, full backward-compat. Coherence-
  mode and divergence-mode consumers see no change.
- **P64 — Producer/Consumer Seam Coverage**: surface tested on both
  producer (the response shape) and consumer-shape boundary (the brief
  text that references the field by name).
- **F67 — Subagent Schema Fabrication**: implementation re-read
  `evaluate.ts:179-186` (the actual response shape) before coding —
  followed I1 plan note that warned against fabricating a `body` field.

## Test plan

- [x] `npm run build` exits 0
- [x] `npx vitest run server/tools/evaluate.test.ts -t "I1 adrCanonicalized"` exits 0 (5 passed)
- [x] `npx vitest run server/lib/generator.test.ts -t "I4 post-PASS canonicalization"` exits 0 (4 passed)
- [x] `npx vitest run server/lib/adr-extractor.test.ts` exits 0 (9 passed)
- [x] `npx vitest run` exits 0 (1043 passed, 68 files)
- [x] `git diff origin/master -- 'server/lib/dashboard-renderer.ts' 'server/lib/run-record.ts' 'docs/'` empty
- [x] AC-2 baseline captured at `tests/fixtures/i1-baseline-master-diff.txt`
- [ ] CI passes (set after push)