### PR TITLE
feat(anthropic): FORGE_MODEL env override + 404 obsolescence guard (alpha + A1)

### DIFF
--- a/.ai-workspace/plans/2026-05-08-forge-model-alpha-a1-implementation.md
+++ b/.ai-workspace/plans/2026-05-08-forge-model-alpha-a1-implementation.md
@@ -1,0 +1,253 @@
+---
+plan: FORGE_MODEL — α + A1 implementation (Phase 2)
+status: DRAFT (pre-light-reviewer-chain)
+authors: forge-plan
+date: 2026-05-08
+ratifies: .ai-workspace/plans/2026-05-08-forge-model-config-decision.md (4-0 ship-it on option α; operator ratified 2026-05-08T1600Z)
+ships_in: v0.40.6
+---
+
+## ELI5
+
+Phase 1 (decision plan) is done — all four reviewers voted α (single `FORGE_MODEL` env var) with A1 (obsolescence-aware loud failure). Operator ratified.
+
+This Phase-2 plan captures the implementation. Two changes:
+
+1. **α — `FORGE_MODEL` env var.** Read at module-load via IIFE in `anthropic.ts` (same pattern as `FORGE_CORRECTOR_MAX_TOKENS`). Export `DEFAULT_MODEL` constant. `cost.ts:90` imports it (kills the live `"claude-sonnet-4-6"` literal duplicate).
+2. **A1 — obsolescence-aware loud failure.** `callClaude` catches `404 model_not_found` from the Anthropic API and re-throws with operator-actionable guidance ("set `FORGE_MODEL` to a current model, see https://docs.anthropic.com/...").
+
+Operator UX: `FORGE_MODEL=claude-opus-4-6 npm test` (or `export` in shell). Restart MCP child after change (F54 trap — module-load reads stick until the child process restarts; same pattern as v0.40.x release transitions).
+
+## Execution model
+
+**Single-PR shipping order.** Three files (`anthropic.ts` + `cost.ts` + tests). A1 and α are tightly coupled — A1 needs the resolver from α. Ship as one PR, v0.40.6.
+
+**Stages:**
+
+1. Worktree from `origin/master` per Rule 12: `.claude/worktrees/forge-model-alpha-20260508/`.
+2. Implement α in `anthropic.ts` (export `DEFAULT_MODEL` via module-load IIFE reading `FORGE_MODEL`, with whitespace-trim).
+3. Implement A1 in `anthropic.ts`'s `callClaude` (catch `404 model_not_found`, re-throw with operator-actionable guidance).
+4. Update `cost.ts:90` to import `DEFAULT_MODEL` (kills the live P43 violation). Add `unknownModelWarned` field + warning method following the `stalePricingWarned` pattern at `cost.ts:44,58`.
+5. New test cases (8 total — 4 α + 2 A1 in `anthropic.test.ts`, 2 cost in `cost.test.ts`) using `vi.stubEnv` + `vi.resetModules` OR direct env mutation (see §D for both established patterns).
+6. `npm test` PASS, `npm run build` PASS.
+7. PR + CI + `/ship` Stages 0-10 → v0.40.6.
+8. Mail macbook-monday post-merge: changes + smoke-test request. Restart-Claude-Code F54 trap warning at top.
+
+## Why
+
+Architectural choice (α + A1 over β/γ/δ/ε) is already 4-0 reviewer-validated. See `2026-05-08-forge-model-config-decision.md` for full rationale.
+
+This Phase-2 plan focuses on implementation correctness, not architectural choice. The reviewer chain on this plan should audit:
+- A1's error-detection logic (typed instance check on Anthropic API errors, similar to F6's `Anthropic.AuthenticationError` pattern)
+- IIFE module-load + test mocking pattern matches the established convention
+- `cost.ts:90` import wiring is single-source-of-truth (no third hardcode locus emerges)
+- The 7 test cases cover all platform/env-state combinations
+
+## What
+
+### A. `server/lib/anthropic.ts:6-7` — env-var read + export (α core)
+
+**Locus.** Top of file, replacing the existing single-line `const DEFAULT_MODEL = "claude-sonnet-4-6"`.
+
+**Shape.**
+
+```ts
+/**
+ * α (v0.40.6) — operator-overridable default model for callClaude.
+ *
+ * Default model for callClaude when the caller does not pass `options.model`.
+ *
+ * Resolution order:
+ *   1. FORGE_MODEL env var (if set + non-whitespace, trimmed)
+ *   2. Built-in fallback: claude-sonnet-4-6
+ *
+ * Reading happens at module-load (IIFE) — matches FORGE_CORRECTOR_MAX_TOKENS
+ * (plan.ts:336-348) convention. Operators who change FORGE_MODEL mid-process
+ * must restart the MCP child to pick it up (F54 trap — same as v0.40.x release
+ * transitions).
+ *
+ * EXPORTED so cost.ts can use the same default for its PRICING-table lookup —
+ * single source-of-truth per F49 (no dual-locus drift between API client's
+ * default and cost tracker's fallback). Same export pattern as
+ * KEYCHAIN_SERVICE_NAME (line 26, F6 v0.40.5 precedent).
+ *
+ * Whitespace handling: `raw.trim()` treats whitespace-only env values as
+ * unset. INTENTIONAL DIVERGENCE from FORGE_CORRECTOR_MAX_TOKENS (which
+ * doesn't trim). Plan's behavior is strictly safer (catches "   " typo).
+ */
+export const DEFAULT_MODEL: string = (() => {
+  const raw = process.env.FORGE_MODEL;
+  if (raw && raw.trim()) return raw.trim();
+  return "claude-sonnet-4-6";
+})();
+```
+
+### B. `server/lib/anthropic.ts:callClaude` — A1 obsolescence-aware loud failure
+
+**Locus.** `callClaude` function, inside the existing try/catch around `messages.stream(...).finalMessage()` at **`anthropic.ts:366-376`** (the F6 v0.40.5 401-retry block). P1 verified the line numbers — the previous draft cited `:289-300`, which is actually inside `extractJson`'s error path.
+
+**Shape.** Add an `if (err instanceof Anthropic.NotFoundError)` branch BEFORE the existing F6 `AuthenticationError` check. **A1 (NotFoundError = 404) and F6 (AuthenticationError = 401) are type-disjoint subclasses of `APIError`** — ordering between them is safe either way; we place A1 first for read-clarity. P1 verified `Anthropic.NotFoundError` is exposed in SDK 0.82.0 at `node_modules/@anthropic-ai/sdk/index.d.ts:6` (re-export from `core/error.d.ts:40`: `export declare class NotFoundError extends APIError<404, Headers> {}`) AND as a static on the default Anthropic class at `client.d.ts:202`. The plan's `err instanceof Anthropic.NotFoundError` check will work.
+
+**Terminal-path semantics (P2 catch).** A1's `throw new Error(...)` is **terminal for the catch block** — it exits `callClaude` entirely. F6's downstream `isAuthError` block runs ONLY in the non-NotFoundError path. The implementer must NOT add a `return` or fall-through after the A1 throw; the throw IS the exit. Code shape:
+
+```ts
+} catch (err) {
+  if (err instanceof Anthropic.NotFoundError) {
+    throw new Error(/* A1 message */); // ← terminal; rest of catch is skipped
+  }
+  // F6 401-retry path — only reached when err is NOT a NotFoundError:
+  const isAuthError = err instanceof Anthropic.AuthenticationError;
+  // ... existing F6 retry logic unchanged ...
+}
+```
+
+```ts
+// Inside callClaude, alongside the existing AuthenticationError retry:
+try {
+  response = await getClient().messages.stream(streamArgs).finalMessage();
+} catch (err) {
+  // A1: obsolescence-aware loud failure (v0.40.6).
+  // Anthropic API returns 404 model_not_found when the requested model has
+  // been deprecated. Re-throw with operator-actionable guidance instead of
+  // letting the cryptic SDK error bubble up.
+  if (err instanceof Anthropic.NotFoundError) {
+    const modelName = streamArgs.model;
+    throw new Error(
+      `Anthropic API rejected model "${modelName}" — likely deprecated. ` +
+        `Set FORGE_MODEL to a current model: https://docs.anthropic.com/en/docs/about-claude/models. ` +
+        `Forge-harness ships an in-code default that gets bumped each release; ` +
+        `if you set FORGE_MODEL=${modelName} explicitly, that name has been deprecated separately. ` +
+        `Restart the MCP child after the change (F54 trap).`,
+    );
+  }
+
+  // Existing F6 401-retry logic stays unchanged ...
+  const isAuthError = err instanceof Anthropic.AuthenticationError;
+  // ...
+}
+```
+
+**SDK probe — DONE in plan-time.** P1 verified `Anthropic.NotFoundError` is the right symbol (typed class, not interface). Implementer can skip re-probing; the typed instance check is correct. **Caveat:** the SDK ALSO exposes `BetaNotFoundError` (interface) and `shared.NotFoundError` (interface). Implementer must use the class form via `Anthropic.NotFoundError` (default namespace static) — NOT the structural interfaces.
+
+### C. `server/lib/cost.ts:90` — single-source-of-truth (P43 fix + P45 warning)
+
+**Locus 1: the fallback (live P43 violation).** Line 90 currently reads `const effectiveModel = model ?? "claude-sonnet-4-6";`. Change to:
+
+```ts
+import { DEFAULT_MODEL } from "./anthropic.js";
+// ...
+const effectiveModel = model ?? DEFAULT_MODEL;
+```
+
+**Locus 2: the unknown-model warning.** Add a one-time-per-instance warning when `isPricingModel(effectiveModel)` returns false — mirrors `stalePricingWarned` at `cost.ts:44,58`:
+
+```ts
+private unknownModelWarned = false;
+
+private warnUnknownModel(model: string): void {
+  if (this.unknownModelWarned) return;
+  console.error(
+    `forge: model "${model}" is not in the cost-tracking PRICING table ` +
+    `(known: ${Object.keys(PRICING).join(", ")}). ` +
+    `Estimates will be null for this run; calls still proceed.`,
+  );
+  this.unknownModelWarned = true;
+}
+```
+
+Wired into `recordUsage()` at the existing `if (isPricingModel(effectiveModel)) { … }` site: add an `else { this.warnUnknownModel(effectiveModel); }` branch.
+
+### D. Tests (`anthropic.test.ts` + `cost.test.ts`)
+
+**Pattern (mandatory).** Two equivalent options — implementer picks one and uses it consistently:
+
+1. **Direct `process.env` mutation with manual save/restore** (the established in-repo pattern — see `plan.test.ts:1313-1389` FORGE_CORRECTOR_MAX_TOKENS test block). Save original via `const ORIGINAL = process.env.FORGE_MODEL; delete process.env.FORGE_MODEL;` in `beforeEach`; restore in `afterEach`. Combined with `vi.resetModules() + await import("./anthropic.js")` for the IIFE re-evaluation.
+2. **Vitest `vi.stubEnv` + `vi.unstubAllEnvs`** (no in-repo precedent — divergence justified by cleaner restore semantics; Vitest officially recommends this for env-stubbing). Pair with `vi.resetModules()` + dynamic import as above. Sibling-test contamination guard: `afterEach(() => { vi.unstubAllEnvs(); vi.resetModules(); })`.
+
+P1 caught that the previous draft cited `plan.test.ts:1313-1389` as the precedent for `vi.stubEnv` — that block actually uses pattern #1 (direct mutation). Either pattern is correct; pick one.
+
+**Mock-class wiring (mandatory) — P1 catch.** `anthropic.test.ts:24-27` defines `MockAnthropic` with `static AuthenticationError = MockAuthenticationError` so production code's `err instanceof Anthropic.AuthenticationError` resolves correctly against thrown mocks. **Tests for AC-D cases (v) and (vi) MUST extend `MockAnthropic` with `static NotFoundError = MockNotFoundError`** (and define `class MockNotFoundError extends Error {}` similarly). Without this, `err instanceof Anthropic.NotFoundError` returns `false` against test-thrown errors and case (v) silently fails to assert what it claims.
+
+**Suite-scoped beforeEach gotcha (P2 catch).** `anthropic.test.ts:65-87` sets `process.env.ANTHROPIC_API_KEY = "sk-test-key"` in the suite's `beforeEach`. **Case (vi)** (regression-positive on F6 401-retry path) MUST `delete process.env.ANTHROPIC_API_KEY` in its own `beforeEach` to actually exercise the retry path — otherwise the test silently runs with the API-key set and the F6 retry never triggers. Established precedent: `anthropic.test.ts:313, 353, 395` all `delete process.env.ANTHROPIC_API_KEY` for the same reason. Cases (i)-(iv) (α-cases) inherit the suite-scoped API-key default safely — no override needed.
+
+**New cases (8 total — 4 α-cases + 2 A1-cases in `anthropic.test.ts` + 2 cost cases in `cost.test.ts`):**
+
+`anthropic.test.ts`:
+- (i) `FORGE_MODEL=claude-3-7-sonnet` → `DEFAULT_MODEL` reflects it; `messages.stream` receives that model.
+- (ii) `FORGE_MODEL` unset → `DEFAULT_MODEL = "claude-sonnet-4-6"`.
+- (iii) `FORGE_MODEL="   "` (whitespace-only) → trimmed and treated as unset; default applied.
+- (iv) per-call override (`callClaude({ model: "claude-opus-4-6" })`) wins over `FORGE_MODEL`.
+- (v) **A1: `Anthropic.NotFoundError` thrown by `messages.stream` → re-thrown as Error with model name + docs URL + FORGE_MODEL guidance + restart instruction.** Assert exact substrings.
+- (vi) **A1: non-404 errors (`AuthenticationError`, `APIConnectionError`) NOT caught by A1 — they pass through to existing handlers.** Regression-positive on F6's 401-retry logic.
+
+`cost.test.ts`:
+- (vii) unknown model → warning emitted exactly once per `CostTracker` instance, `costUsd === null`.
+- (viii) `DEFAULT_MODEL` import from `anthropic.ts` is used as the fallback at `cost.ts:90` (test-mock observation; verifies P43 violation fix landed).
+
+## Critical files
+
+- `server/lib/anthropic.ts` (current 414 LOC post-F6; +20-30 LOC for IIFE + A1 catch + JSDoc).
+- `server/lib/cost.ts` (current 144 LOC; +1 import, +1 line replacement at :90, +5-10 LOC for warning method + field).
+- `server/lib/anthropic.test.ts` (current 614 LOC post-F6; +6 cases — see AC-D).
+- `server/lib/cost.test.ts` (current 123 LOC; +2 cases).
+- `dist/lib/anthropic.js` + `dist/lib/cost.js` — auto-built.
+
+## Considered alternatives
+
+Architectural choice ratified in Phase 1 (decision plan); 4-0 reviewer verdict. See `.ai-workspace/plans/2026-05-08-forge-model-config-decision.md` §The five candidate options for full comparison. Rejected (with reasons): β (per-stage env vars — premature, no current EASY stage); γ (HARD/EASY tiers — same issue); δ (config file — F66 risk + 12-factor break); ε (config + env hybrid — six-layer resolution).
+
+This Phase-2 plan does NOT re-litigate option choice. Reviewers evaluate implementation correctness only.
+
+## Out of scope for this Phase-2 PR
+
+- Plumbing `model:` through `forge_evaluate`, `forge_generate`, `forge_coordinate`, `forge_reconcile` MCP tool surfaces (deferred — file as enhancement issue if reviewers want).
+- Per-stage routing (β shape) — deferred to v0.40.7+; file issue #547 with the plan-time TODO comment in code.
+- Recording per-stage model name in run records — separable enhancement (additive field — fits P50). File if demand surfaces.
+- `run-record.ts:307-308` rate-drift trap (`SPEC_GEN_INPUT_PER_MILLION` literal duplicate of sonnet PRICING row) — acknowledged in v1 plan §Out-of-scope, drift risk is intentional (avoids circular import); file separate issue if cost-accuracy bug surfaces.
+
+## Cairn references
+
+- **F49 (Dual-Level Enforcement of Same Rule) — ANTI-pattern (refusal-class).** Verified at `02-anti-patterns.md:343`. RISK if `cost.ts:90` keeps a hardcoded `"claude-sonnet-4-6"` separately from `anthropic.ts:DEFAULT_MODEL`. Mitigation (mandatory in this PR): import `DEFAULT_MODEL` so the fallback lives at one source-of-truth.
+- **P43 (Single Source of Truth for EC Commands)** — tighter mechanical fit than F49 for the `DEFAULT_MODEL` export-import shape. F49 names the *risk*, P43 names the *mitigation*.
+- **P44 (Loud Failure on Parse Errors)** — A1's typed `404 model_not_found` re-throw with operator-actionable guidance is canonical P44.
+- **P45 (Warn on Missing Data Defaults — Never Silent $0)** — unknown-model fires `console.error` once per `CostTracker` instance and lets `estimatedCostUsd` stay `null`. Operators distinguish "no PRICING row" from "actual zero."
+- **F46 (Silent Numeric Default When Data Missing) — anti-pattern correctly avoided.** This plan keeps `null` as the sentinel + emits the P45 warning, staying on the right side of F46.
+- **F54 (Stale MCP Server After dist/ Rebuild)** — module-load IIFE means `FORGE_MODEL` changes require MCP restart. macbook-monday smoke-test mail MUST lead with the restart instruction.
+- **F45 (Empty Catch Block) — none.** A1's catch is non-empty (re-throws with guidance).
+- **F66 (Hybrid-First Design Reflex) — anti-pattern correctly avoided.** α is single-locus (one env var, one resolver, one in-code fallback) — no hybrid.
+- **F6 v0.40.5 precedent.** `KEYCHAIN_SERVICE_NAME` exported from `anthropic.ts:26`, imported by `spec-generator.ts`. Same export-import shape used here for `DEFAULT_MODEL`.
+- **Tier-b card to write at ship time:** `2026-05-08-forge-model-alpha-a1-shipped.md` under `tier-b/topics/forge-harness/` — placed via `memory write`.
+
+## Notes for implementer (originally for reviewer chain — most resolved at plan-time)
+
+The four-reviewer chain on this plan was a LIGHT pass — architectural choice ratified by Phase-1 4-0 verdict. Reviewers focused on implementation correctness; their findings are folded into §What and §Binary AC. The notes below remain as **implementer-facing** guidance:
+
+1. ~~**A1 SDK probe.**~~ **RESOLVED at plan-time (P1):** `Anthropic.NotFoundError` is exposed in SDK 0.82.0 at `node_modules/@anthropic-ai/sdk/index.d.ts:6` (typed class re-export from `core/error.d.ts:40` as `export declare class NotFoundError extends APIError<404, Headers> {}`) AND as a static on the default Anthropic class at `client.d.ts:202`. Implementer can use `err instanceof Anthropic.NotFoundError` directly. Caveat: do NOT confuse with `BetaNotFoundError` (interface) or `shared.NotFoundError` (interface) — use the class form via `Anthropic.NotFoundError` (default namespace static).
+2. ~~**Test pattern coherence.**~~ **RESOLVED at plan-time (P1):** §D offers two equivalent patterns — direct `process.env` mutation (precedent at `plan.test.ts:1313-1389`) or `vi.stubEnv` (no in-repo precedent but cleaner restore). Implementer picks one and uses it consistently.
+3. **No new third hardcode locus.** Implementer must `grep -n '"claude-sonnet-4-6"' server/lib/` after wiring; expected: matches ONLY in `anthropic.ts` (JSDoc + IIFE fallback) and `cost.ts:11` (PRICING table KEY — legitimate, exempt). Zero matches in `cost.ts:90`'s default-fallback site. Verify before commit.
+4. **A1 error-message coherence.** No `forge.config.json` reference (would mislead operators under α). Lead with "set FORGE_MODEL." Restart-MCP instruction included. Match the existing voice at `anthropic.ts:179-184` (no-creds error) and `executor.ts:80-95` (no-bash error) — concrete instructions + URL pointer + reason for failure.
+5. **F6 401-retry regression-positive.** A1's catch is for `NotFoundError`; F6's `AuthenticationError` retry must continue to work. AC-D case (vi) tests this; per P2's catch, the test MUST `delete process.env.ANTHROPIC_API_KEY` (suite-scoped beforeEach sets it; established precedent at `anthropic.test.ts:313,353,395`).
+6. **`cost.ts:90` literal must be GONE.** Phase-2 AC verifies via grep (AC-G). If implementer leaves it, that's a P43 violation re-introduced.
+7. **A1 throw is terminal (P2 catch).** Inside the `catch` block, A1's `throw new Error(...)` exits `callClaude` entirely. F6's `isAuthError` block runs ONLY in the non-NotFoundError path. Don't add `return` or fall-through — the throw IS the exit. See §B for the full code shape.
+
+## Binary AC
+
+- **AC-A (FORGE_MODEL respected).** With `FORGE_MODEL=claude-3-7-sonnet`, `DEFAULT_MODEL` (read after `vi.resetModules`) equals `"claude-3-7-sonnet"`. `callClaude({ system, messages })` sends that model to the SDK. Test-mock observation.
+- **AC-B (default unchanged when unset).** With `FORGE_MODEL` unset, `DEFAULT_MODEL = "claude-sonnet-4-6"`. Existing 1060 tests pass without modification.
+- **AC-C (per-call override wins).** `callClaude({ system, messages, model: "claude-opus-4-6" })` overrides `FORGE_MODEL` regardless. Test-mock observation.
+- **AC-D (test coverage).** 8 new cases (6 in `anthropic.test.ts`, 2 in `cost.test.ts`) all PASS. Patterns: `Object.defineProperty` for platform mocking (n/a here — no platform check; this is env-only); `vi.stubEnv` + `vi.resetModules` + `afterEach(unstubAllEnvs+resetModules)`.
+- **AC-E (build clean).** `npm run build` exits 0.
+- **AC-F (existing tests unchanged).** All 1060 existing tests pass without modification.
+- **AC-G (P43 violation killed).** Post-implementation, `cost.ts` has ZERO `"claude-sonnet-4-6"` literal as a default-model fallback (currently lives at `cost.ts:90` — the target to kill). PRICING table KEYS at `cost.ts:11` are EXEMPT — those are pricing-row identifiers, not default-model fallbacks. Refined verification: `grep -n '"claude-sonnet-4-6"' server/lib/cost.ts | grep -v 'PRICING\|inputPerMillion'` returns zero matches. The `anthropic.ts:7` literal survives in the IIFE fallback (intentional). P1 catch — earlier framing didn't carve out the legitimate PRICING-table exemption.
+- **AC-H (A1 fires correctly).** Mocked `Anthropic.NotFoundError` thrown by `messages.stream` → `callClaude` re-throws with `Error.message` containing: (i) model name verbatim, (ii) `https://docs.anthropic.com/en/docs/about-claude/models`, (iii) `FORGE_MODEL`, (iv) `Restart the MCP child`. Substring assertions in test.
+- **AC-I (A1 doesn't catch non-404).** `Anthropic.AuthenticationError` thrown → A1 doesn't intercept; F6's existing 401-retry logic runs. Regression-positive.
+- **AC-J (PR shipped).** PR for α+A1 merged to master; tag `v0.40.6` published with GitHub Release; CHANGELOG updated. **Cadence note (P2 raised):** Phase-2 ships more user-visible behavior than F6 (new env var, new error message, new console warning) — gating tag-and-release on macbook-monday smoke would lower release-defect risk. **Operator decision:** ship-then-mail-then-smoke cadence retained per explicit instruction (2026-05-08T1610Z); fix-forward in v0.40.7 is the recovery path if smoke surfaces a regression. Tests + light reviewer chain catch most regressions; the residual risk is "behavior macbook-monday observes that we couldn't predict at plan-time," which fix-forward handles cleanly.
+- **AC-K (operator-runnable smoke).** macbook-monday can run `FORGE_MODEL=claude-3-7-sonnet forge_evaluate('US-13')` and observe (a) the run completes, (b) the run record's `estimatedCostUsd` is null, (c) console warning fires once with: `forge: model "claude-3-7-sonnet" is not in the cost-tracking PRICING table (known: claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5). Estimates will be null for this run; calls still proceed.`
+
+## Revision log
+
+- **2026-05-08T1605Z** — initial draft. Phase-2 implementation plan for α + A1. Architectural choice ratified by Phase-1 4-0 reviewer verdict + operator confirmation. All Phase-1 reviewer concerns folded into AC: cost.ts:90 P43 fix (AC-G); A1 error-message scrub of `forge.config.json` reference; F54 IIFE-restart caveat; SDK NotFoundError probe (note 1); F6 401-retry regression-positive (AC-I); whitespace-trim divergence documented; F49 reclassified to ANTI-pattern; P32 5-7-knob threshold removed (extrapolation). Author: forge-plan.
+- **2026-05-08T1620Z** — P1 light-pass review applied. VERDICT: iterate (6 edits). Changes: (1) **A1 SDK probe DONE in plan-time** — `Anthropic.NotFoundError` confirmed at SDK 0.82.0 `index.d.ts:6` (typed class, not interface); implementer can skip re-probing; (2) §B locus corrected — F6 401-retry block is at `anthropic.ts:366-376` (not `:289-300` as draft said; that range is inside `extractJson`); (3) §B ordering note added — A1 (404) and F6 (401) are type-disjoint subclasses of `APIError`; ordering is safe either way, A1 first chosen for read-clarity; (4) §D test pattern: TWO equivalent options offered (direct `process.env` mutation matching `plan.test.ts:1313-1389` precedent, OR `vi.stubEnv`/`vi.unstubAllEnvs` with no in-repo precedent but cleaner restore semantics); P1 caught that the draft falsely cited `plan.test.ts:1313-1389` as `vi.stubEnv` precedent (that block uses direct mutation); (5) §D mock-class wiring mandate added — tests must extend `MockAnthropic` with `static NotFoundError = MockNotFoundError` (mirrors F6's `AuthenticationError` pattern at `anthropic.test.ts:24-27`); without it `err instanceof Anthropic.NotFoundError` resolves false and AC-D cases (v)/(vi) silently fail; (6) AC-G grep refined — PRICING table KEYS at `cost.ts:11` are exempt (legitimate pricing-row identifiers, not default-model fallbacks); grep scoped accordingly. AC-D framing reworded: "4 α + 2 A1 + 2 cost" instead of "6 from v1 + 2 for A1." Author: forge-plan (applying P1 edits).
+- **2026-05-08T1635Z** — P2 light-pass review applied. VERDICT: iterate (4 edits). Comparative-axis catches: (1) JSDoc tone — added "α (v0.40.6) — operator-overridable default model for callClaude." version-tag header to mirror F6's "F6 (v0.40.5) — …" opener at `anthropic.ts:9`; future readers grep version tags for context. (2) §B A1 terminal-throw semantics now explicit — implementer cannot accidentally add fall-through; F6's `isAuthError` block runs ONLY in non-NotFoundError path. (3) §D suite-scoped beforeEach gotcha — case (vi) MUST `delete process.env.ANTHROPIC_API_KEY` to exercise F6 retry path; established precedent at `anthropic.test.ts:313,353,395`. (4) AC-J cadence note — operator chose ship-then-mail-then-smoke; fix-forward to v0.40.7 is the recovery path if smoke surfaces unforeseen behavior. P2 verified zero circular-import risk between `anthropic.ts` and `cost.ts`. Author: forge-plan (applying P2 edits).
+- **2026-05-08T1655Z** — P3 light-pass cairn-grounded review complete. **VERDICT: ship-it (zero required edits).** All 8 cairn citations audited against canonical KB phrasing — F49, P43, P44, P45, F46, F54, F45, F66 ALL CORRECT. Findings: (1) F49 vs P43 framing internally coherent (F49 names risk, P43 names mitigation); (2) A1 catch is safe against typo accidents — TypeScript catches `Anthropic.NotFoundEror` at compile time; F45 doesn't apply (catch is non-empty, re-throws loudly); (3) A1 error-message voice matches forge convention (numbered-list / URL pointer / "Set FORGE_*" — consistent with `anthropic.ts:183-187` no-creds and `executor.ts:86-92` no-bash); (4) IIFE precedent confirmed at `plan.ts:336-348`; (5) test-pollution risk bounded by `resetClient()` in beforeEach + new `vi.resetModules()`; (6) F33 (Ambiguous File Locations) avoided — every locus pinned to file:line; (7) tier-b precedent `2026-05-08-v0404-shipped-i8-i6-merged-i7-deferred.md` supports F54-restart messaging — plan §Stage 8 follows the established mail pattern; (8) zero KB hand-edit violations. Optional non-blocking suggestions: cite P56 (Research-First Delegation) crediting the SDK-probe work and F33 (Ambiguous File Locations) crediting the file:line discipline — left out of cairn-references to keep the section tight. Author: forge-plan (recording P3 verdict; no edits to apply).
+- **2026-05-08T1710Z** — P4 mechanical-sweep complete. VERDICT: iterate (4 micro-edits — all cosmetic, no architectural problems). Changes: (1) §Execution model Stage 5: "~7 cases" → "8 total — 4 α + 2 A1 + 2 cost" matching §D + AC-D; (2) §Critical files: refreshed stale LOC counts (anthropic.ts 338→414 post-F6; anthropic.test.ts 441→614 post-F6; cost.ts ~200→144; cost.test.ts added 123); (3) §ELI5: glossed "(F54 trap)" inline so cold readers don't hit unexplained jargon; (4) §Notes-for-reviewer-chain renamed to §Notes-for-implementer with notes 1+2 marked RESOLVED at plan-time (no need for a fifth reviewer to redo SDK probe + test-pattern verification). All 8 ACs verifiability-clean. No internal contradictions. No reviewer-edit collision. No new pattern miscitations. **Final 4-round verdict: ship-it.** Author: forge-plan (applying P4 edits).

--- a/.ai-workspace/plans/2026-05-08-forge-model-config-decision.md
+++ b/.ai-workspace/plans/2026-05-08-forge-model-config-decision.md
@@ -1,0 +1,199 @@
+---
+plan: AI-model un-hardcoding — DECISION plan (pick the shape, then implement)
+status: DRAFT (pre-reviewer-chain)
+authors: forge-plan
+date: 2026-05-08
+asked_by: operator (2026-05-08T13:30Z, after F6/v0.40.5 merge; expanded 13:50Z with obsolescence + dual-model questions; expanded again 14:00Z with config-file ask)
+supersedes: .ai-workspace/_quarantine-superseded-plans-20260508/2026-05-08-forge-model-env-override.md (v1 single-option plan; locked at 4-0 ship-it but operator added obsolescence + dual-model + config-file scope before /delegate)
+---
+
+## ELI5
+
+We need to un-hardcode the Claude model name in forge-harness. The operator raised three follow-up concerns that reshape the design:
+
+1. **Obsolescence** — what if `claude-sonnet-4-6` (today's hardcoded default) gets deprecated? Today: every forge call would 404-crash until someone restarts the MCP after editing source code. Bad UX.
+2. **Dual-model routing** — what if some stages should use sonnet/opus (hard reasoning) and others should use haiku (cheap classifier work)?
+3. **Config file** — should config live in environment variables, in a `forge.config.json` file, or both?
+
+This plan does NOT pick a single implementation. It lays out **five candidate option-bundles**, asks the four-reviewer chain to vote on which one wins, and surfaces the verdict to the operator for ratification. After ratification, a separate implementation plan ships in v0.40.6.
+
+Think of this as a "tournament bracket" round before the implementation round.
+
+## Execution model
+
+**Two-phase plan.**
+
+- **Phase 1 — DECISION (this plan).** File the option-bundle comparison; run /auto-flow Stage 1 four-reviewer chain (P1 stateless / P2 comparative / P3 cairn-grounded / P4 mechanical-sweep); each reviewer picks a winner with concrete rationale. Tally verdicts. Show-and-wait for operator ratification.
+- **Phase 2 — IMPLEMENTATION (separate plan, written after operator ratifies).** File a new Plan-First plan tightly scoped to the chosen winner; re-run the four-reviewer chain on the implementation specifics (the option-comparison work above is reviewer-validated, so Phase 2's chain only audits implementation correctness, not architectural choice); show-and-wait; dispatch implementer; ship in v0.40.6; mail macbook-monday for smoke test.
+
+**Why two phases.** The original v1 plan (single-option `FORGE_MODEL` env var) reached 4-0 ship-it before the operator raised obsolescence + dual-model + config-file. Re-doing v1 with three new dimensions of scope folded in would produce a plan with 5 nested architectural choices that the reviewer chain can't cleanly vote on (the chain reviews coherence, not multi-axis choice). Splitting decision-from-implementation gives reviewers a focused vote, then a focused implementation review.
+
+## Why we're picking, not just shipping v1
+
+The operator's three follow-up questions each invalidate a v1 assumption:
+
+1. **v1 assumed in-code default ("claude-sonnet-4-6") is durable.** Operator: "any AI model will be obsolete one day." → v1 plan's reliance on a hardcoded fallback breaks the day Anthropic deprecates that name.
+2. **v1 assumed one model fits all stages.** Operator: "what if dual models — sonnet/opus for hard, haiku for easy?" → v1 has no path to per-stage routing without a v2 redesign.
+3. **v1 chose env vars without considering config files.** Operator: "suggest AI model in config file too." → config-file shape was rejected in v1 as overkill for one knob; operator wants it on the table.
+
+All three questions are forward-looking design concerns, not regressions. The right move is a fresh decision pass that weighs them up-front rather than shipping v1 and then reshaping in v0.40.7 / v0.40.8.
+
+## The five candidate options
+
+Each option includes **A1 (obsolescence-aware loud failure)** because all five reviewers and the operator implicitly agreed on that — operator confirmed in chat. So A1 is non-optional and identical across all five. The variance is in how the model is *configured* (B0 / B1 / B2 / C / B1+C).
+
+### Common to all options: A1 — obsolescence-aware loud failure
+
+When the Anthropic API returns `404 model_not_found`, `callClaude` catches it and re-throws with operator-actionable guidance:
+
+> Anthropic API rejected model "<modelId>" — likely deprecated. Set `FORGE_MODEL` (or update `forge.config.json` if Option C/ε) to a current model. Forge-harness ships an in-code default that is bumped each release; current available Claude models: https://docs.anthropic.com/en/docs/about-claude/models
+
+No retry. Single typed warning emit. ~10 LOC change. Same loud-failure pattern (P44 + P45) F6 used.
+
+### Option α — A1 + B0 (defer dual-model)
+
+**Shape:** v1 plan + A1. Single `FORGE_MODEL` env var. No per-stage routing. File issue #547 to add per-stage routing as a v0.40.7 follow-up.
+
+- **PR size:** ~2 files (anthropic.ts + cost.ts) + ~10 LOC for A1. Smallest blast radius.
+- **Operator UX:** `FORGE_MODEL=claude-opus-4-6` → opus for everything. Restart MCP to apply.
+- **Pro:** Ships fastest; v1 was already 4-0 ship-it; A1 is additive.
+- **Con:** No path for dual-model today; per-stage routing waits for v0.40.7.
+- **When right:** operator's per-stage need is "nice to have" not "must have"; ship cheap, iterate.
+
+### Option β — A1 + B1 (per-stage env vars)
+
+**Shape:** Single `FORGE_MODEL` env var as global default + per-stage overrides: `FORGE_MODEL_PLANNER`, `FORGE_MODEL_CRITIC`, `FORGE_MODEL_CORRECTOR`, `FORGE_MODEL_COHERENCE_EVALUATOR`, `FORGE_MODEL_SPEC_GENERATOR` (5 stages already tagged via `trackedCallClaude(ctx, _, stageName, _)`).
+
+- **PR size:** ~3 files (anthropic.ts + cost.ts + run-context.ts to thread the stage name into model resolution). Plus ~6 env vars.
+- **Resolution order:** per-call `model:` > `FORGE_MODEL_<STAGE>` > `FORGE_MODEL` > in-code default.
+- **Operator UX:** `FORGE_MODEL=claude-sonnet-4-6 FORGE_MODEL_SPEC_GENERATOR=claude-haiku-4-5` → sonnet everywhere except spec-gen runs on haiku. Restart MCP to apply.
+- **Pro:** Dual-model works on day one; infrastructure exists (`stageName` already plumbed); cleanest backward-compat (operators using only `FORGE_MODEL` see no change).
+- **Con:** FORGE_* family grows from 5 → 11 env vars. Operator must remember stage names. No good shape for "stage X uses Y" without setting an env var.
+- **When right:** operator wants granular routing today AND prefers env-var idiom (12-factor-ish).
+
+### Option γ — A1 + B2 (tier env vars)
+
+**Shape:** Single `FORGE_MODEL` global + two tier overrides: `FORGE_MODEL_HARD` and `FORGE_MODEL_EASY`. Plan declares which stage is which tier (e.g. all 5 current stages = HARD; future lint/classifier stages = EASY).
+
+- **PR size:** ~3 files. 3 env vars total (`FORGE_MODEL` + 2 tiers).
+- **Operator UX:** `FORGE_MODEL_EASY=claude-haiku-4-5 FORGE_MODEL_HARD=claude-opus-4-6` → tier-routed.
+- **Pro:** Fewer env vars than β. Conceptually simple ("hard or easy").
+- **Con:** **Forge today has zero EASY stages.** All 5 current `trackedCallClaude` sites are reasoning-heavy. The HARD/EASY split has no current customer; introducing it pre-emptively risks (a) miscategorization (someone marks spec-gen "easy" later because it feels lighter, then quality drops), (b) future surprise when a new stage doesn't fit cleanly into one of two buckets.
+- **When right:** operator believes EASY stages will exist soon AND is OK with binary categorization.
+
+### Option δ — A1 + C (config file only, no env var)
+
+**Shape:** New `forge.config.json` (or `.forge.config.json`) at project root. Schema:
+
+```json
+{
+  "model": "claude-sonnet-4-6",
+  "perStage": {
+    "planner": "claude-opus-4-6",
+    "spec-generator": "claude-haiku-4-5"
+  }
+}
+```
+
+- **PR size:** ~5 files (anthropic.ts + cost.ts + new `forge-config.ts` parser + Zod schema in run-record.ts + 1 test file). New file format.
+- **Resolution order:** per-call `model:` > config-file `perStage[stageName]` > config-file `model` > in-code default. **No env-var path.**
+- **Operator UX:** edit `forge.config.json` in the repo root, restart MCP. No environment-variable management.
+- **Pro:** Composes cleanly with future config knobs (per-stage maxTokens, per-stage temperature, retry policy, etc.). Versioned-with-the-repo (committable). Discoverable (single file vs scattered env vars).
+- **Con:** New file format means schema migration burden when forge accumulates more options. Operator can't override per-shell-session (needs file edit + commit/uncommit dance). Doesn't respect the FORGE_* convention that 5 sibling vars already follow.
+- **When right:** forge will accumulate 5+ config knobs (we're at 5 today + 1 if we add MODEL = 6, near the threshold) AND repo-versioned config is desired (CI runners pick it up automatically).
+
+### Option ε — A1 + B1 + C (hybrid: env vars layered over config file)
+
+**Shape:** Optional `forge.config.json` (Option C) + env-var overrides (Option B1). Either works alone; both together give precedence to env vars (operator-shell wins over committed config).
+
+- **PR size:** ~6 files (everything from δ + env-var resolution layer from β). Largest blast radius of all five options.
+- **Resolution order:** per-call `model:` > `FORGE_MODEL_<STAGE>` > `FORGE_MODEL` > config-file `perStage[stageName]` > config-file `model` > in-code default. Six layers.
+- **Operator UX:** committable team-default in `forge.config.json`; per-developer override via `FORGE_MODEL_<STAGE>` env vars in shell.
+- **Pro:** Most flexible. Industry-standard pattern (Vite, Vitest, ESLint, Prettier all do env-vars-on-top-of-config-file).
+- **Con:** Six-level resolution is a UX cliff. Operators must understand precedence. Debug surface is large ("why is forge using haiku here? ... because FORGE_MODEL_SPEC_GENERATOR is set in your shell from 3 days ago"). Schema + env-var validation has to stay coherent across two surfaces.
+- **When right:** team uses CI + per-developer overrides simultaneously AND has the discipline for multi-layer config debugging.
+
+## Comparison matrix
+
+| Axis | α (B0) | β (B1) | γ (B2) | δ (C) | ε (B1+C) |
+|---|---|---|---|---|---|
+| Files touched | 2 | 3 | 3 | 5 | 6 |
+| New env vars | 1 | 6 | 3 | 0 | 6 |
+| New file formats | 0 | 0 | 0 | 1 | 1 |
+| Resolution layers | 3 | 4 | 4 | 4 | 6 |
+| Dual-model day-1? | No | Yes | Yes | Yes | Yes |
+| EASY stage exists? | n/a | n/a | **No** | n/a | n/a |
+| FORGE_* family count after | 5 | 10 | 7 | 4 | 10 |
+| Backward-compat (no-op when unset) | Yes | Yes | Yes | Yes | Yes |
+| Industry-pattern fit | high | high | medium | medium | very high |
+| Team-default committable? | No | No | No | **Yes** | **Yes** |
+| Operator debug complexity | low | medium | low | low | high |
+
+## Cairn references (decision-relevant)
+
+- **F49 (Dual-Level Enforcement of Same Rule) — ANTI-pattern (refusal-class).** Verified at `02-anti-patterns.md:343`. ε's 6-layer resolution structurally invites F49 (config-file says X, env var says Y, in-code default says Z). Mitigation in α/β: single resolution function in `anthropic.ts` walks layers; one constant exported as the producer-side source-of-truth.
+- **P43 (Single Source of Truth)** — applies in all options: one `DEFAULT_MODEL` constant exported from `anthropic.ts`, imported wherever needed.
+- **P32 (Config-as-Parameter Threading)** — canonical text: "Load config once at startup, pass as parameter ... no global singleton." (NOT a "5-7 knob threshold" — that wording was plan-author extrapolation; corrected per P4 mechanical-sweep.) We're at 4 FORGE_* vars today (`FORGE_BASH_PATH`, `FORGE_CORRECTOR_MAX_TOKENS`, `FORGE_DASHBOARD_AUTO_OPEN`, `FORGE_SPEC_VALIDATOR_MODE`); α brings it to 5; β to 10; γ to 7.
+- **F54 (Stale MCP Server After dist/ Rebuild)** — module-load IIFE applies to env-vars; config-file read could be either at-startup OR per-call (designer's choice). All options need a "restart MCP" reminder in operator docs.
+- **P44 + P45** — A1's loud-failure on obsolete model is canonical P44+P45.
+- **F46 (Silent Numeric Default When Data Missing)** — anti-pattern correctly avoided in all options (cost-tracker null-sentinel preserved).
+
+## Reviewer chain — what we're asking
+
+Each reviewer (P1 stateless, P2 comparative, P3 cairn-grounded, P4 mechanical-sweep) must produce **a single-letter verdict** picking one of α / β / γ / δ / ε, with three sentences of justification. The reviewers are NOT asked to ship-it/iterate/drop in this plan — they're asked to **vote**.
+
+Tally rule:
+- 4-0 unanimous → present winner to operator with high confidence.
+- 3-1 majority → present winner with the dissent's reasoning preserved.
+- 2-2 split → escalate to operator with both top choices and the trade.
+- 4 different votes → escalate, but flag the design as not-yet-clear.
+
+## Binary AC (for THIS plan, not the implementation)
+
+- **AC-1.** Each of P1-P4 produces a vote in {α, β, γ, δ, ε} with ≥ 3-sentence rationale tying their pick to a concrete project constraint (FORGE_* convention / cairn pattern / blast radius / operator UX).
+- **AC-2.** The winning option is recorded in this plan's revision log + presented to the operator.
+- **AC-3.** Operator ratifies (or course-corrects) the winner.
+- **AC-4.** A separate Phase-2 implementation plan is filed at `.ai-workspace/plans/2026-05-08-forge-model-<winner-shape>.md` capturing the chosen winner with normal Plan-First sections (ELI5, Why, What, Critical files, Considered alternatives — already covered here, Binary AC for code, etc.). **Phase-2 AC must include**: (i) the live `cost.ts:90` P43 violation fix — replace `model ?? "claude-sonnet-4-6"` literal with `model ?? DEFAULT_MODEL` import (P3 + P4 catch); (ii) the A1 error message must NOT reference `forge.config.json` under α/β (P1 + P3 catch); (iii) the F54 IIFE-at-module-load restart caveat must be documented (P1 catch); (iv) operator's answer to the (a)/(b)/(other) clarifying question above determines whether ζ (`.envrc` + README) is folded into Phase-2 or deferred.
+- **AC-5.** Phase-2 plan goes through its own /auto-flow Stage 1 four-reviewer chain (lighter pass — architectural choice already validated here, so reviewers focus on implementation correctness, not option re-litigation).
+
+## Out of scope for this DECISION plan
+
+- Actual code changes (Phase 2's job).
+- Test plumbing (Phase 2's job).
+- CHANGELOG entry text (Phase 2's job).
+- macbook-monday smoke-test mail (Phase 2's job).
+
+## Operator-intent clarifying question (must resolve BEFORE Phase 2)
+
+P2 + P3 + P4 all independently flagged this as an unresolved ambiguity. The operator's "suggest AI model in config file too" ask has two distinct interpretations and the plan does not adequately tease them apart:
+
+- **(a) Team-default committed for CI pickup.** Operator wants model choice to live in the repo so CI runners (and new dev clones) automatically pick up the team's default without per-machine env-var setup. **This is solvable WITHOUT δ/ε** — committed `.envrc` (direnv) or `.env.example` would do it. P4 verified neither file exists in the repo today, so operator would need to add direnv or similar tooling. Phase-2 would add a `.envrc` template + README pointer instead of a JSON/Zod-schema config file.
+- **(b) Discoverability — "where do I configure forge-harness?"** Operator wants a single visible-to-humans place that lists all available knobs. **This is solvable WITHOUT δ/ε too** — README section + `forge_status` dashboard widget enumerating FORGE_* env vars would do it.
+
+If (a) or (b) is the actual ask, **a sixth option ζ (env-var family + committed `.envrc` + README enumerator)** dominates δ/ε on every axis and lands in v0.40.6 as cleanly as α does.
+
+**This question goes to the operator at ratification time.** All four reviewers voted α regardless of which interpretation wins because α is the cheapest both-direction option (P2's "cheapest mobility" property), so the vote is robust to the unresolved ask. But if operator's answer is (a) or (b), Phase-2's plan should fold ζ into α (one-line `.envrc.example` add + README section), not pursue δ/ε.
+
+## Notes for reviewer chain
+
+1. **You are voting, not iterating.** Do NOT ask for the plan to be iterated to add details about the implementation of the option you favor — that's Phase 2's job. Your vote is a single-letter pick + rationale.
+2. **F6 just shipped (v0.40.5, 30 min ago).** The `KEYCHAIN_SERVICE_NAME` export pattern is fresh precedent for single-source-of-truth between `anthropic.ts` and consumer files. P3 should weigh whether each option upholds or breaks that pattern.
+3. **The original v1 plan reached 4-0 ship-it.** It's the single-option ancestor of α (without A1). If your reasoning matches v1's, vote α + A1.
+4. **Consider operator's likely follow-ups.** If today's operator-UX preference might shift in 6 months (e.g., they start running CI that needs different models per environment), an option that's "just right today" may be "wrong soon." Score multi-step robustness, not just current fit.
+5. **B2's "no current EASY stage" is a real cost.** Don't vote γ if you can't name an EASY stage that will exist within 3 months.
+6. **ε's six-layer resolution is a real cost.** Don't vote ε if you can't justify why a team needs that many surfaces over a one-off two-surface compromise.
+7. **Config-file (δ, ε) means a new schema** — Zod parser, error messages on malformed files, version field for forward-compat. Score that effort honestly.
+8. **The operator implicitly committed to A1** — your vote is over the B/C variants only.
+
+## Revision log
+
+- **2026-05-08T1450Z** — initial draft. Pre-reviewer-chain. 5 option-bundles framed (α/β/γ/δ/ε), all with A1 (obsolescence-aware loud failure) baked in. v1 plan archived to `_quarantine-superseded-plans-20260508/`. Reviewer chain to vote on winner; operator ratifies; Phase-2 implementation plan filed separately. Author: forge-plan.
+
+### Reviewer-chain votes
+
+- **P1 (stateless, 2026-05-08T1505Z): VOTE α — RUNNER-UP β.** Rationale: (1) blast-radius alignment with just-shipped F6 precedent (`anthropic.ts:26` `KEYCHAIN_SERVICE_NAME` export pattern; α extends it verbatim). (2) γ's "EASY stage" cost is real — all 5 current `trackedCallClaude` callsites route reasoning-heavy work; β/γ/δ/ε build dual-model machinery for a customer that doesn't exist; YAGNI applies, file #547 when a real haiku candidate appears. (3) Obsolescence-recovery UX is strongest with α — operator types one `export FORGE_MODEL=` and restarts; δ/ε add Zod schema + migration burden at the moment of breakage. (4) v1 was α-without-A1 at 4-0 ship-it; operator's three questions add A1 (unanimous) but don't invalidate v1's core. β fallback is clean because `stageName` already plumbed. Concerns flagged: (a) if operator has near-term per-stage need, β is materially better at 3-file vs 2-file cost; (b) Phase-2 implementation plan MUST scrub the A1 error message's `forge.config.json` reference (won't exist under α); (c) Phase-2 MUST document F54 IIFE-at-module-load restart caveat.
+- **P2 (comparative, 2026-05-08T1515Z): VOTE α — RUNNER-UP β. AGREES WITH P1.** Rationale: (1) industry-pattern fit on ε cuts AGAINST ε, not for it — forge is an MCP server consumed by an agent (12-factor backend neighborhood: `PG_*`, `REDIS_*`, `AWS_*`), not a human-editable dev tool (Vite/ESLint/Prettier neighborhood). The plan's matrix overrated ε's fit by importing UX expectations from the wrong peer family. (2) Forge's 5-strong FORGE_* family + v0.40.4 I8 + v0.40.5 F6 are a deliberate cultural choice (env-var-all-the-way), not coincidence; δ/ε break the pattern at knob #6 without an inflection-point trigger. (3) The next 3 likely config knobs (per-stage maxTokens, retry policy, log-level) are all per-environment knobs (CI vs local) — exactly the env-var sweet spot. δ's "committable team default" pro is double-edged: a CI runner committing `forge.config.json` with `model: opus-4` then forgetting to bump it on opus deprecation reproduces the obsolescence problem at a different layer. (4) α→β upgrade is 3 LOC + 5 env-vars; δ→α retreat is deprecating a parser without breaking CI consumers. **α has the cheapest both-direction mobility** of all five options — that's the real architectural property worth optimizing for. Push-back on P1: P1's "obsolescence-recovery UX strongest with α" understates β's parity (β has the same one-line export shape; the α-vs-β trade is dual-model-day-1, not recovery). Concerns for operator: (a) **if "haiku for easy" has any concrete near-term candidate (issue, mailbox, retro), upgrade to β NOW** — α-then-β burns a v0.40.x cycle; (b) Phase-2 should add a `// TODO: extend to FORGE_MODEL_<STAGE> when first EASY-tier stage lands` comment at the resolution site so β's extension point is documented in code; (c) **Reconsider δ ONLY if operator's "config file" ask was about COMMITTING model choice into the repo (team-default-with-CI-pickup) rather than discoverability — different value prop, plan didn't fully tease apart.**
+
+- **P3 (cairn-grounded, 2026-05-08T1530Z): VOTE α — RUNNER-UP β. AGREES WITH P1+P2.** Rationale (cairn-grounded, 3 independent grounding points): (1) **F66 (Hybrid-First Design Reflex) is the strongest argument against ε that neither P1 nor P2 cited.** ε's "env vars layered over config file ... six-layer resolution" matches F66's failure shape verbatim ("local + remote ... split responsibility across different execution surfaces"). F66's cure is "enumerate single-locus interception points first" — α IS that single-locus solution; δ fails the same check (config + in-code fallback = two loci with schema between them); γ introduces a categorization seam without a customer. **α is the only option that cleanly survives F66.** (2) **P50 (Additive Optional Fields) cuts AGAINST δ/ε's "config-file is composable" pro.** Each new `FORGE_MODEL_*` env var is additive, opt-in, no schema bump — that IS P50. The plan's matrix overrated δ's composability advantage; env-var families compose just as cleanly without parser/migration burden. (3) **Live P43 violation in `cost.ts:90` (`model ?? "claude-sonnet-4-6"` literal duplicate of `anthropic.ts:7` DEFAULT_MODEL) is a Phase-2 finding the plan should pre-load** — whichever option wins, implementer must replace that literal with an import from the single resolver or it becomes a third source of truth and re-creates F49. α's tiny blast radius makes this trivial; ε's six-layer resolution makes it harder to verify the literal got caught. (4) **F67 (Subagent Schema Fabrication)** — δ/ε create a Zod-schema verification surface α/β don't have. Pattern miscitations in plan: F49 framed as "RISK" but is actually a refusal-class ANTI-pattern (ε structurally invites it); P32's "5-7 knob threshold" is plan-author extrapolation, not canonical. **P1+P2 convergence is EARNED, not groupthink** — three independent grounding points (F66, P50, live cost.ts:90 measurement). Concerns for operator: (a) **live `cost.ts:90` P43 violation must be folded into Phase-2 AC regardless of winner**; (b) Phase-2 must scrub A1 error message's `forge.config.json` reference under α/β; (c) **CONFIRMED P2's earlier flag — if operator's "config file" ask was about CI-picks-up-committed-model-choice (team-default-with-CI-pickup), neither δ/ε is needed; solvable via committed `.envrc`/`direnv`/`.env.example`. Worth clarifying with operator before Phase-2.**
+
+- **P4 (mechanical-sweep, 2026-05-08T1545Z): VOTE α — RUNNER-UP β. AGREES WITH P1+P2+P3. CONVERGENCE AUDIT: EARNED.** Rationale: (1) all cited line numbers verify against current source (`anthropic.ts:7` DEFAULT_MODEL, `:26` KEYCHAIN_SERVICE_NAME, `cost.ts:90` literal duplicate confirmed, `run-context.ts:43-45` stage plumbing confirmed; 5 stage names verified by grep). (2) **Convergence is EARNED, not cascade.** P1 grounds in F6 precedent + YAGNI (mechanical/measurement axis); P2 in industry-pattern reframing (peer-family axis); P3 in F66+P50+live measurement (cairn axis). Three independent axes, three different cited evidences, one converged answer — textbook earned-convergence signature. A cascade would show each reviewer leaning on prior reasoning; instead each found new grounding the prior missed. (3) P3's F49 reclassification (RISK → ANTI-pattern, refusal-class) is verified at `02-anti-patterns.md:343` — INCREASES the case against ε; doesn't change verdict. P32's "5-7 knob threshold" is plan-author extrapolation, corrected. (4) **Matrix imprecision: actual current FORGE_* count is 4 not 5** (`FORGE_BASH_PATH`, `FORGE_CORRECTOR_MAX_TOKENS`, `FORGE_DASHBOARD_AUTO_OPEN`, `FORGE_SPEC_VALIDATOR_MODE`); α brings it to 5, β to 10, γ to 7, δ stays at 4, ε to 10. Directional correctness preserved; cosmetic correction applied. (5) **Operator-intent gap (P2+P3 flag) is real but does not change the vote** — α is the cheapest both-direction option regardless of which interpretation wins, so voting α is robust to the unresolved ask. The clarifying question goes to the operator BEFORE Phase-2 begins. Plan edits applied: matrix corrected; F49 reclassified; P32 threshold marked extrapolation; new §Operator-intent block added; Phase-2 AC scope expanded with cost.ts:90 + error-message scrub + F54 caveat. Final tally: **4-0 unanimous α (β runner-up); convergence audit EARNED.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.40.6](https://github.com/ziyilam3999/forge-harness/compare/v0.40.5...v0.40.6) (2026-05-09)
+
+### Features
+
+- **anthropic:** `FORGE_MODEL` env var to override the default model + obsolescence-aware loud failure on 404 model_not_found (A1). Default unchanged when `FORGE_MODEL` unset. α reads `FORGE_MODEL` at module-load via an IIFE in `anthropic.ts` (mirrors the `FORGE_CORRECTOR_MAX_TOKENS` pattern at `plan.ts:336-348`); whitespace-only values are trimmed and treated as unset (intentional divergence — strictly safer than the corrector's no-trim shape). `DEFAULT_MODEL` is exported and imported by `cost.ts`, killing the live P43 violation at `cost.ts:90` where the literal `"claude-sonnet-4-6"` was duplicated as a default-model fallback. Same export-import shape `KEYCHAIN_SERVICE_NAME` used in F6 v0.40.5. A1 catches `Anthropic.NotFoundError` (typed-class instance check, SDK 0.82.0 `core/error.d.ts:40`) inside `callClaude` and re-throws with operator-actionable guidance (model name verbatim + docs URL + `FORGE_MODEL` reference + restart instruction). Type-disjoint with F6's `AuthenticationError` catch (404 vs 401), so F6's 401-retry path is regression-positive. New `unknownModelWarned` warning method on `CostTracker` follows the `stalePricingWarned` pattern at `cost.ts:44,58` — fires once per instance when an operator-set model is not in the PRICING table; `estimatedCostUsd` stays `null` (P45 + F46 — never silent $0). Architectural choice ratified by Phase-1 4-0 reviewer verdict (option α over β/γ/δ/ε); Phase-2 implementation plan ran a 4-round light reviewer chain (14 implementation-correctness edits across rounds 1, 2, 4; round 3 zero edits — earned convergence). Plan: `.ai-workspace/plans/2026-05-08-forge-model-alpha-a1-implementation.md`. Decision plan: `.ai-workspace/plans/2026-05-08-forge-model-config-decision.md`. Tests: +8 cases (1060 → 1068) — 4 α-cases + 2 A1-cases on `anthropic.test.ts`, 2 cost-cases on `cost.test.ts`. Operators must restart the MCP child to pick up `FORGE_MODEL` changes (F54 trap — module-load read).
+
 ## [0.40.5](https://github.com/ziyilam3999/forge-harness/compare/v0.40.4...v0.40.5) (2026-05-08)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forge-harness",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forge-harness",
-      "version": "0.40.5",
+      "version": "0.40.6",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-harness",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "type": "module",
   "description": "Composable AI primitives — plan, evaluate, generate, coordinate — as a local MCP server",
   "scripts": {

--- a/server/lib/anthropic.test.ts
+++ b/server/lib/anthropic.test.ts
@@ -21,9 +21,24 @@ class MockAuthenticationError extends Error {
   }
 }
 
+// A1 (v0.40.6) — production code branches on `err instanceof Anthropic.NotFoundError`
+// (404 model_not_found). Expose a real, throwable class as a static on the default
+// mock so the `instanceof` check resolves correctly against test-thrown errors.
+// Without this static, `err instanceof Anthropic.NotFoundError` returns false and
+// the A1 catch silently fails to fire — case (v) would pass the test but not exercise
+// the production path.
+class MockNotFoundError extends Error {
+  status = 404;
+  constructor(message = "404 model_not_found") {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
 class MockAnthropic {
   messages = { stream: mockStream, create: mockCreate };
   static AuthenticationError = MockAuthenticationError;
+  static NotFoundError = MockNotFoundError;
 }
 
 vi.mock("@anthropic-ai/sdk", () => {
@@ -610,5 +625,183 @@ describe("F6 — KEYCHAIN_SERVICE_NAME export contract (F49 mitigation)", () => 
   it("exports the canonical Keychain service name as a string constant", async () => {
     const mod = await import("./anthropic.js");
     expect(mod.KEYCHAIN_SERVICE_NAME).toBe("Claude Code-credentials");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// α (v0.40.6) — FORGE_MODEL env var override (AC-A, AC-B, AC-C, AC-D)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// Plan: .ai-workspace/plans/2026-05-08-forge-model-alpha-a1-implementation.md.
+//
+// `DEFAULT_MODEL` is read at module-load via an IIFE (matches
+// FORGE_CORRECTOR_MAX_TOKENS pattern at plan.ts:336-348). Test the resolution
+// order via `vi.resetModules()` + dynamic re-import after mutating
+// `process.env.FORGE_MODEL`. Pattern matches `plan.test.ts:1313-1389` precedent
+// (direct env mutation with manual save/restore).
+describe("α — FORGE_MODEL env var override (AC-A, AC-B, AC-C)", () => {
+  const ORIGINAL_FORGE_MODEL = process.env.FORGE_MODEL;
+
+  afterEach(() => {
+    if (ORIGINAL_FORGE_MODEL === undefined) {
+      delete process.env.FORGE_MODEL;
+    } else {
+      process.env.FORGE_MODEL = ORIGINAL_FORGE_MODEL;
+    }
+  });
+
+  it("(i) FORGE_MODEL=claude-3-7-sonnet → DEFAULT_MODEL reflects it; messages.stream receives that model", async () => {
+    process.env.FORGE_MODEL = "claude-3-7-sonnet";
+    vi.resetModules();
+    const { DEFAULT_MODEL, callClaude, resetClient } = await import("./anthropic.js");
+    resetClient();
+    expect(DEFAULT_MODEL).toBe("claude-3-7-sonnet");
+
+    mockStream.mockReturnValueOnce(
+      streamHandle({
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 2 },
+      }),
+    );
+
+    await callClaude({ system: "s", messages: [{ role: "user", content: "u" }] });
+
+    const sdkArgs = mockStream.mock.calls[0][0];
+    expect(sdkArgs.model).toBe("claude-3-7-sonnet");
+  });
+
+  it("(ii) FORGE_MODEL unset → DEFAULT_MODEL = claude-sonnet-4-6 (AC-B default unchanged)", async () => {
+    delete process.env.FORGE_MODEL;
+    vi.resetModules();
+    const { DEFAULT_MODEL } = await import("./anthropic.js");
+    expect(DEFAULT_MODEL).toBe("claude-sonnet-4-6");
+  });
+
+  it("(iii) FORGE_MODEL='   ' (whitespace-only) → trimmed; default applied", async () => {
+    process.env.FORGE_MODEL = "   ";
+    vi.resetModules();
+    const { DEFAULT_MODEL } = await import("./anthropic.js");
+    expect(DEFAULT_MODEL).toBe("claude-sonnet-4-6");
+  });
+
+  it("(iv) per-call options.model overrides FORGE_MODEL (AC-C)", async () => {
+    process.env.FORGE_MODEL = "claude-3-7-sonnet";
+    vi.resetModules();
+    const { callClaude, resetClient } = await import("./anthropic.js");
+    resetClient();
+
+    mockStream.mockReturnValueOnce(
+      streamHandle({
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 2 },
+      }),
+    );
+
+    await callClaude({
+      system: "s",
+      messages: [{ role: "user", content: "u" }],
+      model: "claude-opus-4-6",
+    });
+
+    const sdkArgs = mockStream.mock.calls[0][0];
+    expect(sdkArgs.model).toBe("claude-opus-4-6");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// A1 (v0.40.6) — obsolescence-aware loud failure on 404 model_not_found
+// ───────────────────────────────────────────────────────────────────────────
+//
+// AC-H: callClaude re-throws Anthropic.NotFoundError as a loud Error whose
+// message contains the model name verbatim, the docs URL, FORGE_MODEL, and a
+// restart instruction.
+//
+// AC-I: A1 does NOT catch non-404 errors. F6's existing 401-retry logic
+// continues to work (regression-positive). Suite-scoped beforeEach sets
+// ANTHROPIC_API_KEY=sk-test-key; case (vi) MUST `delete` it to actually
+// exercise F6's retry path — established precedent at lines 313, 353, 395.
+describe("A1 — callClaude re-throws NotFoundError with operator guidance (AC-H)", () => {
+  it("(v) Anthropic.NotFoundError thrown by stream → re-thrown with model name + docs URL + FORGE_MODEL + restart guidance", async () => {
+    const notFoundErr = new MockNotFoundError("404 model_not_found");
+    mockStream.mockReturnValueOnce({
+      finalMessage: () => Promise.reject(notFoundErr),
+    });
+
+    const { callClaude } = await import("./anthropic.js");
+
+    let caught: Error | undefined;
+    try {
+      await callClaude({
+        system: "s",
+        messages: [{ role: "user", content: "u" }],
+        model: "claude-deprecated-3",
+      });
+      expect.fail("should have thrown");
+    } catch (e) {
+      caught = e as Error;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught!.message).toContain("claude-deprecated-3");
+    expect(caught!.message).toContain(
+      "https://docs.anthropic.com/en/docs/about-claude/models",
+    );
+    expect(caught!.message).toContain("FORGE_MODEL");
+    expect(caught!.message).toContain("Restart");
+    // The original NotFoundError should NOT propagate as-is — A1 wraps it.
+    expect(caught).not.toBe(notFoundErr);
+
+    // Producer-side assertion: stream invoked exactly once (no retry on 404).
+    expect(mockStream).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("A1 — A1 does NOT catch non-404 errors (AC-I, F6 401-retry regression-positive)", () => {
+  it("(vi) Anthropic.AuthenticationError thrown → A1 doesn't intercept; F6's 401-retry runs", async () => {
+    // F6 retry path requires the OAuth fallback (skips when ANTHROPIC_API_KEY
+    // is set). Suite-scoped beforeEach at :65-87 sets it; established precedent
+    // for this delete: anthropic.test.ts:313, 353, 395.
+    delete process.env.ANTHROPIC_API_KEY;
+    const { resetClient } = await import("./anthropic.js");
+    resetClient();
+
+    // Provide a valid OAuth token for getClient()'s fallback path.
+    mockReadFileSync.mockImplementation(() =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "oauth-access-token",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        },
+      }),
+    );
+
+    // First stream() invocation: rejects with 401. Second: resolves normally.
+    // If A1 incorrectly caught AuthenticationError, the second call would
+    // never happen and the test would fail at the call-count assertion.
+    mockStream
+      .mockReturnValueOnce({
+        finalMessage: () => Promise.reject(new MockAuthenticationError()),
+      })
+      .mockReturnValueOnce(
+        streamHandle({
+          content: [{ type: "text", text: "after-retry" }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 4 },
+        }),
+      );
+
+    const { callClaude } = await import("./anthropic.js");
+
+    const result = await callClaude({
+      system: "s",
+      messages: [{ role: "user", content: "u" }],
+    });
+
+    expect(result.text).toBe("after-retry");
+    // Two-surface assertion (P64): producer (call count proves retry ran) +
+    // consumer (returned text proves second call's payload was used).
+    expect(mockStream).toHaveBeenCalledTimes(2);
   });
 });

--- a/server/lib/anthropic.ts
+++ b/server/lib/anthropic.ts
@@ -4,7 +4,35 @@ import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { homedir, userInfo } from "node:os";
 
-const DEFAULT_MODEL = "claude-sonnet-4-6";
+/**
+ * α (v0.40.6) — operator-overridable default model for callClaude.
+ *
+ * Default model for callClaude when the caller does not pass `options.model`.
+ *
+ * Resolution order:
+ *   1. FORGE_MODEL env var (if set + non-whitespace, trimmed)
+ *   2. Built-in fallback: claude-sonnet-4-6
+ *
+ * Reading happens at module-load (IIFE) — matches FORGE_CORRECTOR_MAX_TOKENS
+ * (plan.ts:336-348) convention. Operators who change FORGE_MODEL mid-process
+ * must restart the MCP child to pick it up (F54 trap — same as v0.40.x release
+ * transitions, where dist/index.js is rebuilt at install but the parent Claude
+ * Code process must restart for the new code to load).
+ *
+ * EXPORTED so cost.ts can use the same default for its PRICING-table lookup —
+ * single source-of-truth per F49 (no dual-locus drift between API client's
+ * default and cost tracker's fallback). Same export pattern as
+ * KEYCHAIN_SERVICE_NAME (line 26 below, F6 v0.40.5 precedent).
+ *
+ * Whitespace handling: `raw.trim()` treats whitespace-only env values as
+ * unset. INTENTIONAL DIVERGENCE from FORGE_CORRECTOR_MAX_TOKENS (which
+ * doesn't trim). Plan's behavior is strictly safer (catches "   " typo).
+ */
+export const DEFAULT_MODEL: string = (() => {
+  const raw = process.env.FORGE_MODEL;
+  if (raw && raw.trim()) return raw.trim();
+  return "claude-sonnet-4-6";
+})();
 
 /**
  * F6 (v0.40.5) — macOS Keychain service name for Claude Code's OAuth blob.
@@ -366,6 +394,30 @@ export async function callClaude(options: CallClaudeOptions): Promise<CallClaude
   try {
     response = await getClient().messages.stream(streamArgs).finalMessage();
   } catch (err) {
+    // A1 (v0.40.6) — obsolescence-aware loud failure.
+    //
+    // Anthropic API returns 404 model_not_found when the requested model has
+    // been deprecated. Re-throw with operator-actionable guidance instead of
+    // letting the cryptic SDK error bubble up. Terminal for this catch block —
+    // F6's 401-retry path runs only when err is NOT a NotFoundError.
+    //
+    // SDK 0.82.0 exposes `Anthropic.NotFoundError` as a typed class
+    // (extends `APIError<404, Headers>`) at `core/error.d.ts:40`, re-exported
+    // at `index.d.ts:6`, and as a static on the default Anthropic class at
+    // `client.d.ts:202`. NOT to be confused with `BetaNotFoundError`
+    // (interface) or `shared.NotFoundError` (interface) — use the class form
+    // via `Anthropic.NotFoundError` (default namespace static).
+    if (err instanceof Anthropic.NotFoundError) {
+      const modelName = streamArgs.model;
+      throw new Error(
+        `Anthropic API rejected model "${modelName}" — likely deprecated. ` +
+          `Set FORGE_MODEL to a current model: https://docs.anthropic.com/en/docs/about-claude/models. ` +
+          `Forge-harness ships an in-code default that gets bumped each release; ` +
+          `if you set FORGE_MODEL=${modelName} explicitly, that name has been deprecated separately. ` +
+          `Restart the MCP child after the change (F54 trap).`,
+      );
+    }
+
     const isAuthError = err instanceof Anthropic.AuthenticationError;
     const hasApiKey = Boolean(process.env.ANTHROPIC_API_KEY);
     if (!isAuthError || hasApiKey) {

--- a/server/lib/cost.test.ts
+++ b/server/lib/cost.test.ts
@@ -120,4 +120,69 @@ describe("CostTracker", () => {
     const date = new Date(PRICING_LAST_UPDATED);
     expect(date.toString()).not.toBe("Invalid Date");
   });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // α + P45 (v0.40.6) — unknown-model warning + DEFAULT_MODEL import wiring
+  // ─────────────────────────────────────────────────────────────────────
+  //
+  // Plan: .ai-workspace/plans/2026-05-08-forge-model-alpha-a1-implementation.md.
+  //
+  // (vii) When the operator-set FORGE_MODEL (or per-call model override) is
+  // not in the PRICING table, recordUsage emits a console.error EXACTLY ONCE
+  // per CostTracker instance and records `estimatedCostUsd: null` for every
+  // affected stage (P45 + F46 — never silent $0).
+  //
+  // (viii) cost.ts imports DEFAULT_MODEL from anthropic.ts (kills the live
+  // P43 violation at the previous `?? "claude-sonnet-4-6"` literal). When
+  // recordUsage is called without an explicit model, the fallback resolves
+  // through the imported constant — verified by observing that the sonnet
+  // pricing applies (and not, say, throwing or null'ing).
+  it("(vii) warns once per CostTracker instance for unknown models (P45)", () => {
+    const tracker = new CostTracker();
+    tracker.recordUsage("planner", 100, 50, "claude-3-7-sonnet");
+    tracker.recordUsage("critic", 200, 100, "claude-3-7-sonnet");
+    tracker.recordUsage("evaluator", 50, 25, "claude-3-7-sonnet");
+
+    // Filter to the unknown-model warnings (excludes the staleness warning,
+    // which fires unconditionally if PRICING_LAST_UPDATED is more than 90 days old).
+    const calls = (console.error as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const unknownModelWarnings = calls.filter((c) =>
+      String(c[0] ?? "").includes("is not in the cost-tracking PRICING table"),
+    );
+
+    expect(unknownModelWarnings).toHaveLength(1);
+    expect(String(unknownModelWarnings[0][0])).toContain('"claude-3-7-sonnet"');
+    expect(String(unknownModelWarnings[0][0])).toContain("claude-sonnet-4-6");
+    expect(String(unknownModelWarnings[0][0])).toContain("Estimates will be null");
+
+    // All three stages recorded with null cost.
+    const summary = tracker.summarize();
+    expect(summary.breakdown).toHaveLength(3);
+    expect(summary.breakdown.every((s) => s.estimatedCostUsd === null)).toBe(true);
+    expect(tracker.totalCostUsd).toBeNull();
+  });
+
+  it("(viii) recordUsage falls back to DEFAULT_MODEL imported from anthropic.ts (kills cost.ts:90 P43 violation)", async () => {
+    // DEFAULT_MODEL with FORGE_MODEL unset = "claude-sonnet-4-6". cost.ts:90
+    // previously hardcoded that same literal — now it imports DEFAULT_MODEL,
+    // so this test verifies (a) the import wiring landed AND (b) the runtime
+    // fallback still resolves to the sonnet PRICING row.
+    const { DEFAULT_MODEL } = await import("./anthropic.js");
+    expect(DEFAULT_MODEL).toBe("claude-sonnet-4-6"); // pre-condition pin
+
+    const tracker = new CostTracker();
+    // No model arg → falls back to DEFAULT_MODEL.
+    tracker.recordUsage("planner", 1_000_000, 0);
+
+    // sonnet input: 1M * 3.0/M = 3.0. Non-null cost proves the fallback hit
+    // a known PRICING row — i.e. DEFAULT_MODEL resolved to a sonnet variant.
+    expect(tracker.totalCostUsd).toBeCloseTo(3.0);
+
+    // No unknown-model warning fired (DEFAULT_MODEL is in PRICING).
+    const calls = (console.error as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const unknownModelWarnings = calls.filter((c) =>
+      String(c[0] ?? "").includes("is not in the cost-tracking PRICING table"),
+    );
+    expect(unknownModelWarnings).toHaveLength(0);
+  });
 });

--- a/server/lib/cost.ts
+++ b/server/lib/cost.ts
@@ -6,6 +6,8 @@
  * output that wastes all tokens spent so far.
  */
 
+import { DEFAULT_MODEL } from "./anthropic.js";
+
 /** Hardcoded pricing per million tokens (USD). */
 const PRICING = {
   "claude-sonnet-4-6": { inputPerMillion: 3.0, outputPerMillion: 15.0 },
@@ -42,6 +44,7 @@ export class CostTracker {
   private budgetUsd: number | null;
   private isOAuth: boolean;
   private stalePricingWarned = false;
+  private unknownModelWarned = false;
 
   constructor(options: { budgetUsd?: number; isOAuth?: boolean } = {}) {
     this.budgetUsd = options.budgetUsd ?? null;
@@ -60,6 +63,26 @@ export class CostTracker {
       );
       this.stalePricingWarned = true;
     }
+  }
+
+  /**
+   * P45 (v0.40.6) — warn once per CostTracker instance when the operator-set
+   * FORGE_MODEL (or per-call override) is not in the PRICING table.
+   *
+   * Mirrors `stalePricingWarned` (lines 44, 58) — single-instance latch so
+   * the warning fires exactly once even if many `recordUsage` calls land for
+   * the same unknown model in one run. Estimates remain `null` (P45 + F46:
+   * never silent $0 — operators must distinguish "no PRICING row" from
+   * "actual zero").
+   */
+  private warnUnknownModel(model: string): void {
+    if (this.unknownModelWarned) return;
+    console.error(
+      `forge: model "${model}" is not in the cost-tracking PRICING table ` +
+        `(known: ${Object.keys(PRICING).join(", ")}). ` +
+        `Estimates will be null for this run; calls still proceed.`,
+    );
+    this.unknownModelWarned = true;
   }
 
   /**
@@ -87,12 +110,14 @@ export class CostTracker {
     }
 
     let costUsd: number | null = null;
-    const effectiveModel = model ?? "claude-sonnet-4-6";
+    const effectiveModel = model ?? DEFAULT_MODEL;
     if (isPricingModel(effectiveModel)) {
       const pricing = PRICING[effectiveModel];
       costUsd =
         (inputTokens / 1_000_000) * pricing.inputPerMillion +
         (outputTokens / 1_000_000) * pricing.outputPerMillion;
+    } else {
+      this.warnUnknownModel(effectiveModel);
     }
 
     this.stages.push({

--- a/server/lib/run-context.test.ts
+++ b/server/lib/run-context.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { CallClaudeResult } from "./anthropic.js";
 
-// Mock the anthropic module
+// Mock the anthropic module. `DEFAULT_MODEL` is the α (v0.40.6) export — cost.ts
+// imports it as the fallback when no model is supplied to recordUsage. Without
+// it on the mock, cost.ts throws "No DEFAULT_MODEL export is defined" the moment
+// trackedCallClaude reaches its CostTracker.recordUsage call.
 vi.mock("./anthropic.js", () => ({
   callClaude: vi.fn(),
+  DEFAULT_MODEL: "claude-sonnet-4-6",
 }));
 
 // Mock audit to avoid file I/O


### PR DESCRIPTION
## Summary

- **α** — `FORGE_MODEL` env var read at module-load via IIFE in `anthropic.ts` (mirrors `FORGE_CORRECTOR_MAX_TOKENS` pattern). Defaults to `claude-sonnet-4-6` when unset (zero behavior change for existing operators). `DEFAULT_MODEL` exported and imported by `cost.ts`, killing the live P43 violation at `cost.ts:90` where the literal was duplicated. Same export-import shape F6 v0.40.5 used for `KEYCHAIN_SERVICE_NAME`.
- **A1** — `callClaude` catches `Anthropic.NotFoundError` (404 model_not_found) and re-throws with operator-actionable guidance (set FORGE_MODEL + docs URL + restart instruction). Type-disjoint with F6's `AuthenticationError` catch (404 vs 401), so F6's 401-retry path is regression-positive.
- **`cost.ts` P45 warning** — new `unknownModelWarned` method following the `stalePricingWarned` pattern at `cost.ts:44,58`. When operator sets `FORGE_MODEL` to a model not in the PRICING table, `console.error` fires once per `CostTracker` instance and `estimatedCostUsd` stays `null` (P45 + F46 — never silent $0).

## Process

- Phase-1 decision plan ratified by 4-0 reviewer verdict on option α (over β/γ/δ/ε). See `.ai-workspace/plans/2026-05-08-forge-model-config-decision.md`.
- Phase-2 implementation plan ran a 4-round light reviewer chain — ship-it after 14 implementation-correctness edits across rounds 1, 2, 4 (round 3 zero edits). See `.ai-workspace/plans/2026-05-08-forge-model-alpha-a1-implementation.md`.

## Tests

- 1060 → **1068** (+8 cases). 4 α + 2 A1 in `anthropic.test.ts`, 2 in `cost.test.ts`.
- AC-G grep: zero `"claude-sonnet-4-6"` literal in `cost.ts` outside the legitimate PRICING table key (line 13).
- AC-E `npm run build` exits 0.

## Operator-restart caveat (F54 trap)

`FORGE_MODEL` is read at module-load (IIFE). Operators who set or change the env var mid-process MUST restart the MCP child to pick it up — same trap as v0.40.x release transitions where `dist/index.js` is rebuilt at install but the parent Claude Code process must restart for the new code to load.

## Test plan

- [x] `npm run build` exits 0
- [x] `npm test` — 1068/1068 pass
- [x] AC-G grep: zero matches in default-fallback site
- [ ] CI green (Linux/macOS/Windows)
- [ ] Smoke (deferred to macbook-monday post-merge): `FORGE_MODEL=claude-haiku-4-5 forge_evaluate('US-13')` exercises α; `FORGE_MODEL=claude-3-7-sonnet ...` exercises P45 unknown-model warning; `FORGE_MODEL=claude-2.0 ...` exercises A1.