### PR TITLE
docs: README Troubleshooting section for Max-plan OAuth-tier 429 (#549)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ npm test          # Run Vitest suite
 npm run lint      # Run ESLint
 ```
 
+## Troubleshooting
+
+### Max-plan OAuth-tier rate-limit (429)
+
+If you're running forge-harness with Claude Code's Max-plan OAuth login (no `ANTHROPIC_API_KEY` set), high-volume spec regeneration can hit the Max-plan OAuth rate-limit bucket. The OAuth bucket is **separate from the API-key bucket** — it has its own (tighter, undocumented) limits and isn't visible in the Anthropic console.
+
+Symptoms:
+
+- `spec-gen-shell-only` warning with `429 rate_limit_error` in the run record
+- Often co-emitted with a misleading `spec-gen-creds-keychain-only` warning (see [#546](https://github.com/ziyilam3999/forge-harness/issues/546))
+- The failing request_ids do **not** appear in your Anthropic console Logs view — because that console only shows API-key traffic
+
+**Workaround:** set `ANTHROPIC_API_KEY` from a separate API-key identity. The API-key path uses a different rate-limit bucket and bypasses the OAuth tier entirely. API-key traffic is also visible in your Anthropic console for cost tracking.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Get an API key at: https://console.anthropic.com/settings/keys
+
+After setting the env var, restart Claude Code so the forge MCP child picks up the new environment.
+
 ## Architecture
 
 Forge runs as a local MCP server — a Node subprocess that Claude Code (or any MCP client) connects to over stdio. No network calls except `forge_plan`'s LLM round-trip; everything else stays on your machine.


### PR DESCRIPTION
## Summary
Adds a `## Troubleshooting` section with a `### Max-plan OAuth-tier rate-limit (429)` H3 documenting the OAuth-vs-API-key separate-bucket diagnosis and the `ANTHROPIC_API_KEY` workaround.

## Diagnosis (confirmed 2026-05-09)
- Operator queried `console.anthropic.com` Logs view; only API-key tier requests are visible.
- macbook-monday's two failing 429 request_ids (`req_011Car5MF8ndJ4KDzMwWvpBn`, `req_011CarTPBD1eTYEU8uHyQo3z`) on Max-plan OAuth path do NOT appear in console.
- Conclusion: OAuth/Max-plan and API-key are completely separate rate-limit buckets. Max-plan OAuth bucket is tighter and invisible to the console.

## Test plan
- [x] `grep -F "Max-plan OAuth-tier rate-limit" README.md` → exit 0 (AC-549-1)
- [x] `grep -F "export ANTHROPIC_API_KEY=" README.md` → exit 0 (AC-549-2)
- [x] `grep -F "console.anthropic.com/settings/keys" README.md` → exit 0 (AC-549-3)
- [x] New section under H2 `## Troubleshooting` (AC-549-4)
- [x] No code changes; markdown only

## Related
- Closes #549
- Cross-refs #546 (co-emitted misleading keychain-only warning — same root cause, different surface)
- Plan: `.ai-workspace/plans/2026-05-09-audit-thread-fix-batch-549-546-548-544.md` Task 1 of 4