### PR TITLE
feat(spec-generator): surface retry-after header on 429 RateLimitError (#548)

### DIFF
--- a/server/lib/spec-generator.test.ts
+++ b/server/lib/spec-generator.test.ts
@@ -897,3 +897,124 @@ describe("spec-generator — I6 shell-only path (LLM unavailable)", () => {
     }
   });
 });
+
+// #548 (v0.40.7) — Surface Anthropic's `retry-after` header on 429 in the
+// spec-gen-shell-only warning so operators know when it's safe to retry.
+//
+// The SDK exposes `RateLimitError` (extends APIError<429, Headers>) with a
+// `Headers` Web-API instance. Accessor is `.get('retry-after')` —
+// bracket-index is a TS error.
+describe("spec-generator — #548 retry-after surfaced on 429 RateLimitError", () => {
+  let tmp: string;
+  let ctx: RunContext;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-548-"));
+    ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  // AC-548-1 — RateLimitError with retry-after: N → message contains "retry after Ns".
+  it("AC-548-1: includes retry-after seconds when 429 with header", async () => {
+    // Mock Anthropic.RateLimitError shape — same nominal-typing pattern used
+    // in anthropic.test.ts (static <X>Error = Mock<X>Error precedent).
+    const Anthropic = await import("@anthropic-ai/sdk");
+    const headers = new Headers({ "retry-after": "60" });
+    const rateLimitErr = new Anthropic.default.RateLimitError(
+      429,
+      { type: "error", error: { type: "rate_limit_error", message: "Error" } },
+      undefined,
+      headers,
+    );
+    const synthThrowsRateLimit = async (): Promise<SynthesisResponse> => {
+      throw rateLimitErr;
+    };
+    const result = await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: synthThrowsRateLimit,
+    });
+    const shellOnly = result.warnings.find((w) => w.kind === "spec-gen-shell-only");
+    expect(shellOnly).toBeDefined();
+    if (shellOnly && shellOnly.kind === "spec-gen-shell-only") {
+      expect(shellOnly.message).toContain("retry after 60s");
+    }
+  });
+
+  // AC-548-2 — non-RateLimitError synth throw produces message WITHOUT retry-after.
+  it("AC-548-2: non-RateLimitError throw produces message without retry-after", async () => {
+    const synthThrowsGeneric = async (): Promise<SynthesisResponse> => {
+      throw new Error("ENOTFOUND api.anthropic.com");
+    };
+    const result = await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: synthThrowsGeneric,
+    });
+    const shellOnly = result.warnings.find((w) => w.kind === "spec-gen-shell-only");
+    expect(shellOnly).toBeDefined();
+    if (shellOnly && shellOnly.kind === "spec-gen-shell-only") {
+      expect(shellOnly.message).not.toContain("retry after");
+    }
+  });
+
+  // AC-548-2 (no-header coverage) — RateLimitError WITHOUT the header → no suffix.
+  it("AC-548-2: RateLimitError without retry-after header produces unsuffixed message", async () => {
+    const Anthropic = await import("@anthropic-ai/sdk");
+    const headers = new Headers(); // empty — no retry-after
+    const rateLimitNoHeader = new Anthropic.default.RateLimitError(
+      429,
+      { type: "error", error: { type: "rate_limit_error", message: "Error" } },
+      undefined,
+      headers,
+    );
+    const synthThrowsNoHeader = async (): Promise<SynthesisResponse> => {
+      throw rateLimitNoHeader;
+    };
+    const result = await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: synthThrowsNoHeader,
+    });
+    const shellOnly = result.warnings.find((w) => w.kind === "spec-gen-shell-only");
+    expect(shellOnly).toBeDefined();
+    if (shellOnly && shellOnly.kind === "spec-gen-shell-only") {
+      expect(shellOnly.message).not.toContain("retry after");
+    }
+  });
+
+  // Non-numeric retry-after value (HTTP-date fallback) — preserved verbatim.
+  it("AC-548-1 (HTTP-date variant): non-integer retry-after is preserved verbatim", async () => {
+    const Anthropic = await import("@anthropic-ai/sdk");
+    const httpDate = "Wed, 21 Oct 2026 07:28:00 GMT";
+    const headers = new Headers({ "retry-after": httpDate });
+    const rateLimitDate = new Anthropic.default.RateLimitError(
+      429,
+      { type: "error", error: { type: "rate_limit_error", message: "Error" } },
+      undefined,
+      headers,
+    );
+    const synthThrowsDate = async (): Promise<SynthesisResponse> => {
+      throw rateLimitDate;
+    };
+    const result = await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: synthThrowsDate,
+    });
+    const shellOnly = result.warnings.find((w) => w.kind === "spec-gen-shell-only");
+    if (shellOnly && shellOnly.kind === "spec-gen-shell-only") {
+      expect(shellOnly.message).toContain(`retry after ${httpDate}`);
+    }
+  });
+});

--- a/server/lib/spec-generator.ts
+++ b/server/lib/spec-generator.ts
@@ -19,6 +19,7 @@
  * The merge is by `id`, not by position.
  */
 
+import Anthropic from "@anthropic-ai/sdk";
 import { readFileSync, mkdirSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { userInfo } from "node:os";
@@ -637,7 +638,31 @@ export async function generateSpecForStory(
     });
   } catch (err) {
     shellOnly = true;
-    const raw = err instanceof Error ? err.message : String(err);
+    let raw = err instanceof Error ? err.message : String(err);
+
+    // #548 (v0.40.7) — surface Anthropic's `retry-after` header on 429 so
+    // operators know when it's safe to retry. The SDK exposes `RateLimitError`
+    // (extends APIError<429, Headers>) with a `Headers` Web-API instance —
+    // accessor is `.get('retry-after')` (NOT bracket-index — Headers is a
+    // class, not a record).
+    //
+    // The header value per RFC 7231 §7.1.3 is either:
+    //   - integer seconds (most common — Anthropic returns this shape)
+    //   - HTTP-date (RFC 1123) — fallback parse
+    //
+    // We append the parsed/raw value to `raw` BEFORE the truncation step
+    // so the suffix lives inside the warning's visible window.
+    if (err instanceof Anthropic.RateLimitError) {
+      const retryAfter = err.headers?.get("retry-after");
+      if (retryAfter) {
+        const seconds = Number.parseInt(retryAfter, 10);
+        const suffix = Number.isFinite(seconds) && seconds > 0
+          ? ` (retry after ${seconds}s)`
+          : ` (retry after ${retryAfter})`;
+        raw = `${raw}${suffix}`;
+      }
+    }
+
     shellOnlyMessage =
       raw.length > SHELL_ONLY_MESSAGE_MAX
         ? raw.slice(0, SHELL_ONLY_MESSAGE_MAX) + "…(truncated)"


### PR DESCRIPTION
## Summary
Parse Anthropic's `retry-after` header on 429 `RateLimitError` and append a human-readable hint to the `spec-gen-shell-only` warning body. Operators get a concrete retry signal instead of opaque raw 429 JSON.

## Format
- Integer seconds (most common Anthropic shape): `... (retry after 60s)`
- HTTP-date (RFC 1123 fallback): `... (retry after Wed, 21 Oct 2026 07:28:00 GMT)`
- No header / non-RateLimitError: unchanged (no suffix)

## SDK shape note
`RateLimitError extends APIError<429, Headers>` per `node_modules/@anthropic-ai/sdk/core/error.d.ts:46`. `Headers` is the Web API class — accessor is `.get(name)`, NOT bracket-index.

## Test plan
- [x] AC-548-1: integer retry-after produces `(retry after 60s)` suffix
- [x] AC-548-1 HTTP-date variant: non-integer value is preserved verbatim
- [x] AC-548-2: non-RateLimitError throw produces no suffix
- [x] AC-548-2: RateLimitError WITHOUT header produces no suffix
- [x] AC-548-3: `npm test -- spec-generator` exit 0 (29/29 tests pass)
- [x] AC-548-4: mock RateLimitError instantiated via real SDK class (matches anthropic.test.ts mock-class precedent)

## Related
- Closes #548
- Stacks on #546 (PR #551) — same file, different sub-locus (catch block at :638-644 vs warning emit at :688). Branched from origin/master so atomic-revert preserved.
- Plan: `.ai-workspace/plans/2026-05-09-audit-thread-fix-batch-549-546-548-544.md` Task 3 of 4