### PR TITLE
feat(status): emit staleSpecWarning when TECHNICAL-SPEC.md older than FORGE_SPEC_STALE_DAYS (#544)

### DIFF
--- a/server/tools/status.test.ts
+++ b/server/tools/status.test.ts
@@ -411,3 +411,147 @@ describe("forge_status + forge_declare_story — activeRun (AC-8a)", () => {
     expect(r.isError).toBe(true);
   });
 });
+
+// #544 (v0.40.7) — staleSpecWarning surfaced when docs/generated/TECHNICAL-SPEC.md
+// is older than FORGE_SPEC_STALE_DAYS (default 30). Probe runs on every
+// non-no-forge-dir status response. Field omitted when fresh / absent /
+// stat-error.
+describe("forge_status — #544 staleSpecWarning (TECHNICAL-SPEC.md staleness)", () => {
+  let projectPath: string;
+
+  beforeEach(async () => {
+    projectPath = makeTmpDir();
+    await mkdir(join(projectPath, ".forge", "runs"), { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(projectPath, { recursive: true, force: true });
+  });
+
+  // AC-544-1 — stale spec emits banner.
+  it("AC-544-1: emits staleSpecWarning when TECHNICAL-SPEC.md older than threshold", async () => {
+    const specDir = join(projectPath, "docs", "generated");
+    await mkdir(specDir, { recursive: true });
+    const specPath = join(specDir, "TECHNICAL-SPEC.md");
+    await writeFile(specPath, "# Stale spec\n");
+    // Backdate mtime to 35d ago (> default 30d threshold).
+    const thirtyFiveDaysAgo = Date.now() - 35 * 24 * 60 * 60 * 1000;
+    const utimes = (await import("node:fs/promises")).utimes;
+    await utimes(specPath, new Date(thirtyFiveDaysAgo), new Date(thirtyFiveDaysAgo));
+
+    // Need a record so we land in case-5 (snapshot), not case-3 (no-runs).
+    await writeFile(
+      join(projectPath, ".forge", "runs", "r1.json"),
+      JSON.stringify(makeRecord("US-01", "PASS", new Date().toISOString())),
+    );
+
+    const result = await handleStatus({ projectPath });
+    const body = parseBody(result);
+    expect(body.staleSpecWarning).toBeDefined();
+    expect(body.staleSpecWarning).toContain("TECHNICAL-SPEC.md");
+    expect(body.staleSpecWarning).toContain("days old");
+    expect(body.staleSpecWarning).toMatch(/3[5-9] days old/); // 35-39d window
+  });
+
+  // AC-544-2 — fresh spec → no banner.
+  it("AC-544-2: omits staleSpecWarning when TECHNICAL-SPEC.md is fresh", async () => {
+    const specDir = join(projectPath, "docs", "generated");
+    await mkdir(specDir, { recursive: true });
+    await writeFile(join(specDir, "TECHNICAL-SPEC.md"), "# Fresh spec\n");
+    // Default mtime ≈ now → not stale.
+
+    await writeFile(
+      join(projectPath, ".forge", "runs", "r1.json"),
+      JSON.stringify(makeRecord("US-01", "PASS", new Date().toISOString())),
+    );
+
+    const result = await handleStatus({ projectPath });
+    const body = parseBody(result);
+    expect(body.staleSpecWarning).toBeUndefined();
+  });
+
+  // AC-544-3 — file absent → no banner.
+  it("AC-544-3: omits staleSpecWarning when TECHNICAL-SPEC.md is absent", async () => {
+    // No spec file written. Add a run record so we exercise the snapshot path.
+    await writeFile(
+      join(projectPath, ".forge", "runs", "r1.json"),
+      JSON.stringify(makeRecord("US-01", "PASS", new Date().toISOString())),
+    );
+
+    const result = await handleStatus({ projectPath });
+    const body = parseBody(result);
+    expect(body.staleSpecWarning).toBeUndefined();
+  });
+
+  // AC-544-4 — boot-time validation: bad env value throws via the parser
+  // function (extracted from the IIFE for testability — Vitest's bundler
+  // doesn't support query-string cache-bust, so re-import would not
+  // re-evaluate the module).
+  it("AC-544-4: parseSpecStaleDays('foo') throws operator-actionable error", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(() => parseSpecStaleDays("foo")).toThrow(
+      /FORGE_SPEC_STALE_DAYS must be a positive integer/,
+    );
+  });
+
+  it("AC-544-4: parseSpecStaleDays('-5') throws operator-actionable error", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(() => parseSpecStaleDays("-5")).toThrow(
+      /FORGE_SPEC_STALE_DAYS must be a positive integer/,
+    );
+  });
+
+  it("AC-544-4: parseSpecStaleDays('0') throws (must be >= 1)", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(() => parseSpecStaleDays("0")).toThrow(
+      /FORGE_SPEC_STALE_DAYS must be a positive integer/,
+    );
+  });
+
+  it("AC-544-4: parseSpecStaleDays(undefined) returns default 30", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(parseSpecStaleDays(undefined)).toBe(30);
+  });
+
+  it("AC-544-4: parseSpecStaleDays('') returns default 30 (empty equiv to unset)", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(parseSpecStaleDays("")).toBe(30);
+  });
+
+  it("AC-544-4: parseSpecStaleDays('  60  ') trims and returns 60", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(parseSpecStaleDays("  60  ")).toBe(60);
+  });
+
+  // probeSpecStaleness directly — unit-level test for the helper itself.
+  it("probeSpecStaleness: returns banner when threshold breached", async () => {
+    const { probeSpecStaleness } = await import("./status.js");
+    const specDir = join(projectPath, "docs", "generated");
+    await mkdir(specDir, { recursive: true });
+    const specPath = join(specDir, "TECHNICAL-SPEC.md");
+    await writeFile(specPath, "x");
+    const oldMs = Date.now() - 100 * 24 * 60 * 60 * 1000; // 100d ago
+    const utimes = (await import("node:fs/promises")).utimes;
+    await utimes(specPath, new Date(oldMs), new Date(oldMs));
+
+    // Inject threshold + nowFn for deterministic test.
+    const banner = await probeSpecStaleness(projectPath, 30, () => Date.now());
+    expect(banner).toBeDefined();
+    expect(banner).toMatch(/100 days old/);
+  });
+
+  it("probeSpecStaleness: returns undefined when fresh (below threshold)", async () => {
+    const { probeSpecStaleness } = await import("./status.js");
+    const specDir = join(projectPath, "docs", "generated");
+    await mkdir(specDir, { recursive: true });
+    await writeFile(join(specDir, "TECHNICAL-SPEC.md"), "x");
+    // Fresh: just-written, 0 days old.
+    const banner = await probeSpecStaleness(projectPath, 30);
+    expect(banner).toBeUndefined();
+  });
+
+  it("probeSpecStaleness: returns undefined silently when file absent (ENOENT)", async () => {
+    const { probeSpecStaleness } = await import("./status.js");
+    const banner = await probeSpecStaleness(projectPath, 30);
+    expect(banner).toBeUndefined();
+  });
+});

--- a/server/tools/status.ts
+++ b/server/tools/status.ts
@@ -5,6 +5,79 @@ import { readRunRecords, type PrimaryRecord, type TaggedRunRecord } from "../lib
 import { getDeclaration } from "../lib/declaration-store.js";
 import type { RunRecord } from "../lib/run-record.js";
 
+/**
+ * #544 (v0.40.7) — parse FORGE_SPEC_STALE_DAYS env var.
+ *
+ * Resolution: undefined / empty → 30 fallback. Otherwise parsed integer
+ * ≥ 1, else throw with operator-actionable error (F46 — Silent Numeric
+ * Default avoided; loud failure preserved).
+ *
+ * Exported so tests can drive the parser directly without re-importing
+ * this module (Vitest bundler doesn't support query-string cache-bust).
+ */
+export function parseSpecStaleDays(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === "") return 30;
+  const parsed = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(
+      `FORGE_SPEC_STALE_DAYS must be a positive integer (got "${raw}"). ` +
+        `Set to a number of days >= 1, or unset for the default of 30.`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Module-load IIFE — single-source-of-truth resolution per v0.40.6's
+ * FORGE_MODEL precedent at `server/lib/anthropic.ts:6-7`. F49+P43 risk/
+ * mitigation pair (single locus avoids dual-level enforcement).
+ *
+ * Throws at module load on bad env input — operator sees the failure
+ * before any forge tool dispatches.
+ */
+export const SPEC_STALE_DAYS_THRESHOLD: number = parseSpecStaleDays(
+  process.env.FORGE_SPEC_STALE_DAYS,
+);
+
+const SPEC_REL_PATH = "docs/generated/TECHNICAL-SPEC.md";
+
+/**
+ * Probe `docs/generated/TECHNICAL-SPEC.md` for staleness. Returns the
+ * human-friendly banner string when the file is older than the threshold,
+ * or undefined when fresh / absent / unstattable.
+ *
+ * F45 escape: a `fs.stat` error (broken symlink, permission denied) is
+ * logged to stderr (loud-failure for ops visibility) but does NOT throw —
+ * forge_status is read-only and partial info is always better than a
+ * thrown error.
+ */
+export async function probeSpecStaleness(
+  projectPath: string,
+  thresholdDays: number = SPEC_STALE_DAYS_THRESHOLD,
+  nowFn: () => number = () => Date.now(),
+): Promise<string | undefined> {
+  const specPath = join(projectPath, SPEC_REL_PATH);
+  let mtimeMs: number;
+  try {
+    const s = await stat(specPath);
+    mtimeMs = s.mtimeMs;
+  } catch (err) {
+    // ENOENT (file not generated yet) is expected on a fresh repo —
+    // silent return. Other errors (permission, broken symlink) are loud
+    // for ops visibility.
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "ENOENT") {
+      console.error(
+        `forge_status: stat failed for ${SPEC_REL_PATH} (${code ?? "unknown"}); skipping staleness probe.`,
+      );
+    }
+    return undefined;
+  }
+  const daysSinceUpdate = Math.floor((nowFn() - mtimeMs) / (1000 * 60 * 60 * 24));
+  if (daysSinceUpdate < thresholdDays) return undefined;
+  return `⚠ TECHNICAL-SPEC.md is ${daysSinceUpdate} days old (forge_evaluate to refresh)`;
+}
+
 // ── Zod schema for MCP input ────────────────────────────────
 
 const scopeSchema = z
@@ -90,6 +163,15 @@ export interface StatusOutput {
   };
   corruptedFiles?: string[];
   reason?: string;
+  /**
+   * #544 (v0.40.7) — human-readable banner emitted when
+   * `docs/generated/TECHNICAL-SPEC.md` is older than the
+   * FORGE_SPEC_STALE_DAYS threshold (default 30). Field omitted when
+   * fresh, absent, or stat-error. Additive optional per P50 — agent
+   * consumers can detect staleness via field presence; the string
+   * contains the human-friendly banner for prose surfaces.
+   */
+  staleSpecWarning?: string;
 }
 
 // ── Internal helpers ────────────────────────────────────────
@@ -391,6 +473,10 @@ export async function handleStatus(input: StatusInput): Promise<McpResponse> {
   // Read disk records + detect corruption.
   const { records, corruptedFiles } = await readDiskRecordsWithCorruption(projectPath);
 
+  // #544 — probe TECHNICAL-SPEC.md staleness for cases that return non-empty
+  // bodies. Silent on ENOENT (no spec yet); loud on other stat errors.
+  const staleSpecWarning = await probeSpecStaleness(projectPath);
+
   // Filter to primary records and by scope.
   const primaryAll = records.filter(
     (r): r is PrimaryRecord => r.source === "primary",
@@ -425,6 +511,7 @@ export async function handleStatus(input: StatusInput): Promise<McpResponse> {
       activeRun,
       totals,
       corruptedFiles,
+      ...(staleSpecWarning ? { staleSpecWarning } : {}),
     };
     return { content: [{ type: "text", text: JSON.stringify(body, null, 2) }] };
   }
@@ -436,6 +523,7 @@ export async function handleStatus(input: StatusInput): Promise<McpResponse> {
       generatedAt,
       reason: "no-runs",
       activeRun,
+      ...(staleSpecWarning ? { staleSpecWarning } : {}),
     };
     return { content: [{ type: "text", text: JSON.stringify(body, null, 2) }] };
   }
@@ -447,6 +535,7 @@ export async function handleStatus(input: StatusInput): Promise<McpResponse> {
       generatedAt,
       reason: "scope-miss",
       activeRun,
+      ...(staleSpecWarning ? { staleSpecWarning } : {}),
     };
     return { content: [{ type: "text", text: JSON.stringify(body, null, 2) }] };
   }
@@ -461,6 +550,7 @@ export async function handleStatus(input: StatusInput): Promise<McpResponse> {
     stories,
     activeRun,
     totals,
+    ...(staleSpecWarning ? { staleSpecWarning } : {}),
   };
 
   return { content: [{ type: "text", text: JSON.stringify(body, null, 2) }] };


### PR DESCRIPTION
## Summary
Add `staleSpecWarning?: string` field to `forge_status` response body. Populated with a banner like `⚠ TECHNICAL-SPEC.md is N days old (forge_evaluate to refresh)` when the spec file's mtime exceeds the configured threshold (default 30 days, env-var overridable via `FORGE_SPEC_STALE_DAYS`).

## Design choices (locked pre-implementation per plan §Decision points)
- **Field shape**: separate `staleSpecWarning?: string` field (NOT body-prefix), additive optional per P50. Agent consumers detect via field presence; humans read the prose.
- **Threshold default**: 30 days. Env-var override `FORGE_SPEC_STALE_DAYS`. Rejected: per-project config-file (F66 hybrid-first concern).
- **Loud failure**: bad env value throws at module load with operator-actionable error (F46 — Silent Numeric Default avoided).
- **Silent omission**: fresh / absent / ENOENT → no banner. Other stat errors → stderr warn + no banner (F45 escape; status is read-only, partial info > thrown error).

## Cairn references
- F49 + P43 (risk/mitigation pair) — env-var IIFE single-source-of-truth, mirrors v0.40.6 FORGE_MODEL precedent.
- P50 — additive-optional field shape (backward compat preserved).
- F45 / F46 — loud-failure on parse errors / no silent numeric defaults.
- F66 — rejected per-project config-file shape.

## Implementer note
The plan stipulated testing the IIFE error path via dynamic re-import with cache-bust. Vitest's bundler doesn't support query-string cache-bust. **Refactored**: extracted parser into `parseSpecStaleDays(raw)` exported function; IIFE calls it. Tests drive the parser directly. Module-load throw still works in production.

## Test plan
- [x] AC-544-1: `staleSpecWarning` populated when TECHNICAL-SPEC.md backdated 35d (uses `fs.utimes`)
- [x] AC-544-2: omitted when fresh
- [x] AC-544-3: omitted when absent
- [x] AC-544-4: `parseSpecStaleDays('foo' | '-5' | '0')` throws `/FORGE_SPEC_STALE_DAYS must be a positive integer/`
- [x] AC-544-4: `parseSpecStaleDays(undefined | '')` returns 30 default
- [x] AC-544-4: `parseSpecStaleDays('  60  ')` trims and returns 60
- [x] AC-544-5: `npm test -- status` exit 0 (27/27 tests pass)
- [x] AC-544-6: `grep -nE "FORGE_SPEC_STALE_DAYS|staleSpecWarning"` references both source + test files
- [x] Direct unit tests of `probeSpecStaleness(projectPath, threshold, nowFn)` helper (3 cases)

## Related
- Closes #544
- Plan: `.ai-workspace/plans/2026-05-09-audit-thread-fix-batch-549-546-548-544.md` Task 4 of 4
- Operator override on the original "keep deferred" verdict