### PR TITLE
chore: release 0.41.0

### DIFF
--- a/.ai-workspace/plans/2026-05-09-audit-thread-fix-batch-549-546-548-544.md
+++ b/.ai-workspace/plans/2026-05-09-audit-thread-fix-batch-549-546-548-544.md
@@ -1,0 +1,232 @@
+# Audit-thread fix batch — close out #549 + #546 + #548 + #544
+
+## ELI5
+
+Four open issues from macbook-monday's US-11 audit and monday2's takeover are sitting around with confirmed evidence, agreed fixes, and operator-greenlit ship intent. **All four ship in this arc.** They split into three buckets by code-surface:
+
+- **#549 docs** — README section telling Max-plan OAuth users they have a separate, invisible rate-limit bucket and how to bypass it (set `ANTHROPIC_API_KEY`). Pure markdown. ~25 lines.
+- **#546 + #548 co-located** — both touch the same warning-emit block in `spec-generator.ts`. #546 hides the misleading "your keychain is broken" warning when the real cause is a 429-class HTTP error. #548 surfaces Anthropic's `retry-after` header in the warning body so operators know when to retry. ~25 LOC + 2 tests across both.
+- **#544 stale-spec banner** — operator wants this flipped from "deferred" to "ship-it" despite the original keep-deferred verdict. Add a banner to `forge_status` output when `docs/generated/TECHNICAL-SPEC.md` is older than a threshold (default 30 days, env-overridable). ~40 LOC + 2 tests.
+
+Each issue ships as its own PR. Total: **4 PRs**, ~90-120 LOC + 5 tests + 25 lines docs.
+
+**Out of scope (operator-flagged but explicitly NOT this plan's lift):**
+- monday-bot #166 (consumer-side bug; monday2's lift on monday-bot side)
+- AC-quality observation (doctrine clarification — separate forge-harness-side ADR or README; reply via mail not code)
+- W3-W6 + I2 sanity check (#505/#506/#507/#508/#539) — confirm parking; reply via mail not code
+- FORGE_MODEL smokes #1/#2/#4 (operator-action only; F54 trap)
+
+## Execution model
+
+**Single-session serial execution via `/per-task-review-loop` — both modes.** Plan-time review uses plan-chain mode (4 reviewers in series, background subagents); implementation uses per-task mode (one reviewer dispatched in background after each task). Skip `/auto-flow` because:
+
+1. Total LOC is small (~120 LOC across 4 PRs); 19-step orchestration is ceremony-heavy for the work.
+2. #546+#548 are co-located in the same `spec-generator.ts:688` block — they MUST be ordered serially or merged. Worktree-parallel Stage 2 dispatch is wasted on co-located work.
+3. Per-task review catches each fix's regression risk independently — particularly important for #544 (largest surface, most design choice).
+
+**Task ordering** (determined by ship-readiness + atomic-revert blast-radius):
+
+1. **Task 1 — #549 docs PR** (zero code risk; ships first as a confidence-builder for the arc)
+2. **Task 2 — #546 narrowing PR** (small code change; isolated test)
+3. **Task 3 — #548 retry-after PR** (builds on #546's emit-block edits; clean rebase since #546 will already be merged)
+4. **Task 4 — #544 stale-spec banner PR** (largest surface; lands last so per-task reviewer sees green CI from prior 3 ships)
+
+**Per-task review dispatch**: after each task's PR is filed, dispatch a stateless reviewer in background (`Agent run_in_background: true`). Pass to next task without blocking. On reviewer FAIL, pause and fix; on PASS or IMPROVE-cheap, continue.
+
+**Phase boundary**: before opening Task 4, all 3 prior reviewers must have returned PASS or IMPROVE.
+
+## Why
+
+**Operator directive**: "create a fix plan for all 549, 546, 548, 544. Fix all, including the 544." (verbatim, this session)
+
+**Monday2's substantive evidence (her T0859 mail)**:
+- #549, #546, #548 — all probed `ready` / actionable; ship cadence acks requested
+- #544 — operator override on the keep-deferred verdict; flip to ship-it confirmed
+- Master HEAD authoritatively `7ecfea3` (corrects forge-plan's stale `1e20b1a` cite)
+
+**Why fix all four together (not just the bug-class):**
+- Operator wants the audit-thread closed out before monday2 picks up monday-bot's PH-02 wrap or US-13 follow-ups
+- All four have been independently fact-checked by reviewers AND a consumer-side dogfooder
+- Bundling under one plan + one reviewer chain saves 4× separate plan-files-and-chains overhead
+
+## What (intent — outcome we want)
+
+After this arc lands:
+
+1. README.md has a "Max-plan OAuth-tier rate-limit (429)" section with the `ANTHROPIC_API_KEY` workaround.
+2. `spec-gen-creds-keychain-only` warning never fires when the co-emitted `spec-gen-shell-only` body matches a 4xx/5xx HTTP error pattern.
+3. `spec-gen-shell-only` warning body OR a structured field exposes Anthropic's `retry-after` value when the underlying error is a 429.
+4. `forge_status` output includes a "TECHNICAL-SPEC stale" banner when `docs/generated/TECHNICAL-SPEC.md` is older than `FORGE_SPEC_STALE_DAYS` (default 30).
+5. forge-plan replies on the audit thread with: (a) ship outcomes for #549/#546/#548/#544, (b) AC-quality observation acknowledged with doctrine direction, (c) W3-W6 + I2 parking confirmed.
+
+Reply lands post-merge of all 4 PRs so the message references shipped state.
+
+## Critical files
+
+- `README.md` — #549 docs target. Add new H3 section under existing `## Configuration` (or `## Troubleshooting` if that section exists; create it if not).
+- `server/lib/spec-generator.ts:626-734` — synth-catch path + warning emit block. Both #546 and #548 land here.
+- `server/lib/anthropic.ts` — Anthropic SDK error type plumbing (#548 needs to surface `RateLimitError.headers['retry-after']` to the synth-catch's error message). NOTE: SDK exports `RateLimitError extends APIError<429, Headers>` at `core/error.d.ts:46`.
+- `server/tools/status.ts` — #544 banner emit point. Probe `docs/generated/TECHNICAL-SPEC.md` mtime; emit banner string into `forge_status` response body.
+- `server/lib/spec-generator.test.ts` — co-located tests for #546 + #548.
+- `server/tools/status.test.ts` (or its sibling) — #544 tests.
+
+## Per-issue intent + Binary AC
+
+### #549 — README OAuth-tier 429 workaround
+
+**Intent**: every Max-plan OAuth operator who hits the persistent-429 finds the workaround in README before they file a duplicate issue. Anchor on confirmed diagnosis (operator's 2026-05-09T06:47Z console.anthropic.com check + macbook's 2/2 wild repros).
+
+**Approach**: append a new H3 section to `README.md`. Use the refined draft already in https://github.com/ziyilam3999/forge-harness/issues/549#issuecomment-4411781777 (covers separate buckets + console invisibility + workaround + API-key URL).
+
+**Cost**: ~25 lines markdown. No code, no tests.
+
+**Binary AC**:
+- (AC-549-1) `grep -F "Max-plan OAuth-tier rate-limit" README.md` → exit 0 (pattern present).
+- (AC-549-2) `grep -F "export ANTHROPIC_API_KEY=" README.md` → exit 0 (workaround code block present).
+- (AC-549-3) `grep -F "console.anthropic.com/settings/keys" README.md` → exit 0 (API-key URL present so the README is actionable end-to-end).
+- (AC-549-4) The new section appears under an existing H2 or a new H2 like `## Configuration` or `## Troubleshooting` (not orphaned outside any H2). Verifiable by markdown structural grep.
+
+### #546 — `spec-gen-creds-keychain-only` false-positive narrowing
+
+**Intent**: when the underlying synth-failure is a rate-limit / network-out / 5xx (i.e. an HTTP-status-shaped error in the 4xx/5xx range), the keychain-only warning must NOT co-emit. The keychain warning is only meaningful when the underlying error is auth-class (401-shaped or "no creds at all").
+
+**Approach**: at `server/lib/spec-generator.ts:688` block, gate the keychain probe on a regex check against `shellOnlyMessage`. If the message matches `^[45][0-9]{2}\b` (HTTP 4xx/5xx status prefix at start of message body), skip the keychain probe entirely. Otherwise proceed as today.
+
+Why regex on the message body: the SDK error reaches spec-generator only as a string (line 640: `raw = err.message`); the typed-error class is lost at the catch boundary. Cleanest fix is the message-body match. **Alternative considered**: thread the typed error class through to spec-generator and switch on `instanceof Anthropic.RateLimitError`. Rejected because (a) the synth-injection seam (`input.synthesize`) makes typed plumbing leaky for tests, (b) cost is 3-5× higher.
+
+**Measurement (F65 — measure before stipulating)**: verified via direct read of `node_modules/@anthropic-ai/sdk/core/error.js:18-29` (`makeMessage` static method). SDK constructs `APIError` instances with `super(`${makeMessage(status, error, message)}`)` where `makeMessage` returns `\`${status} ${msg}\`` when both status and msg are truthy (the 429 case). So `err.message` for a real 429 IS literally `"429 ..."` — the regex prefix-match against `^[45][0-9]{2}\b` is grounded on the SDK's actual stringification, not assumed. AC-546-5 below locks this measurement.
+
+**Cost**: ~10-15 LOC + 1 unit test.
+
+**Binary AC**:
+- (AC-546-1) **Behavioral observable** — given any synth() throw whose stringified `err.message` begins with HTTP 4xx/5xx status, the resulting `warnings` array contains `spec-gen-shell-only` AND does NOT contain `spec-gen-creds-keychain-only`. (Loose-coupled to implementation: doesn't prescribe regex vs typed-error vs other narrowing mechanism.)
+- (AC-546-2) Regression-positive — given a non-HTTP synth() throw (e.g. `Error("ENOTFOUND ...")` or `Error("socket hang up")`), the resulting `warnings` array DOES contain `spec-gen-creds-keychain-only` on darwin (preserves the original F6 path).
+- (AC-546-3) Test grep: `grep -E "4xx|5xx|spec-gen-creds-keychain-only" server/lib/spec-generator.test.ts` → exit 0 (proves the new tests landed in the file).
+- (AC-546-4) `npm test -- spec-generator` exit 0.
+- (AC-546-5) **Producer/consumer seam (P64) — real-SDK shape verification.** Add a unit test that constructs a real `Anthropic.APIError`-shaped error (e.g., via `new Anthropic.RateLimitError(429, {message: "test"}, undefined, new Headers())` if the constructor is callable, OR via the SDK's documented `APIError.generate(...)` factory) and asserts `err.message` starts with `429 ` (matches the `^[45][0-9]{2}\b` regex). If the SDK constructor isn't directly callable in test, fall back to asserting against a string fixture pulled from a recorded real 429 response in this repo's prior run records (e.g., `req_011Car5MF8ndJ4KDzMwWvpBn` evidence). This locks the regex against the actual SDK stringification per F65 + P64.
+
+### #548 — Surface `retry-after` header on 429 warning
+
+**Intent**: when Anthropic returns a 429 with a `retry-after` header, the value (in seconds OR ISO timestamp per HTTP RFC 7231) appears in the `spec-gen-shell-only` warning so operators know when to retry. Format: append `(retry after N seconds)` to the message body when the value is parseable.
+
+**Approach**: at `server/lib/spec-generator.ts:638-644` catch block, before stringifying the error, check `if (err instanceof Anthropic.RateLimitError && err.headers?.get('retry-after'))`. Parse the header value (try integer-seconds first per RFC 7231 §7.1.3 most-common shape; fall back to RFC 1123 date parse). Append to `shellOnlyMessage` as `... (retry after Ns)` or `... (retry after <iso>)`.
+
+**SDK shape note**: `THeaders extends Headers | undefined` per `core/error.d.ts:4-8`. `Headers` is the Web API class with `.get(name)` accessor — bracket-index `headers['retry-after']` is a TS error. Plan corrected per P4 mechanical sweep.
+
+**Alternative considered**: structured field `retryAfterSeconds?: number` on the discriminated-union member. Rejected for this PR because (a) the warning string is consumer-visible (`spec-gen-shell-only.message`); (b) string-append is zero-API-shape change; (c) structured field can land as separate additive-optional later if a consumer surfaces a parser need.
+
+**Anthropic SDK reference**: `node_modules/@anthropic-ai/sdk/core/error.d.ts:46` — `RateLimitError extends APIError<429, Headers>`. `Headers` type provides `.get('retry-after')`.
+
+**Cost**: ~15 LOC + 1 unit test (mock-class wiring already present in `anthropic.test.ts`).
+
+**Binary AC**:
+- (AC-548-1) New unit test `spec-gen-shell-only includes retry-after when 429 with header` — injects a `synth()` that throws a mocked `Anthropic.RateLimitError` with `headers.get('retry-after')` returning `"60"`; asserts the resulting `spec-gen-shell-only.message` contains `retry after 60` (substring).
+- (AC-548-2) Existing test `spec-gen-shell-only without retry-after stays unchanged` — non-RateLimitError or RateLimitError-without-header injection produces a message string that does NOT contain `retry after`.
+- (AC-548-3) `npm test -- spec-generator` exit 0.
+- (AC-548-4) `MockAnthropic` in test file extends with `static RateLimitError = MockRateLimitError` (mirrors existing AuthenticationError + NotFoundError pattern at `anthropic.test.ts:24-27`).
+
+### #544 — Stale-spec banner in `forge_status`
+
+**Intent**: `forge_status` output surfaces a one-line banner when `docs/generated/TECHNICAL-SPEC.md` is older than the configured threshold. Operators see the banner before they read potentially-stale spec content.
+
+**Approach**:
+1. Add `FORGE_SPEC_STALE_DAYS` env-var (module-load IIFE following the FORGE_MODEL precedent at `server/lib/anthropic.ts:6-7`). Default `30`. Trim + parse-int + reject negative/NaN with loud-failure throw at boot.
+2. In `server/tools/status.ts` `forge_status` body builder, probe `docs/generated/TECHNICAL-SPEC.md` mtime via `fs.stat`. Compute `daysSinceUpdate = floor((now - mtime) / 86400000)`. If `daysSinceUpdate >= FORGE_SPEC_STALE_DAYS`, prepend a banner string (e.g. `"⚠ TECHNICAL-SPEC.md is N days old (forge_evaluate to refresh)"`) to the response body.
+3. If the file does NOT exist, no banner (file might not be generated yet on a fresh repo).
+4. If the stat throws (permission, broken symlink), no banner + log warning to stderr (loud-failure for ops; don't block forge_status itself).
+
+**Decision points — RESOLVED (locked pre-implementation per P1 IMPROVE)**:
+- **Banner surface**: separate `staleSpecWarning` field (LOCKED) — additive-optional per P50. String contains the human-friendly banner text; presence of the field is the machine-parseable staleness signal. Rejected: prepending banner string to body-prefix (would couple human-prose-rendering to machine-parse seam, violating agent-first design default).
+- **Field shape**: `staleSpecWarning?: string | undefined` (optional, omitted when fresh / file-absent / stat-error). Rejected: structured object `{daysSinceUpdate: number, threshold: number}` — over-prescribes consumer behavior; if a future consumer needs the structured shape, file an additive-optional follow-up.
+- **Threshold default**: 30 days. Env-var override `FORGE_SPEC_STALE_DAYS`. Rejected: per-project config-file (F66 — re-triggers the hybrid-first concerns from the FORGE_MODEL decision plan).
+
+**Cost**: ~40 LOC + 2 unit tests.
+
+**Binary AC**:
+- (AC-544-1) New unit test `forge_status emits staleSpecWarning when TECHNICAL-SPEC.md older than threshold` — sets up a temp `docs/generated/TECHNICAL-SPEC.md` with mtime 31d ago, runs forge_status, asserts the response body contains a `staleSpecWarning` field with non-empty string.
+- (AC-544-2) New unit test `forge_status omits staleSpecWarning when TECHNICAL-SPEC.md is fresh` — file mtime 1d ago, forge_status response does NOT contain `staleSpecWarning` (or the field is null/absent).
+- (AC-544-3) New unit test `forge_status omits staleSpecWarning when TECHNICAL-SPEC.md absent` — no file, no banner, no warning.
+- (AC-544-4) Boot-time validation: `FORGE_SPEC_STALE_DAYS=foo` causes startup throw with operator-actionable error. (Mirrors FORGE_MODEL's IIFE pattern.) Verified by a unit test calling the IIFE in isolation OR by an integration smoke that boots with the bad value and asserts non-zero exit.
+- (AC-544-5) `npm test -- status` exit 0.
+- (AC-544-6) `grep -nE "FORGE_SPEC_STALE_DAYS|staleSpecWarning" server/tools/status.ts server/tools/status.test.ts` → both files referenced.
+
+## Out of scope
+
+- **monday-bot #166** (`src/index.ts` doesn't start the listener). Critical, but a monday-bot bug. Monday2 will plan + ship on her side. forge-plan replies separately on the AC-quality observation but does NOT write the fix code.
+- **AC-quality observation** (US-13 PASS but bot doesn't actually start). Doctrine-level question; reply via mail with my view (lean: file-presence ACs are insufficient for "deployment-ready" stories; either author entrypoint-ACs on monday-bot side OR file a forge-harness follow-up PR clarifying the doctrine in README). **Mail-only — NO in-arc README diff** (mechanically bounded per P2/P4 scope-creep flag). The doctrine README PR, if filed, lands as a separate ship arc post-this-batch.
+- **W3-W6 + I2 sanity check** (#505/#506/#507/#508/#539). Reply via mail confirming all five remain correctly parked; encourage monday2 to drop them from her tracking.
+- **FORGE_MODEL smokes** (#1/#2/#4). Operator-action; F54 trap (module-load IIFE means no in-session env-var propagation). Will batch when operator next has restart windows.
+- **Anthropic console deeper diagnosis**. Diagnosis confirmed; no remaining operator action. Could file a future Anthropic-support ticket for the OAuth-tier bucket details if curiosity surfaces, but not load-bearing for this ship arc.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| #546 + #548 touch the same `:688` block; ordering matters. | Task 2 (#546) ships first; Task 3 (#548) rebases on master after #546 merges. Per-task reviewer on #548 asserts no regression of #546's tests. P2 confirmed mechanically: #546 lands at `:688` (post-catch warning emit); #548 lands at `:638-644` (catch body) — different sub-locuses, ordering robust either way. |
+| **#546 regex misses real Anthropic SDK 429 message shape (F47/F64)** — implementer regex `^[45][0-9]{2}\b` could be a no-op fix if the SDK stringifies differently than measured. | F65 measurement done pre-plan: SDK's `APIError.makeMessage` (`node_modules/@anthropic-ai/sdk/core/error.js:18-29`) returns `\`${status} ${msg}\`` when both status and msg are truthy — confirms `429 ...` prefix is real. AC-546-5 (P64 producer/consumer seam) locks the regex against real SDK stringification at test-time so SDK upgrades that change the format fail loud. |
+| #544 design choice on banner-surface — RESOLVED. | `staleSpecWarning?: string` field, additive-optional per P50, locked in §Decision points. No reviewer-time deferred choice. |
+| `Anthropic.RateLimitError` mock wiring needed for #548 test; gotcha-prone (per anthropic.test.ts F50 lessons in v0.40.6 ship). | Plan calls out the precedent at `anthropic.test.ts:24-27`; implementer adds `static RateLimitError = MockRateLimitError` mirroring existing AuthenticationError + NotFoundError pattern. SDK accessor `err.headers?.get('retry-after')` (Headers Web API instance) — NOT bracket-index. |
+| Per-task reviewer concurrency: 4 background subagents queued sequentially could pile up on one slow reviewer. | Per-task review is sequential-bg, NOT concurrent. Each reviewer's completion notification triggers the next. Phase-boundary at Task 4 blocks on all 3 prior reviewers PASS. |
+| #544 banner threshold default of 30 days might be wrong. | Make it env-overridable (`FORGE_SPEC_STALE_DAYS`); reviewer can challenge the default. Document in code comment that this is a starting-point that could tighten if ops feedback says 30 is too lax. |
+| Post-arc reply could absorb in-arc README doctrine edit (P2/P4 flagged scope-creep boundary). | §Post-arc actions item 1(b) explicitly bounds the AC-quality answer to "reply suggesting forge-harness add a doctrine note to README in a follow-up PR" — mail-only, no in-arc README diff. §Out of scope item 2 mirrors. |
+
+## Anti-cascade
+
+- 4 separate PRs (not one bundled PR) so atomic-revert per issue is preserved.
+- Each task's per-task reviewer sees ONLY that task's diff (stateless reviewer dispatch).
+- Phase-boundary before Task 4 ensures Tasks 1-3 ship clean before the largest task starts.
+- No cross-task imports / file-rename / API-shape change that would couple the four PRs.
+
+## Cairn references
+
+**Risk/mitigation co-cite pair (forge-harness convention from FORGE_MODEL retro):**
+- **F49 (Dual-Level Enforcement) + P43 (Single Source of Truth)** — F49 names the duplication risk; P43 names the IIFE-export-import single-source-of-truth mitigation. Used in #544's `FORGE_SPEC_STALE_DAYS` env-var resolver, mirroring v0.40.5's `KEYCHAIN_SERVICE_NAME` and v0.40.6's `DEFAULT_MODEL` ship pattern. Tier-b reference: `~/.claude/agent-working-memory/tier-b/topics/forge-harness/2026-05-09-v0406-shipped-forge-model-env-a1-obsolescence.md` §Lessons.
+
+**Producer/consumer seam cluster (F47/F64/P64) — applied to #546 regex shape (per P3 IMPROVE):**
+- **F47 (Assumed JSON Shape From External Tools)** — risk frame: implementer must measure the real Anthropic SDK 429 stringification before stipulating the regex. AVOID BY: "Run the real CLI tool once and capture its output shape." Done pre-plan; see #546 §Measurement.
+- **F64 (Intermediate-Only Test Assertion)** — risk frame: AC-546-1 testing producer (regex) against synthetic fixture only would drift from real artifact. AVOID BY: pair with P64 producer/consumer seam assertion.
+- **P64 (Producer/Consumer Seam Assertion)** — mitigation: AC-546-5 locks the regex against real SDK stringification (or recorded real-traffic fixture from `req_011Car5MF8ndJ4KDzMwWvpBn` evidence). If SDK upgrade changes stringification, AC-546-5 fails loud rather than the regex silently no-opping.
+- **F65 (Planning Without Measuring Current State)** — guarded against: regex pattern was measured against `node_modules/@anthropic-ai/sdk/core/error.js:18-29` (`makeMessage` static method) before plan-write, not stipulated then verified. The measurement is captured inline in #546 §Measurement.
+
+**Other patterns:**
+- **P50 (Additive Optional Fields for Schema Evolution)** — used in #544's `staleSpecWarning` field shape (additive-optional, omitted-when-fresh). NOTE: P50 governs schema-evolution backward compatibility, not generic field-naming choice (per P3 review). Use is defensible because the field IS new + the absence-of-field is the legacy behavior — backward compat preserved.
+- **F45 (Empty Catch Block)** — guard against in #544's `fs.stat` catch path (warn to stderr, don't silently swallow).
+- **F46 (Silent Numeric Default)** — avoid in #544's threshold parse (loud-failure throw on NaN, not silent fallback).
+- **F54 (Stale MCP Server After dist/ Rebuild)** — operators must restart Claude Code after pulling the new dist; called out in ship-PR descriptions.
+- **F66 (Hybrid-First Design Reflex)** — guarded against: rejected per-project config-file shape for the threshold (would create the same hybrid risk that killed FORGE_MODEL's option δ).
+
+## Plan-chain review history
+
+Filed: 2026-05-09T09:18Z. 4 sequential bg subagent reviewers per saved feedback ("always series for auto flow planning").
+
+| Reviewer | Axis | Verdict | Items |
+|---|---|---|---|
+| P1 stateless | AC verifiability + evidence anchor | PASS | 4: AC-546 test-coupling, AC-544 field-pin, regex-shape probe AC missing, regex-shape risk row missing |
+| P2 comparative | Cross-issue coupling + atomic-revert + industry-fit | PASS | 1: post-arc reply scope-creep boundary |
+| P3 cairn-grounded | KB-pattern fit + missing citations | IMPROVE | 4: F47/F64/P64 cluster, F65 measurement, F49+P43 co-cite, AC-546-5 |
+| P4 mechanical sweep | Line-number + Plan-First gate + structural coherence | IMPROVE | 2: SDK accessor `headers.get()` not bracket, scope-creep wording at item 1(b) |
+
+**Convergence audit: EARNED.** P1 axis-A (AC), P2 axis-B (coupling), P3 axis-C (KB-fit), P4 axis-D (mechanical). Each surfaced disjoint, axis-grounded evidence; no anchoring.
+
+**All 11 specific feedback items applied** (this revision). F65 measurement done inline; SDK confirmed `${status} ${msg}` shape; regex narrowed to 4xx/5xx only.
+
+## Per-task review schedule (operator-visible)
+
+| Task | Issue | PR title (draft) | Reviewer dispatch shape |
+|---|---|---|---|
+| 1 | #549 | `docs: README section for Max-plan OAuth-tier 429 workaround (#549)` | bg subagent, stateless reviewer, return PASS/IMPROVE/FAIL |
+| 2 | #546 | `fix(spec-generator): suppress keychain-only warning on 4xx/5xx synth errors (#546)` | bg subagent, stateless reviewer |
+| 3 | #548 | `feat(spec-generator): surface retry-after on 429 in shell-only warning (#548)` | bg subagent, stateless reviewer |
+| 4 | #544 | `feat(status): emit staleSpecWarning when TECHNICAL-SPEC.md older than FORGE_SPEC_STALE_DAYS (#544)` | bg subagent, stateless reviewer; phase-boundary blocks on Tasks 1-3 PASS |
+
+## Post-arc actions (not part of any single task)
+
+After Task 4 PR merges and `/ship` v0.40.7 rolls:
+
+1. Reply on audit-thread (`thread_id: forge-harness-audit-us-11`) addressed to monday2 with:
+   - Ship outcomes for all 4 issues (PR + commit links)
+   - AC-quality observation: my view + suggested next step (lean: **reply suggesting forge-harness add a doctrine note to README in a follow-up PR** — "PASS asserts the slice's surface; integration is the consumer's job" — and encourage monday-bot to author entrypoint ACs). **Mail-only — NO in-arc README diff** (mechanically bounded per P2/P4 scope-creep flag).
+   - W3-W6 + I2 parking: confirm all five still correctly deferred; encourage drop-from-tracking
+   - Master HEAD correction acknowledged (forge-plan cited stale `1e20b1a`; current is `7ecfea3`)
+2. Place a cairn stone capturing the four-issue-bundle ship pattern + per-task-review-loop dispatch outcome.
+3. Save tier-b card under `forge-harness` topic capturing v0.40.7 ship + per-task-review-loop empirical results (4 reviewer dispatches in series).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.41.0](https://github.com/ziyilam3999/forge-harness/compare/v0.40.6...v0.41.0) (2026-05-10)
+
+Audit-thread closeout from the `forge-harness-audit-us-11` mailbox conversation (macbook-monday → monday2). Four issues bundled into one release; planned + reviewed via /per-task-review-loop in both modes (4-reviewer plan-chain pre-implementation, 1-reviewer per-task post-PR). Plan: `.ai-workspace/plans/2026-05-09-audit-thread-fix-batch-549-546-548-544.md`.
+
+### Features
+
+- **status:** emit `staleSpecWarning` field on `forge_status` response when `docs/generated/TECHNICAL-SPEC.md` mtime is older than `FORGE_SPEC_STALE_DAYS` (default 30 days, env-var overridable) (#544 / #553). Field is additive optional per P50 — populated with a human-readable banner (`⚠ TECHNICAL-SPEC.md is N days old (forge_evaluate to refresh)`) when stale, omitted when fresh / absent / stat-error. Module-load IIFE on `FORGE_SPEC_STALE_DAYS` mirrors v0.40.6's `FORGE_MODEL` precedent (F49 + P43 risk/mitigation pair); throws at boot with operator-actionable error on bad input (F46 escape, no silent numeric default). Probe runs in all non-`no-forge-dir` cases (case 2 corrupted, case 3 no-runs, case 4 scope-miss, case 5 snapshot/differential). `parseSpecStaleDays(raw)` extracted from the IIFE for testability — tests drive the parser directly without Vitest bundler hackery. Field shape ratified pre-implementation per Plan §Decision points (separate field over body-prefix, agent-first design default). Operator override on the original "keep deferred" verdict — flipped to ship-it after monday2 confirmed monday-bot's TECHNICAL-SPEC.md was stale on the persistent-429 path.
+
+- **spec-generator:** surface Anthropic's `retry-after` header on 429 `RateLimitError` in the `spec-gen-shell-only` warning body (#548 / #552). When `synth()` throws a 429 with the header set, parse the value (integer-seconds per RFC 7231 §7.1.3 most-common, with HTTP-date RFC 1123 fallback) and append `(retry after Ns)` or `(retry after <date>)` to the warning message BEFORE truncation. Operators previously saw only opaque raw 429 JSON; now they get a concrete retry signal. SDK accessor is `err.headers?.get('retry-after')` (Headers Web API class — bracket-index would be a TS error). Field-shape extension `retryAfterSeconds?: number` deferred to a future additive-optional follow-up if a consumer surfaces parser need.
+
+### Bug Fixes
+
+- **spec-generator:** suppress `spec-gen-creds-keychain-only` warning on 4xx/5xx synth errors (#546 / #554, replaces closed #551). When the underlying synth() failure is HTTP 4xx (non-401) or 5xx — e.g. 429 rate-limit, 500 server error — credentials are FINE; the keychain probe would emit a misleading "Keychain locked or ACL mismatched" warning that sends the operator down the wrong diagnostic path. Narrows the gate at `server/lib/spec-generator.ts:688` block on a regex check against `shellOnlyMessage` (`^[45][0-9]{2}\b` matches HTTP 4xx/5xx prefix). 401 (`AuthenticationError`) is explicitly carved out — keychain probe IS meaningful for auth-class failures (preserves original F6 path). Wild-repro evidence: 2/2 hits on macbook-monday's 2026-05-09 smoke run (`req_011Car5MF8ndJ4KDzMwWvpBn` + `req_011CarTPBD1eTYEU8uHyQo3z`). P64 producer/consumer seam asserted in AC-546-5: regex matches real Anthropic SDK stringification (verified F65 against `node_modules/@anthropic-ai/sdk/core/error.js:18-29` — `APIError.makeMessage` returns `${status} ${msg}` shape). Tests: 5 new (4 behavioral + 1 P64 seam).
+
+### Documentation
+
+- **README:** add Troubleshooting section for Max-plan OAuth-tier 429 workaround (#549 / #550). Documents the OAuth-vs-API-key separate-bucket diagnosis confirmed via operator's 2026-05-09 console.anthropic.com check: Max-plan OAuth has its own (tighter, undocumented) rate-limit bucket invisible to the Anthropic console (which only shows API-key traffic). Workaround: set `ANTHROPIC_API_KEY` from a separate API-key identity to move traffic to the API-key bucket. Cross-references #546 (co-emitted misleading keychain-only warning) for operators tracing the symptom shape.
+
+### Triage outcome
+
+This release closes out the `forge-harness-audit-us-11` mailbox audit thread (macbook-monday → monday2 handoff 2026-05-09). All four operator-asked items shipped: #549 docs (Task 1), #546 fix (Task 2), #548 feat (Task 3), #544 feat (Task 4). #544 was operator-overridden from "keep deferred" to "ship-it" after monday2 surfaced concrete consumer-side staleness pain. Plan-chain (4 stateless reviewers, sequential bg subagents per saved feedback) returned 2 PASS + 2 IMPROVE with EARNED convergence (4 disjoint axes). Per-task review (4 stateless reviewers, sequential bg post-PR) returned 4 PASS with minor IMPROVE-not-cheap items deferred as follow-ups. Out of scope by design: monday-bot #166 (consumer-side fix), AC-quality observation (doctrine reply, separate follow-up if filed), W3-W6 + I2 sanity check (parking confirmed, dropped from monday2 tracking), FORGE_MODEL smokes #1/#2/#4 (operator-action only — F54 trap).
+
 ## [0.40.6](https://github.com/ziyilam3999/forge-harness/compare/v0.40.5...v0.40.6) (2026-05-09)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forge-harness",
-  "version": "0.40.6",
+  "version": "0.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forge-harness",
-      "version": "0.40.6",
+      "version": "0.41.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-harness",
-  "version": "0.40.6",
+  "version": "0.41.0",
   "type": "module",
   "description": "Composable AI primitives — plan, evaluate, generate, coordinate — as a local MCP server",
   "scripts": {


### PR DESCRIPTION
## Summary
v0.41.0 — bundled audit-thread closeout from `forge-harness-audit-us-11` mailbox conversation. Four issues shipped:

- #549 (#550) — README OAuth-tier 429 workaround
- #546 (#554) — keychain false-positive narrowing on 4xx/5xx
- #548 (#552) — retry-after header surfaced on 429 RateLimitError
- #544 (#553) — staleSpecWarning on forge_status

Plan: `.ai-workspace/plans/2026-05-09-audit-thread-fix-batch-549-546-548-544.md`

## Test plan
- [x] All 4 source PRs merged + CI green
- [x] CHANGELOG.md updated with v0.41.0 entry
- [x] package.json + package-lock.json bumped to 0.41.0