### PR TITLE
chore: release 0.41.1 — F1 (#546 execFileSyncFn injection seam) + F2 (#544 parser strictness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.41.1](https://github.com/ziyilam3999/forge-harness/compare/v0.41.0...v0.41.1) (2026-05-10)
+
+Patch release closing the two IMPROVE-NIT findings deferred from v0.41.0's per-task review chain. Reviewed via 4-reviewer plan-chain (sequential bg subagents); EARNED convergence with split verdicts (P1/P2 grounded on risk-cost + industry-norms, P3 on KB-pattern severity, P4 on mechanical sweep). Operator override on the F1 2-2 tie. Plan: `.ai-workspace/plans/2026-05-10-deferred-followups-546-regression-test-and-544-parser-strictness.md`.
+
+### Bug Fixes
+
+- **spec-generator:** add `execFileSyncFn` injection seam to `SpecGeneratorInput` so AC-546-2 regression-positive tests can deterministically assert `spec-gen-creds-keychain-only` presence/absence (F1). Mirrors the existing `synthesize` injection seam pattern. Closes a soft F64 (Intermediate-Only Test Assertion) violation flagged by the v0.41.0 per-task reviewer on PR #554. F64 is a graduated n=3 anti-pattern in the cairn KB with three real forge-harness regressions in the past 2 weeks; the seam closes the producer/consumer assertion gap. New tests (3): positive-presence assertion on 401 + non-HTTP paths (gate-off + probe-ran + stub-success → keychain-only IS present); negative-absence assertion on entry-absent (gate-off + probe-ran + stub-throws → keychain-only IS absent); pre-empt assertion on 4xx (gate-on → execFileSyncFn never called). Production behavior unchanged — default = real `execFileSync`.
+- **status:** strict-validate `FORGE_SPEC_STALE_DAYS` env input + add 36500-day (100-year) sanity cap (F2). v0.41.0 used `Number.parseInt` which silently parsed `'3.5' → 3`, `'1e2' → 1`, `'30 garbage' → 30`, and `'9999999999999999' → 1e16` (which would silently disable the staleness banner forever — operator-confusion footgun). Strict regex `^[1-9]\d*$` rejects floats / scientific / junk-suffix / leading-zero; 36500-day cap catches typo overflow. Closes the F46 (Silent Numeric Default) partial-violation flagged by the per-task reviewer on PR #553. New tests (7): each pathological case throws with operator-actionable error; legitimate values (`'30'`, `'  60  '`, `'36500'` boundary) preserved.
+
+### Triage outcome
+
+This release closes the v0.41.0 deferred-followup arc. F1 (#546 regression-test bulletproofing) shipped after a 2-2 reviewer tie was operator-resolved per the plan's AC-D-VERDICT rule. F2 (#544 parser strictness) shipped on a 3-1 majority. Convergence audit was EARNED — P1 (risk-cost), P2 (industry-norms), P3 (KB-pattern severity), P4 (mechanical truth) each grounded on a disjoint axis; P3 split from P1+P2 on F2, P4 tipped F1 from 2-1-DEFER to 2-2-tie. No reviewer cascade. Operator weighted the bundling discount (monday2 hadn't restarted yet) and ratified bundle-as-v0.41.1.
+
 ## [0.41.0](https://github.com/ziyilam3999/forge-harness/compare/v0.40.6...v0.41.0) (2026-05-10)
 
 Audit-thread closeout from the `forge-harness-audit-us-11` mailbox conversation (macbook-monday → monday2). Four issues bundled into one release; planned + reviewed via /per-task-review-loop in both modes (4-reviewer plan-chain pre-implementation, 1-reviewer per-task post-PR). Plan: `.ai-workspace/plans/2026-05-09-audit-thread-fix-batch-549-546-548-544.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forge-harness",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forge-harness",
-      "version": "0.41.0",
+      "version": "0.41.1",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-harness",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "type": "module",
   "description": "Composable AI primitives — plan, evaluate, generate, coordinate — as a local MCP server",
   "scripts": {

--- a/server/lib/spec-generator.test.ts
+++ b/server/lib/spec-generator.test.ts
@@ -1089,20 +1089,32 @@ describe("spec-generator — #546 keychain-only narrowing on 4xx/5xx (darwin)", 
   });
 
   // AC-546-2 — regression positive — 401 (auth-class) STILL emits keychain-only.
+  // F1 (v0.41.1) — execFileSyncFn injection seam lets us deterministically
+  // simulate "Keychain entry exists" so we assert keychain-only IS present.
+  // Closes the F64 (Intermediate-Only Test Assertion) gap from v0.41.0.
   it("AC-546-2: 401 auth error still emits spec-gen-creds-keychain-only on darwin (F6 path preserved)", async () => {
     if (process.platform !== "darwin") return;
     const auth401 = async (): Promise<SynthesisResponse> => {
       throw new Error("401 AuthenticationError: invalid bearer");
     };
+    // Stub execFileSync to simulate "entry exists" (success return).
+    const fakeExecFile = (() => Buffer.from("")) as unknown as typeof import("node:child_process").execFileSync;
     const result = await generateSpecForStory({
       projectPath: tmp,
       storyId: "US-01",
       evalReport: makeReport("US-01"),
       ctx,
       synthesize: auth401,
+      execFileSyncFn: fakeExecFile,
     });
     const shellOnly = result.warnings.find((w) => w.kind === "spec-gen-shell-only");
     expect(shellOnly).toBeDefined();
+    // Positive assertion (F1 closure) — gate is OFF for 401, probe ran,
+    // stub returned success, so keychain-only IS present.
+    const keychainOnly = result.warnings.find(
+      (w) => w.kind === "spec-gen-creds-keychain-only",
+    );
+    expect(keychainOnly).toBeDefined();
   });
 
   // AC-546-2 — non-HTTP error (network out) STILL emits keychain-only.
@@ -1111,15 +1123,77 @@ describe("spec-generator — #546 keychain-only narrowing on 4xx/5xx (darwin)", 
     const networkOut = async (): Promise<SynthesisResponse> => {
       throw new Error("ENOTFOUND api.anthropic.com — connection refused");
     };
+    const fakeExecFile = (() => Buffer.from("")) as unknown as typeof import("node:child_process").execFileSync;
     const result = await generateSpecForStory({
       projectPath: tmp,
       storyId: "US-01",
       evalReport: makeReport("US-01"),
       ctx,
       synthesize: networkOut,
+      execFileSyncFn: fakeExecFile,
     });
     const shellOnly = result.warnings.find((w) => w.kind === "spec-gen-shell-only");
     expect(shellOnly).toBeDefined();
+    // Positive assertion (F1 closure) — gate is OFF for non-HTTP, probe ran,
+    // keychain-only IS present.
+    const keychainOnly = result.warnings.find(
+      (w) => w.kind === "spec-gen-creds-keychain-only",
+    );
+    expect(keychainOnly).toBeDefined();
+  });
+
+  // F1 (v0.41.1) — sibling negative-path: when execFileSyncFn THROWS
+  // (entry-absent), keychain-only is correctly NOT emitted even on the
+  // non-suppressed (401) path. Confirms gate-off + probe-ran + entry-absent
+  // → no warning. P64 producer/consumer seam fully asserted.
+  it("AC-546-2 / F1: 401 with entry-absent (stub throws) produces NO keychain-only warning", async () => {
+    if (process.platform !== "darwin") return;
+    const auth401 = async (): Promise<SynthesisResponse> => {
+      throw new Error("401 AuthenticationError: invalid bearer");
+    };
+    const fakeExecFileThrow = ((): Buffer => {
+      throw new Error("entry not found");
+    }) as unknown as typeof import("node:child_process").execFileSync;
+    const result = await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: auth401,
+      execFileSyncFn: fakeExecFileThrow,
+    });
+    const shellOnly = result.warnings.find((w) => w.kind === "spec-gen-shell-only");
+    expect(shellOnly).toBeDefined();
+    const keychainOnly = result.warnings.find(
+      (w) => w.kind === "spec-gen-creds-keychain-only",
+    );
+    expect(keychainOnly).toBeUndefined();
+  });
+
+  // F1 (v0.41.1) — confirm gate-ON path: 4xx synth + execFileSyncFn never
+  // called (probe doesn't run because the gate suppressed it). Asserts
+  // suppression is TRUE pre-emptive, not "probe ran but found nothing."
+  it("AC-546-1 / F1: 4xx synth never invokes execFileSyncFn (probe pre-empted)", async () => {
+    if (process.platform !== "darwin") return;
+    let probeCalled = false;
+    const rateLimit429 = async (): Promise<SynthesisResponse> => {
+      throw new Error(
+        '429 {"type":"error","error":{"type":"rate_limit_error"}}',
+      );
+    };
+    const trackingExecFile = ((): Buffer => {
+      probeCalled = true;
+      return Buffer.from("");
+    }) as unknown as typeof import("node:child_process").execFileSync;
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: rateLimit429,
+      execFileSyncFn: trackingExecFile,
+    });
+    expect(probeCalled).toBe(false);
   });
 
   // AC-546-5 — P64 producer/consumer seam: verify the regex matches real

--- a/server/lib/spec-generator.ts
+++ b/server/lib/spec-generator.ts
@@ -105,6 +105,15 @@ export interface SpecGeneratorInput {
   ctx: RunContext;
   /** Override LLM with a deterministic injected synthesizer (for tests). */
   synthesize?: (req: SynthesisRequest) => Promise<SynthesisResponse>;
+  /**
+   * #546 / v0.41.1 — override the macOS Keychain probe's `execFileSync`
+   * for deterministic regression-positive tests. P64 producer/consumer
+   * seam: lets AC-546-2 unit tests assert `keychainOnly` presence/absence
+   * directly instead of inferring from code-reading. Mirrors the
+   * `synthesize` injection-seam pattern above. Default = real
+   * `execFileSync` from `node:child_process` — production behavior unchanged.
+   */
+  execFileSyncFn?: typeof execFileSync;
 }
 
 export interface SpecGeneratorResult {
@@ -754,8 +763,12 @@ export async function generateSpecForStory(
     const suppressKeychainProbe = isHttp4xxOr5xx && !is401;
     if (process.platform === "darwin" && !suppressKeychainProbe) {
       let keychainEntryExists = false;
+      // #546 / v0.41.1 — P64 injection seam. Default to real execFileSync;
+      // tests pass `input.execFileSyncFn` to deterministically simulate
+      // entry-exists (success return) or entry-absent (throw).
+      const execFile = input.execFileSyncFn ?? execFileSync;
       try {
-        execFileSync(
+        execFile(
           "/usr/bin/security",
           ["find-generic-password", "-s", KEYCHAIN_SERVICE_NAME, "-a", userInfo().username],
           { stdio: "ignore", timeout: 1000 },

--- a/server/tools/status.test.ts
+++ b/server/tools/status.test.ts
@@ -522,6 +522,57 @@ describe("forge_status — #544 staleSpecWarning (TECHNICAL-SPEC.md staleness)",
     expect(parseSpecStaleDays("  60  ")).toBe(60);
   });
 
+  // F2 (v0.41.1) — parser strictness. parseInt was permissive on
+  // floats / scientific / junk-suffix / overflow; v0.41.1 tightens via
+  // regex `^[1-9]\d*$` + 36500-day cap (F46 closure).
+
+  it("F2: parseSpecStaleDays('3.5') throws (no silent float truncation)", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(() => parseSpecStaleDays("3.5")).toThrow(
+      /FORGE_SPEC_STALE_DAYS must be a positive integer/,
+    );
+  });
+
+  it("F2: parseSpecStaleDays('1e2') throws (no silent scientific-notation parse)", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(() => parseSpecStaleDays("1e2")).toThrow(
+      /FORGE_SPEC_STALE_DAYS must be a positive integer/,
+    );
+  });
+
+  it("F2: parseSpecStaleDays('30 garbage') throws (no silent prefix-only parse)", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(() => parseSpecStaleDays("30 garbage")).toThrow(
+      /FORGE_SPEC_STALE_DAYS must be a positive integer/,
+    );
+  });
+
+  it("F2: parseSpecStaleDays('01') throws (no leading-zero acceptance)", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(() => parseSpecStaleDays("01")).toThrow(
+      /FORGE_SPEC_STALE_DAYS must be a positive integer/,
+    );
+  });
+
+  it("F2: parseSpecStaleDays('9999999999999999') throws via 100-year sanity cap", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(() => parseSpecStaleDays("9999999999999999")).toThrow(
+      /exceeds the 36500-day \(100-year\) sanity cap/,
+    );
+  });
+
+  it("F2: parseSpecStaleDays('36500') exactly at cap is accepted", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(parseSpecStaleDays("36500")).toBe(36500);
+  });
+
+  it("F2: parseSpecStaleDays('36501') just over cap throws", async () => {
+    const { parseSpecStaleDays } = await import("./status.js");
+    expect(() => parseSpecStaleDays("36501")).toThrow(
+      /exceeds the 36500-day/,
+    );
+  });
+
   // probeSpecStaleness directly — unit-level test for the helper itself.
   it("probeSpecStaleness: returns banner when threshold breached", async () => {
     const { probeSpecStaleness } = await import("./status.js");

--- a/server/tools/status.ts
+++ b/server/tools/status.ts
@@ -6,22 +6,39 @@ import { getDeclaration } from "../lib/declaration-store.js";
 import type { RunRecord } from "../lib/run-record.js";
 
 /**
- * #544 (v0.40.7) — parse FORGE_SPEC_STALE_DAYS env var.
+ * #544 (v0.40.7 / v0.41.1 strict-parse) — parse FORGE_SPEC_STALE_DAYS env var.
  *
- * Resolution: undefined / empty → 30 fallback. Otherwise parsed integer
- * ≥ 1, else throw with operator-actionable error (F46 — Silent Numeric
- * Default avoided; loud failure preserved).
+ * Resolution: undefined / empty → 30 fallback. Otherwise STRICT positive-
+ * integer regex `^[1-9]\d*$` (rejects floats, scientific, junk-suffix,
+ * leading-zero, sign prefix), then bounded by 36500-day (100-year) cap.
+ * Else throw with operator-actionable error.
+ *
+ * F46 (Silent Numeric Default) closure: `parseInt`-permissiveness in v0.41.0
+ * silently truncated `'3.5' → 3`, `'1e2' → 1`, `'30 garbage' → 30`, and
+ * `'9999999999999999' → 1e16` (which would silently disable the staleness
+ * banner forever — operator-confusion footgun). Strict regex + 100-year cap
+ * close those holes.
  *
  * Exported so tests can drive the parser directly without re-importing
  * this module (Vitest bundler doesn't support query-string cache-bust).
  */
+const SPEC_STALE_DAYS_MAX = 36500; // 100 years — sanity cap for typo-detection.
+
 export function parseSpecStaleDays(raw: string | undefined): number {
   if (raw === undefined || raw.trim() === "") return 30;
-  const parsed = Number.parseInt(raw.trim(), 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
+  const trimmed = raw.trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) {
     throw new Error(
       `FORGE_SPEC_STALE_DAYS must be a positive integer (got "${raw}"). ` +
-        `Set to a number of days >= 1, or unset for the default of 30.`,
+        `Set to a whole number of days >= 1 (no leading zeros, decimals, scientific notation, or trailing characters), ` +
+        `or unset for the default of 30.`,
+    );
+  }
+  const parsed = Number(trimmed);
+  if (parsed > SPEC_STALE_DAYS_MAX) {
+    throw new Error(
+      `FORGE_SPEC_STALE_DAYS=${raw} exceeds the ${SPEC_STALE_DAYS_MAX}-day (100-year) sanity cap. ` +
+        `Set a smaller value or unset for the default of 30.`,
     );
   }
   return parsed;


### PR DESCRIPTION
## Summary
Bundled patch release closing the two IMPROVE-NIT findings deferred from v0.41.0's per-task review chain. Reviewed via 4-reviewer plan-chain with EARNED convergence; operator-overrode the F1 2-2 tie to bundle (monday2 hadn't restarted yet, so first dogfood is the polished version).

## Changes

**F1 — #546 regression-test bulletproofing**
- Add optional `execFileSyncFn?: typeof execFileSync` to `SpecGeneratorInput` (mirrors existing `synthesize` injection seam)
- Default = real `execFileSync`; production behavior unchanged
- AC-546-2 tests now assert `keychainOnly` presence directly (was inferable only by code-reading — soft F64 violation)
- 3 new tests: positive-presence (entry exists), negative-absence (entry absent), pre-empt (4xx → probe never invoked)

**F2 — #544 parser strictness**
- Strict regex `^[1-9]\d*$` rejects floats / scientific / junk-suffix / leading-zero
- 36500-day (100-year) sanity cap catches typo overflow
- Closes F46 (Silent Numeric Default) partial-violation
- 7 new tests covering each pathological case + boundary conditions

## Reviewer-chain summary (4 sequential bg subagents)

| Item | P1 (risk-cost) | P2 (industry-norms) | P3 (KB-pattern) | P4 (mechanical) | Tally | Outcome |
|---|---|---|---|---|---|---|
| F1 | DEFER | DEFER | SHIP-NOW | SHIP-NOW | 2-2 tie | Operator override → SHIP |
| F2 | SHIP-NOW | SHIP-NOW | DEFER | SHIP-NOW | 3-1 | SHIP |

**EARNED convergence** — each axis disjoint; P3's split from P1+P2 confirms no cascade.

## Test plan
- [x] 70 tests pass (spec-generator + status suites combined)
- [x] `npx tsc --noEmit` clean
- [x] No production-behavior changes (default `execFileSync` preserved; F2 only rejects inputs that would have produced surprising semantics)

## Related
- Closes deferred-followup arc from v0.41.0
- Plan: `.ai-workspace/plans/2026-05-10-deferred-followups-546-regression-test-and-544-parser-strictness.md`
- Builds on v0.41.0 (#555) which shipped #549/#546/#548/#544