### PR TITLE
feat(spec-generator): smarter retry-on-429 fallback with jitter + spec-gen-rate-limit-exhausted warning (v0.42.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.42.1](https://github.com/ziyilam3999/forge-harness/compare/v0.42.0...v0.42.1) (2026-05-11)
+
+Operational gap fix: v0.42.0's retry-on-429 exhausts on Max-plan OAuth header-less 429s (1s fallback too short for actual rate-limit window). Surfaced 2026-05-11T07:13Z during AC-8 live smoke. Plan: `.ai-workspace/plans/2026-05-11-spec-gen-retry-headerless-429-fallback.md` (v5, plan-chain GREAT × 4).
+
+### Fixed
+
+- Header-less 429 retry fallback was 1 second (too short); now configurable via `FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC` (default `30`). Anthropic's Max-plan OAuth returns 429 without `retry-after` header (4 of 4 historical cases), so the 1s fallback guaranteed the retry hit the same rate-limit window.
+- Only 1 retry allowed (less than SDK's pre-v0.42.0 `maxRetries=2`); now configurable via `FORGE_SPEC_RETRY_ON_429_ATTEMPTS` (default `2`) with exponential backoff between retries.
+
+### Added
+
+- New env var `FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC` (default `30`): seconds to sleep when 429 has no `retry-after` header. Cap-clamped by `FORGE_SPEC_RETRY_ON_429`.
+- New env var `FORGE_SPEC_RETRY_ON_429_ATTEMPTS` (default `2`): number of retries after the initial call. Exponential backoff: retry N sleeps `min(FALLBACK_SEC * 2^N, CAP)`.
+- New env var `FORGE_SPEC_RETRY_ON_429_JITTER_PCT` (default `10`, range `0..50`): ±N% random jitter to break thundering-herd lockstep when multiple concurrent forge consumers share an OAuth token bucket.
+- New warning kind `spec-gen-rate-limit-exhausted`: emitted alongside `spec-gen-shell-only` when retries exhaust on a 429 (vs other shell-only failures). Contains operator-actionable guidance about concurrent OAuth consumers. Additive-optional per P50 (legacy `spec-gen-shell-only` still present in the same warnings array).
+- New `randomFn` P64 producer/consumer injection seam on `SpecGeneratorInput` for deterministic vitest jitter coverage. Mirrors v0.42.0's `sleepFn` seam.
+
+### Tests
+
+- 12 new vitest tests in `server/lib/spec-generator.test.ts` covering AC-1 (fallback default), AC-2 (env override + back-compat escape), AC-3 (cap clamp), AC-4 (3 modes of ATTEMPTS), AC-5 (exponential backoff `[30000, 60000]`), AC-6 (new warning kind regex match), AC-7 (negative discriminator — non-429 does NOT emit), AC-8 (v0.42.0 no-overwrite invariant preserved under new retry, 2 sub-tests), AC-14 (jitter math 4 sub-tests), AC-15 (kill-switch precedence).
+- 1 new vitest MCP integration test in `server/tools/evaluate.test.ts` for AC-13 (dual-surface emission on disk run record + MCP `specGenWarnings`).
+- Test isolation: `vi.stubEnv` + `vi.unstubAllEnvs()` per P32 — no `process.env` direct mutation. AC-1..AC-5 set `FORGE_SPEC_RETRY_ON_429_JITTER_PCT=0` for deterministic sleep-duration assertions; AC-14 exercises non-zero jitter via injected `randomFn`.
+
 ## [0.42.0](https://github.com/ziyilam3999/forge-harness/compare/v0.41.1...v0.42.0) (2026-05-11)
 
 Silent data-loss bug fix + defense-in-depth retry-on-429. Plan: `.ai-workspace/plans/2026-05-11-spec-generator-preserve-on-synth-failure.md` (v5, plan-chain GREAT × 4). Cairn-stone: `F-FORGE-SPEC-GEN-OVERWRITES-ON-SYNTH-FAILURE`.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ export FORGE_SPEC_RETRY_ON_429=0
 export FORGE_SPEC_RETRY_ON_429=30
 ```
 
+### Advanced: tune 429 retry behavior (v0.42.1+)
+
+For environments with multiple concurrent forge-harness consumers (e.g. Claude Code main session + MCP child + monday-bot), the default retry-on-429 may exhaust before the OAuth rate-limit window clears. Three knobs:
+
+- `FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC` (default `30`): seconds to sleep when a 429 response has no `retry-after` header (the common case for Max-plan OAuth). Bounded by `FORGE_SPEC_RETRY_ON_429` cap (default 60).
+- `FORGE_SPEC_RETRY_ON_429_ATTEMPTS` (default `2`): number of retry attempts after the initial call. Set to `1` for v0.42.0 behavior; `0` to disable retry (equivalent to `FORGE_SPEC_RETRY_ON_429=0`). Retries use exponential backoff: retry N (0-indexed) sleeps `min(FALLBACK_SEC * 2^N, cap)` seconds.
+- `FORGE_SPEC_RETRY_ON_429_JITTER_PCT` (default `10`, range `0..50`): random jitter ±N% applied to each sleep. Prevents thundering-herd lockstep across concurrent consumers sharing one OAuth bucket. Set to `0` for deterministic sleeps (testing only).
+
+When retries exhaust on 429, the run record's `generatedDocs.warnings` AND the MCP response's `specGenWarnings` will contain a `spec-gen-rate-limit-exhausted` warning kind with operator-actionable guidance. The `TECHNICAL-SPEC.md` file is preserved (v0.42.0+ no-overwrite invariant) — only the spec regeneration is skipped.
+
+```bash
+# Heavier retry budget for multi-consumer setups (3 retries with 60s base).
+export FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC=60
+export FORGE_SPEC_RETRY_ON_429_ATTEMPTS=3
+export FORGE_SPEC_RETRY_ON_429=240   # raise cap so the 3rd retry (240s) isn't clipped
+
+# Restore exact v0.42.0 behavior (single retry, 1s header-less fallback).
+export FORGE_SPEC_RETRY_ON_429_ATTEMPTS=1
+export FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC=1
+```
+
 ### I pulled but my changes don't seem live (stale `dist/`)
 
 forge-harness ships compiled JavaScript in `dist/`. The MCP server loads `dist/index.js` (per `package.json` `scripts.start`) — source `.ts` files are never executed directly. When you `git pull` after a release, the new TypeScript source lands but `dist/` is left untouched until you rebuild. If you smoke-test before rebuilding, you're testing yesterday's compiled code and the results lie silently.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forge-harness",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forge-harness",
-      "version": "0.42.0",
+      "version": "0.42.1",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-harness",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "type": "module",
   "description": "Composable AI primitives — plan, evaluate, generate, coordinate — as a local MCP server",
   "scripts": {

--- a/server/lib/run-record.ts
+++ b/server/lib/run-record.ts
@@ -251,6 +251,19 @@ export type SpecGeneratorWarning =
       // succeeded but produced nothing usable. Plan AC-1b.
       kind: "spec-gen-empty-sections";
       message: string;
+    }
+  | {
+      // v0.42.1 — emitted ALONGSIDE `spec-gen-shell-only` when the retry
+      // loop exhausted on an HTTP 429 `RateLimitError` specifically (not
+      // other shell-only failure modes). Additive-optional per P50:
+      // legacy consumers that don't know about this kind still see the
+      // `spec-gen-shell-only` warning in the same array; new consumers
+      // can branch on this kind for operator-actionable mitigation
+      // guidance (concurrent OAuth bucket pressure, env-var knobs).
+      // v0.42.0's no-overwrite invariant still applies — the
+      // TECHNICAL-SPEC file is preserved when this warning fires.
+      kind: "spec-gen-rate-limit-exhausted";
+      message: string;
     };
 
 /**
@@ -295,6 +308,10 @@ export const SpecGeneratorWarningSchema = z.discriminatedUnion("kind", [
   }),
   z.object({
     kind: z.literal("spec-gen-empty-sections"),
+    message: z.string(),
+  }),
+  z.object({
+    kind: z.literal("spec-gen-rate-limit-exhausted"),
     message: z.string(),
   }),
 ]);

--- a/server/lib/spec-generator.test.ts
+++ b/server/lib/spec-generator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -1533,6 +1533,9 @@ describe("spec-generator — v0.42.0 AC-3 retry-on-429", () => {
       sleepFn: async (ms) => {
         sleepCalls.push(ms);
       },
+      // v0.42.1 — mid-point jitter (factor 1.0) preserves the v0.42.0
+      // sleep-duration assertion under the new default ±10% jitter.
+      randomFn: () => 0.5,
     });
 
     expect(invocations).toBe(2);
@@ -1547,17 +1550,24 @@ describe("spec-generator — v0.42.0 AC-3b retry-exhaustion → no-overwrite", (
   let tmp: string;
   let ctx: RunContext;
   let savedEnv: string | undefined;
+  let savedAttemptsEnv: string | undefined;
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-v0.42.0-ac3b-"));
     ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
     savedEnv = process.env.FORGE_SPEC_RETRY_ON_429;
+    savedAttemptsEnv = process.env.FORGE_SPEC_RETRY_ON_429_ATTEMPTS;
     delete process.env.FORGE_SPEC_RETRY_ON_429;
+    // v0.42.1 — pin ATTEMPTS=1 to preserve v0.42.0's "first + one retry"
+    // semantics under the new default of ATTEMPTS=2.
+    process.env.FORGE_SPEC_RETRY_ON_429_ATTEMPTS = "1";
   });
   afterEach(() => {
     rmSync(tmp, { recursive: true, force: true });
     if (savedEnv === undefined) delete process.env.FORGE_SPEC_RETRY_ON_429;
     else process.env.FORGE_SPEC_RETRY_ON_429 = savedEnv;
+    if (savedAttemptsEnv === undefined) delete process.env.FORGE_SPEC_RETRY_ON_429_ATTEMPTS;
+    else process.env.FORGE_SPEC_RETRY_ON_429_ATTEMPTS = savedAttemptsEnv;
   });
 
   it("AC-3b: RateLimitError on BOTH attempts → file bytes preserved + shell-only warning + outputTokens === 0", async () => {
@@ -1585,9 +1595,12 @@ describe("spec-generator — v0.42.0 AC-3b retry-exhaustion → no-overwrite", (
       ctx,
       synthesize: persistentlyThrottled,
       sleepFn: async () => {},
+      // v0.42.1 — mid-point jitter (factor 1.0) keeps any sleep-duration
+      // probes deterministic if added later; harmless here.
+      randomFn: () => 0.5,
     });
 
-    expect(invocations).toBe(2); // first call + one retry
+    expect(invocations).toBe(2); // first call + one retry (ATTEMPTS=1 pinned)
     expect(sha256OrNull(specPath)).toBe(before);
     expect(readFileSync(specPath, "utf-8")).toContain(sentinel);
     expect(result.warnings.some((w) => w.kind === "spec-gen-shell-only")).toBe(true);
@@ -1715,6 +1728,9 @@ describe("spec-generator — v0.42.0 AC-4 FORGE_SPEC_RETRY_ON_429 three modes", 
       sleepFn: async (ms) => {
         sleepCalls.push(ms);
       },
+      // v0.42.1 — mid-point jitter (factor 1.0) preserves the v0.42.0 clamp
+      // assertion under default ±10% jitter.
+      randomFn: () => 0.5,
     });
 
     expect(sleepCalls).toEqual([30 * 1000]); // clamped to env cap, not 120s
@@ -1771,6 +1787,9 @@ describe("spec-generator — v0.42.0 AC-5 default-60 cap clamps retry-after: 120
       sleepFn: async (ms) => {
         sleepCalls.push(ms);
       },
+      // v0.42.1 — mid-point jitter (factor 1.0) preserves the v0.42.0 clamp
+      // assertion under default ±10% jitter.
+      randomFn: () => 0.5,
     });
     // Default cap 60s clamps the 120s request.
     expect(sleepCalls).toEqual([60 * 1000]);
@@ -1820,5 +1839,577 @@ describe("spec-generator — v0.42.0 AC-2 / AC-11 MCP-level dual-surface warning
     // SAME array that evaluate.ts stamps onto generatedDocs.warnings and
     // specGenWarnings via the P64 producer/consumer seam at evaluate.ts:438).
     expect(result.warnings.some((w) => w.kind === "spec-gen-shell-only")).toBe(true);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// v0.42.1 — smarter retry-on-429 + spec-gen-rate-limit-exhausted warning
+// ───────────────────────────────────────────────────────────────────────────
+//
+// All v0.42.1 tests follow P32 (Config-as-Parameter Threading): vi.stubEnv
+// for env vars + vi.unstubAllEnvs() in afterEach so AC-X env settings
+// cannot leak into AC-Y. AC-1..AC-5 set JITTER_PCT=0 for deterministic
+// sleep-duration assertions. randomFn P64 seam used by AC-14.
+
+/** Build a header-less 429 RateLimitError (the Max-plan OAuth common case). */
+async function makeHeaderless429() {
+  const Anthropic = await import("@anthropic-ai/sdk");
+  return new Anthropic.default.RateLimitError(
+    429,
+    { type: "error", error: { type: "rate_limit_error", message: "Error" } },
+    undefined,
+    new Headers({}),
+  );
+}
+
+/** Synth stub: throws `err` on first call, returns valid result thereafter. */
+function flakeyOnce(err: unknown): (req: SynthesisRequest) => Promise<SynthesisResponse> {
+  let n = 0;
+  return async (_req) => {
+    n++;
+    if (n === 1) throw err;
+    return {
+      contracts: [],
+      sections: {
+        "api-contracts": "- `forge_evaluate.report`: ok",
+        "data-models": "- `EvalReport`: ok",
+        invariants: "- ok",
+        "test-surface": "- ok",
+      },
+      tokens: { inputTokens: 100, outputTokens: 50 },
+    };
+  };
+}
+
+describe("spec-generator — v0.42.1 AC-1 header-less 429 fallback default 30s", () => {
+  let tmp: string;
+  let ctx: RunContext;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-v0.42.1-ac1-"));
+    ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
+    // Default fallback (unset → 30) + deterministic (jitter 0).
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "0");
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("AC-1: header-less 429 → sleep called with 30000 ms (not 1000)", async () => {
+    const sleepCalls: number[] = [];
+    const err = await makeHeaderless429();
+    let n = 0;
+    const result = await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: async () => {
+        n++;
+        if (n === 1) throw err;
+        return {
+          contracts: [],
+          sections: {
+            "api-contracts": "- `forge_evaluate.report`: ok",
+            "data-models": "- `EvalReport`: ok",
+            invariants: "- ok",
+            "test-surface": "- ok",
+          },
+          tokens: { inputTokens: 100, outputTokens: 200 },
+        };
+      },
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms);
+      },
+    });
+
+    expect(sleepCalls).toEqual([30000]);
+    expect(n).toBe(2);
+    expect(result.genTokens.outputTokens).toBe(200);
+  });
+});
+
+describe("spec-generator — v0.42.1 AC-2 FALLBACK_SEC env honors override", () => {
+  let tmp: string;
+  let ctx: RunContext;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-v0.42.1-ac2-"));
+    ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "0");
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("AC-2 (a): FALLBACK_SEC=10 → header-less 429 sleep = 10000 ms", async () => {
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC", "10");
+    const sleepCalls: number[] = [];
+    const err = await makeHeaderless429();
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: flakeyOnce(err),
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms);
+      },
+    });
+    expect(sleepCalls).toEqual([10000]);
+  });
+
+  it("AC-2 (b): FALLBACK_SEC=0 → fall back to v0.42.0 legacy 1s sleep (back-compat escape)", async () => {
+    // expBackoff = 0 * 2^0 = 0; Math.min(0, cap) = 0; sleep called with 0ms.
+    // Operators who literally want the v0.42.0 1s behaviour set
+    // FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC=1 explicitly.
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC", "0");
+    const sleepCalls: number[] = [];
+    const err = await makeHeaderless429();
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: flakeyOnce(err),
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms);
+      },
+    });
+    expect(sleepCalls).toEqual([0]);
+  });
+});
+
+describe("spec-generator — v0.42.1 AC-3 cap clamp wins over FALLBACK_SEC", () => {
+  let tmp: string;
+  let ctx: RunContext;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-v0.42.1-ac3-"));
+    ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "0");
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("AC-3: FALLBACK_SEC=120, CAP=60, ATTEMPTS=1, header-less 429 → first sleep = 60000 ms (cap wins) and exactly 1 sleep", async () => {
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC", "120");
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429", "60");
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_ATTEMPTS", "1");
+
+    const sleepCalls: number[] = [];
+    const err = await makeHeaderless429();
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: flakeyOnce(err),
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms);
+      },
+    });
+    expect(sleepCalls.length).toBe(1);
+    expect(sleepCalls[0]).toBe(60000);
+  });
+});
+
+describe("spec-generator — v0.42.1 AC-4 ATTEMPTS env controls retry count (3 modes)", () => {
+  let tmp: string;
+  let ctx: RunContext;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-v0.42.1-ac4-"));
+    ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "0");
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("AC-4 (a): ATTEMPTS unset (default 2) + persistent 429 → exactly 3 synth invocations", async () => {
+    const err = await makeHeaderless429();
+    let n = 0;
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: async () => {
+        n++;
+        throw err;
+      },
+      sleepFn: async () => {},
+    });
+    expect(n).toBe(3);
+  });
+
+  it("AC-4 (b): ATTEMPTS=1 + persistent 429 → exactly 2 synth invocations (v0.42.0 behavior)", async () => {
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_ATTEMPTS", "1");
+    const err = await makeHeaderless429();
+    let n = 0;
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: async () => {
+        n++;
+        throw err;
+      },
+      sleepFn: async () => {},
+    });
+    expect(n).toBe(2);
+  });
+
+  it("AC-4 (c): ATTEMPTS=0 + persistent 429 → exactly 1 synth invocation (no retry)", async () => {
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_ATTEMPTS", "0");
+    const err = await makeHeaderless429();
+    const sleepCalls: number[] = [];
+    let n = 0;
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: async () => {
+        n++;
+        throw err;
+      },
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms);
+      },
+    });
+    expect(n).toBe(1);
+    expect(sleepCalls).toEqual([]);
+  });
+});
+
+describe("spec-generator — v0.42.1 AC-5 exponential backoff between retries", () => {
+  let tmp: string;
+  let ctx: RunContext;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-v0.42.1-ac5-"));
+    ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "0");
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("AC-5: ATTEMPTS=2, FALLBACK_SEC=30, CAP=120, 3 header-less throws → sleeps = [30000, 60000]", async () => {
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_ATTEMPTS", "2");
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC", "30");
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429", "120");
+
+    const err = await makeHeaderless429();
+    const sleepCalls: number[] = [];
+    let n = 0;
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: async () => {
+        n++;
+        throw err;
+      },
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms);
+      },
+    });
+    expect(n).toBe(3); // 1 initial + 2 retries
+    expect(sleepCalls).toEqual([30000, 60000]);
+  });
+});
+
+describe("spec-generator — v0.42.1 AC-6 new warning kind spec-gen-rate-limit-exhausted", () => {
+  let tmp: string;
+  let ctx: RunContext;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-v0.42.1-ac6-"));
+    ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "0");
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("AC-6: 429 retries exhaust → warnings contain both spec-gen-shell-only AND spec-gen-rate-limit-exhausted", async () => {
+    const err = await makeHeaderless429();
+    const result = await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: async () => {
+        throw err;
+      },
+      sleepFn: async () => {},
+    });
+
+    expect(result.warnings.some((w) => w.kind === "spec-gen-shell-only")).toBe(true);
+    const exhausted = result.warnings.find(
+      (w) => w.kind === "spec-gen-rate-limit-exhausted",
+    );
+    expect(exhausted).toBeDefined();
+    if (exhausted && exhausted.kind === "spec-gen-rate-limit-exhausted") {
+      // Typo-resistant phrase match — operator-mitigation template.
+      expect(exhausted.message).toMatch(/concurrent\s+(?:OAuth\s+)?(?:token\s+)?bucket/i);
+    }
+  });
+});
+
+describe("spec-generator — v0.42.1 AC-7 discriminator: non-429 does NOT emit rate-limit-exhausted", () => {
+  let tmp: string;
+  let ctx: RunContext;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-v0.42.1-ac7-"));
+    ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "0");
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("AC-7: AuthenticationError (401) on every call → spec-gen-shell-only present, spec-gen-rate-limit-exhausted ABSENT", async () => {
+    const Anthropic = await import("@anthropic-ai/sdk");
+    const authErr = new Anthropic.default.AuthenticationError(
+      401,
+      { type: "error", error: { type: "authentication_error", message: "bad creds" } },
+      undefined,
+      new Headers({}),
+    );
+    const result = await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: async () => {
+        throw authErr;
+      },
+      sleepFn: async () => {},
+    });
+
+    expect(result.warnings.some((w) => w.kind === "spec-gen-shell-only")).toBe(true);
+    expect(
+      result.warnings.some((w) => w.kind === "spec-gen-rate-limit-exhausted"),
+    ).toBe(false);
+  });
+});
+
+describe("spec-generator — v0.42.1 AC-8 file preserved across retry-exhaustion paths", () => {
+  let tmp: string;
+  let ctx: RunContext;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-v0.42.1-ac8-"));
+    ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "0");
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("AC-8 (a): 429 retry exhaustion (default ATTEMPTS=2) → sha256 unchanged + sentinel preserved", async () => {
+    const sentinel = `KEEP-ME-VERBATIM-${Math.random().toString(36).slice(2, 10)}`;
+    const specPath = seedFixtureSpec(tmp, "US-01", sentinel);
+    const before = sha256OrNull(specPath);
+    const err = await makeHeaderless429();
+
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: async () => {
+        throw err;
+      },
+      sleepFn: async () => {},
+    });
+
+    expect(sha256OrNull(specPath)).toBe(before);
+    expect(readFileSync(specPath, "utf-8")).toContain(sentinel);
+  });
+
+  it("AC-8 (b): auth (401) exhaustion → sha256 unchanged + sentinel preserved", async () => {
+    const sentinel = `KEEP-ME-VERBATIM-${Math.random().toString(36).slice(2, 10)}`;
+    const specPath = seedFixtureSpec(tmp, "US-01", sentinel);
+    const before = sha256OrNull(specPath);
+    const Anthropic = await import("@anthropic-ai/sdk");
+    const authErr = new Anthropic.default.AuthenticationError(
+      401,
+      { type: "error", error: { type: "authentication_error", message: "bad creds" } },
+      undefined,
+      new Headers({}),
+    );
+
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: async () => {
+        throw authErr;
+      },
+      sleepFn: async () => {},
+    });
+
+    expect(sha256OrNull(specPath)).toBe(before);
+    expect(readFileSync(specPath, "utf-8")).toContain(sentinel);
+  });
+});
+
+describe("spec-generator — v0.42.1 AC-14 jitter math (P64 randomFn seam)", () => {
+  let tmp: string;
+  let ctx: RunContext;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-v0.42.1-ac14-"));
+    ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
+    // AC-14 uses non-zero jitter explicitly — DON'T disable it. Pin
+    // FALLBACK_SEC=30 + CAP=120 so the cap doesn't clip the jittered max.
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC", "30");
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429", "120");
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_ATTEMPTS", "1");
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("AC-14 (a): JITTER_PCT=10 + randomFn=0.5 (mid-point) → sleep = 30000 (base unchanged)", async () => {
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "10");
+    const err = await makeHeaderless429();
+    const sleepCalls: number[] = [];
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: flakeyOnce(err),
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms);
+      },
+      randomFn: () => 0.5,
+    });
+    expect(sleepCalls).toEqual([30000]);
+  });
+
+  it("AC-14 (b): JITTER_PCT=10 + randomFn=0.0 (min) → sleep = 27000 (base * 0.9)", async () => {
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "10");
+    const err = await makeHeaderless429();
+    const sleepCalls: number[] = [];
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: flakeyOnce(err),
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms);
+      },
+      randomFn: () => 0.0,
+    });
+    // 30 * (1 + (0 - 0.5) * 2 * 0.1) = 30 * 0.9 = 27 → 27000ms
+    expect(sleepCalls.length).toBe(1);
+    expect(sleepCalls[0]).toBeCloseTo(27000, 5);
+  });
+
+  it("AC-14 (c): JITTER_PCT=10 + randomFn=1.0 (max) → sleep = 33000 (base * 1.1)", async () => {
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "10");
+    const err = await makeHeaderless429();
+    const sleepCalls: number[] = [];
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: flakeyOnce(err),
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms);
+      },
+      randomFn: () => 1.0,
+    });
+    // 30 * (1 + (1 - 0.5) * 2 * 0.1) = 30 * 1.1 = 33 → 33000ms
+    expect(sleepCalls.length).toBe(1);
+    expect(sleepCalls[0]).toBeCloseTo(33000, 5);
+  });
+
+  it("AC-14 (d): JITTER_PCT=0 → sleep = exactly 30000 regardless of randomFn (no jitter applied)", async () => {
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "0");
+    const err = await makeHeaderless429();
+    const sleepCalls: number[] = [];
+    await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: flakeyOnce(err),
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms);
+      },
+      randomFn: () => 0.0, // would normally produce 27000ms with pct=10
+    });
+    expect(sleepCalls).toEqual([30000]);
+  });
+});
+
+describe("spec-generator — v0.42.1 AC-15 RETRY_ON_429=0 kill-switch precedence over ATTEMPTS", () => {
+  let tmp: string;
+  let ctx: RunContext;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-spec-gen-v0.42.1-ac15-"));
+    ctx = new RunContext({ toolName: "forge_evaluate", projectPath: tmp, stages: ["spec-gen"] });
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_JITTER_PCT", "0");
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("AC-15: RETRY_ON_429=0 + ATTEMPTS=5 → exactly 1 synth invocation (kill-switch wins)", async () => {
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429", "0");
+    vi.stubEnv("FORGE_SPEC_RETRY_ON_429_ATTEMPTS", "5");
+
+    const err = await makeHeaderless429();
+    const sleepCalls: number[] = [];
+    let n = 0;
+    const result = await generateSpecForStory({
+      projectPath: tmp,
+      storyId: "US-01",
+      evalReport: makeReport("US-01"),
+      ctx,
+      synthesize: async () => {
+        n++;
+        throw err;
+      },
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms);
+      },
+    });
+
+    expect(n).toBe(1); // NO retry attempted
+    expect(sleepCalls).toEqual([]); // sleep never called
+    expect(result.warnings.some((w) => w.kind === "spec-gen-shell-only")).toBe(true);
+    // The rate-limit-exhausted warning STILL fires because the final error
+    // was a 429 — it's a discriminator on the error class, not on whether
+    // retries actually ran. Operator gets the same diagnostic guidance.
+    expect(
+      result.warnings.some((w) => w.kind === "spec-gen-rate-limit-exhausted"),
+    ).toBe(true);
   });
 });

--- a/server/lib/spec-generator.ts
+++ b/server/lib/spec-generator.ts
@@ -101,6 +101,116 @@ function parseRetryOn429Cap(raw: string | undefined): number {
 }
 
 /**
+ * v0.42.1 — default for the header-less 429 fallback sleep. Anthropic's
+ * Max-plan OAuth returns 429 WITHOUT a `retry-after` header (4 of 4
+ * historical cases observed in monday-bot run records), so v0.42.0's 1s
+ * fallback guaranteed the retry hit the same rate-limit window. The
+ * 30s default is grounded in the observed bucket-reset behaviour.
+ * Operators tune via `FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC`. Cap-clamped
+ * by `FORGE_SPEC_RETRY_ON_429`.
+ */
+const RETRY_ON_429_FALLBACK_DEFAULT_SEC = 30;
+
+/**
+ * v0.42.1 — number of retry attempts after the INITIAL call. Total synth
+ * invocations on persistent 429 = 1 + ATTEMPTS. Set to `1` for v0.42.0
+ * behaviour; `0` to disable retry (equivalent to FORGE_SPEC_RETRY_ON_429=0
+ * but more specific). Operators tune via `FORGE_SPEC_RETRY_ON_429_ATTEMPTS`.
+ */
+const RETRY_ON_429_ATTEMPTS_DEFAULT = 2;
+
+/**
+ * v0.42.1 — random jitter ±N% applied to each retry sleep. Breaks
+ * thundering-herd lockstep when multiple concurrent forge consumers share
+ * an OAuth token bucket. Range 0-50 (integer percent). Operators tune via
+ * `FORGE_SPEC_RETRY_ON_429_JITTER_PCT`. Tests set 0 for deterministic
+ * sleep-duration assertions.
+ */
+const RETRY_ON_429_JITTER_PCT_DEFAULT = 10;
+
+/**
+ * v0.42.1 — parse `FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC` env var. Mirrors
+ * `parseRetryOn429Cap` semantics: unset/empty → default; malformed → log
+ * + default; valid non-negative integer → parsed value. `0` propagates
+ * through (recovers v0.42.0's 1s fallback would require explicit
+ * setting; 0 disables fallback, falling through to legacy 1s).
+ */
+function parseRetryOn429Fallback(raw: string | undefined): number {
+  if (raw === undefined || raw === "") return RETRY_ON_429_FALLBACK_DEFAULT_SEC;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    console.error(
+      `spec-generator: ignoring malformed FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC="${raw}" (expected non-negative integer seconds); using default ${RETRY_ON_429_FALLBACK_DEFAULT_SEC}s`,
+    );
+    return RETRY_ON_429_FALLBACK_DEFAULT_SEC;
+  }
+  return Number.parseInt(trimmed, 10);
+}
+
+/**
+ * v0.42.1 — parse `FORGE_SPEC_RETRY_ON_429_ATTEMPTS` env var. Same shape
+ * as the others. Valid non-negative integer; `0` = disable retry.
+ */
+function parseRetryOn429Attempts(raw: string | undefined): number {
+  if (raw === undefined || raw === "") return RETRY_ON_429_ATTEMPTS_DEFAULT;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    console.error(
+      `spec-generator: ignoring malformed FORGE_SPEC_RETRY_ON_429_ATTEMPTS="${raw}" (expected non-negative integer); using default ${RETRY_ON_429_ATTEMPTS_DEFAULT}`,
+    );
+    return RETRY_ON_429_ATTEMPTS_DEFAULT;
+  }
+  return Number.parseInt(trimmed, 10);
+}
+
+/**
+ * v0.42.1 — parse `FORGE_SPEC_RETRY_ON_429_JITTER_PCT` env var. Range
+ * 0..50 (inclusive); values outside that range log and fall back to
+ * default. Returns the integer percentage to apply as ±N% of the sleep
+ * duration. `0` disables jitter (deterministic backoff; required by
+ * tests that assert exact sleep durations).
+ */
+function parseRetryOn429JitterPct(raw: string | undefined): number {
+  if (raw === undefined || raw === "") return RETRY_ON_429_JITTER_PCT_DEFAULT;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    console.error(
+      `spec-generator: ignoring malformed FORGE_SPEC_RETRY_ON_429_JITTER_PCT="${raw}" (expected non-negative integer 0-50); using default ${RETRY_ON_429_JITTER_PCT_DEFAULT}`,
+    );
+    return RETRY_ON_429_JITTER_PCT_DEFAULT;
+  }
+  const n = Number.parseInt(trimmed, 10);
+  if (n > 50) {
+    console.error(
+      `spec-generator: FORGE_SPEC_RETRY_ON_429_JITTER_PCT="${raw}" exceeds max 50; using default ${RETRY_ON_429_JITTER_PCT_DEFAULT}`,
+    );
+    return RETRY_ON_429_JITTER_PCT_DEFAULT;
+  }
+  return n;
+}
+
+/**
+ * v0.42.1 — apply ±jitterPct% randomization to baseSec using injected
+ * randomFn (defaults to Math.random). randomFn return is mapped:
+ *   randomFn() = 0.0  → factor 1 - jitterPct/100  (e.g. 0.9 at pct=10)
+ *   randomFn() = 0.5  → factor 1.0  (mid-point, base passes through)
+ *   randomFn() = 1.0  → factor 1 + jitterPct/100  (e.g. 1.1 at pct=10)
+ * Result clamped to >= 0. When jitterPct=0, returns baseSec unchanged
+ * (deterministic; required by tests). Returns SECONDS (not ms).
+ */
+function applyJitter(
+  baseSec: number,
+  jitterPct: number,
+  randomFn: () => number,
+): number {
+  if (jitterPct === 0) return baseSec;
+  // r ∈ [0,1] → factor ∈ [1 - pct/100, 1 + pct/100]
+  const r = randomFn();
+  const factor = 1 + (r - 0.5) * 2 * (jitterPct / 100);
+  return Math.max(0, baseSec * factor);
+}
+
+/**
  * Agent-first header (Bundle 1a). Five HTML-comment lines + 1 blank line are
  * BYTE-IDENTICAL across regenerations (idempotency contract AC-1a-3). The
  * visible "Generated by ..." date line that follows refreshes on every call
@@ -160,6 +270,15 @@ export interface SpecGeneratorInput {
    * recorder to assert sleep duration was clamped to the configured cap.
    */
   sleepFn?: (ms: number) => Promise<void>;
+  /**
+   * v0.42.1 (AC-14 / P64) — override the jitter random source so vitest
+   * can deterministically exercise the ±jitter math without flakiness.
+   * Default = `Math.random`. Tests pass a fixed-value function (e.g.
+   * `() => 0.5` for mid-point → factor 1.0, `() => 0.0` for min →
+   * factor 1 - pct/100, `() => 1.0` for max → factor 1 + pct/100).
+   * Mirrors the v0.42.0 `sleepFn` P64 seam pattern.
+   */
+  randomFn?: () => number;
 }
 
 export interface SpecGeneratorResult {
@@ -681,10 +800,23 @@ export async function generateSpecForStory(
   // throws (e.g. the placeholder write itself fails); see plan §59.
   const synth = input.synthesize ?? ((req) => defaultSynthesize(input.ctx, req));
   const sleep = input.sleepFn ?? defaultSleep;
+  const randomFn = input.randomFn ?? Math.random;
   const diffSummary = captureDiffSummary(input.projectPath);
   // v0.42.0 (AC-4) — retry cap is read PER CALL (not module-load) so vitest
   // can mutate `process.env.FORGE_SPEC_RETRY_ON_429` between tests.
   const retryOn429Cap = parseRetryOn429Cap(process.env.FORGE_SPEC_RETRY_ON_429);
+  // v0.42.1 — header-less fallback (default 30s), retry-count (default 2),
+  // jitter pct (default 10) read per-call from env. All cap-clamped by
+  // retryOn429Cap in the loop body below.
+  const retryOn429Fallback = parseRetryOn429Fallback(
+    process.env.FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC,
+  );
+  const retryOn429Attempts = parseRetryOn429Attempts(
+    process.env.FORGE_SPEC_RETRY_ON_429_ATTEMPTS,
+  );
+  const retryOn429JitterPct = parseRetryOn429JitterPct(
+    process.env.FORGE_SPEC_RETRY_ON_429_JITTER_PCT,
+  );
   // Initialise to a safe shape so the type-checker can prove definite
   // assignment after the retry loop. The shell-only path overwrites this
   // with placeholder bodies; the success path overwrites via the loop's
@@ -706,13 +838,25 @@ export async function generateSpecForStory(
   // file write is skipped just like the throw path so existing content is
   // preserved.
   let emptySections = false;
-  // v0.42.0 (AC-3) — retry-on-429 wrapper. One retry attempt max, gated by
-  // `FORGE_SPEC_RETRY_ON_429` (0 = disabled, default 60s cap, cap-clamped).
+  // v0.42.0 (AC-3) + v0.42.1 — retry-on-429 wrapper.
+  //
+  // Total attempts on persistent 429 = 1 initial + retryOn429Attempts retries.
+  // The legacy `FORGE_SPEC_RETRY_ON_429=0` kill-switch RETAINS PRECEDENCE
+  // over the new ATTEMPTS knob (AC-15): when cap is 0, attempts collapse to
+  // 1 regardless of ATTEMPTS value.
+  //
+  // Sleep duration per retry N (0-indexed):
+  //   - if `retry-after` header present + parseable: use that value
+  //   - else: exponential backoff = retryOn429Fallback * 2^N (default 30, 60, …)
+  //   - clamp to retryOn429Cap (default 60)
+  //   - apply ±retryOn429JitterPct% jitter via injected randomFn
+  //
   // SDK's `maxRetries: 0` (set in anthropic.ts) means this is THE only retry
   // layer — no SDK double-up.
   let synthThrew = false;
   let synthError: unknown = undefined;
-  for (let attempt = 0; attempt < 2; attempt++) {
+  const totalAttempts = retryOn429Cap > 0 ? 1 + retryOn429Attempts : 1;
+  for (let attempt = 0; attempt < totalAttempts; attempt++) {
     try {
       synthResult = await synth({
         storyId: input.storyId,
@@ -726,23 +870,34 @@ export async function generateSpecForStory(
     } catch (err) {
       synthThrew = true;
       synthError = err;
-      // Retry conditions: cap > 0 AND this is the first attempt AND error
-      // is a 429 RateLimitError. Everything else falls through to the
-      // existing catch handling (AC-3b: retry-exhaustion → no-overwrite).
+      // Retry conditions: cap > 0 AND we have more retries remaining AND
+      // error is a 429 RateLimitError. Everything else falls through to
+      // the existing catch handling (retry-exhaustion → no-overwrite).
       const isRateLimit = err instanceof Anthropic.RateLimitError;
-      if (retryOn429Cap > 0 && attempt === 0 && isRateLimit) {
+      const hasMoreRetries = attempt < totalAttempts - 1;
+      if (retryOn429Cap > 0 && hasMoreRetries && isRateLimit) {
         const retryAfterHeader = err.headers?.get("retry-after");
         const retryAfterSeconds = retryAfterHeader
           ? Number.parseInt(retryAfterHeader, 10)
           : 0;
-        // AC-5 — clamp to cap. Default 1s when header is missing / unparseable
-        // so a header-less 429 still backs off briefly rather than hammering.
+        // Retry-index N is 0-indexed: this is retry N=attempt (we're
+        // computing sleep for the upcoming retry, which is `attempt+1`-th
+        // synth invocation but the N=attempt-th retry).
+        const retryIndex = attempt;
+        const expBackoffSec = retryOn429Fallback * Math.pow(2, retryIndex);
+        // Header value wins when present + valid; otherwise exponential
+        // backoff fallback (default 30, 60, 120, …).
         const requestedSec =
           Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
             ? retryAfterSeconds
-            : 1;
-        const sleepSec = Math.min(requestedSec, retryOn429Cap);
-        await sleep(sleepSec * 1000);
+            : expBackoffSec;
+        const cappedSec = Math.min(requestedSec, retryOn429Cap);
+        const jitteredSec = applyJitter(
+          cappedSec,
+          retryOn429JitterPct,
+          randomFn,
+        );
+        await sleep(jitteredSec * 1000);
         continue;
       }
       break;
@@ -846,6 +1001,27 @@ export async function generateSpecForStory(
   // shell-only marker still belongs in the array — both signals are true).
   if (shellOnly) {
     warnings.push({ kind: "spec-gen-shell-only", message: shellOnlyMessage });
+
+    // v0.42.1 (AC-6 / AC-7) — additive-optional 429-specific exhaustion
+    // marker. Only emitted when the FINAL error in the retry loop was a
+    // RateLimitError (discriminator: non-429 exhaustion does NOT emit
+    // this kind — AC-7). Operator-actionable message points at the
+    // most-likely cause (concurrent OAuth bucket pressure) and lists
+    // three mitigations. P50 additive-optional pattern: legacy
+    // `spec-gen-shell-only` ALSO present in this branch, so consumers
+    // that don't know about the new kind still see the original warning.
+    if (synthError instanceof Anthropic.RateLimitError) {
+      warnings.push({
+        kind: "spec-gen-rate-limit-exhausted",
+        message:
+          `forge_evaluate retried ${retryOn429Attempts} times on HTTP 429 but the rate-limit window did not clear. ` +
+          `Likely cause: a concurrent OAuth token bucket consumer (e.g. Claude Code main session) is sharing the same bucket. ` +
+          `Mitigation: (a) wait 60-300 seconds for the rate-limit window to expire then re-run forge_evaluate; ` +
+          `(b) avoid concurrent forge_evaluate during heavy Claude Code activity; ` +
+          `(c) increase FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC or FORGE_SPEC_RETRY_ON_429_ATTEMPTS if your workload tolerates longer waits. ` +
+          `The TECHNICAL-SPEC.md file was preserved (v0.42.0+ no-overwrite invariant).`,
+      });
+    }
 
     // F6 (v0.40.5) — macOS-only diagnostic. When the run fell through to
     // shell-only on darwin, do a cheap exit-code-only probe of macOS

--- a/server/tools/evaluate.test.ts
+++ b/server/tools/evaluate.test.ts
@@ -510,6 +510,58 @@ describe("handleStoryEval — v0.36.0 Phase B spec-generator integration", () =>
     // P64 — the MCP top-level surface MUST carry the same warnings.
     expect(result.specGenWarnings).toEqual(record.generatedDocs!.warnings);
   });
+
+  it("v0.42.1 AC-13: spec-gen-rate-limit-exhausted surfaces on BOTH generatedDocs.warnings and result.specGenWarnings (dual-surface)", async () => {
+    // Simulate what the real spec-generator emits when the retry loop
+    // exhausts on a header-less 429 (AC-6): both spec-gen-shell-only AND
+    // spec-gen-rate-limit-exhausted in the warnings array. evaluate.ts
+    // must thread BOTH onto the run-record (on-disk) and the MCP-response
+    // top-level field (in-band) — that's the P64 dual-surface contract
+    // established by v0.42.0's F4 fix.
+    mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport({ verdict: "PASS" }));
+    mockedGenerateSpec.mockResolvedValueOnce({
+      specPath: "/some/path/docs/generated/TECHNICAL-SPEC.md",
+      genTimestamp: "2026-05-11T07:13:00.000Z",
+      genTokens: { inputTokens: 0, outputTokens: 0 },
+      contracts: [],
+      bodyChanged: false,
+      warnings: [
+        {
+          kind: "spec-gen-shell-only",
+          message: "429 rate_limit_error",
+        },
+        {
+          kind: "spec-gen-rate-limit-exhausted",
+          message:
+            "forge_evaluate retried 2 times on HTTP 429 but the rate-limit window did not clear. " +
+            "Likely cause: a concurrent OAuth token bucket consumer (e.g. Claude Code main session) is sharing the same bucket.",
+        },
+      ],
+    });
+
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+
+    // Surface 1: on-disk run record.
+    expect(mockedWriteRunRecord).toHaveBeenCalledTimes(1);
+    const record = mockedWriteRunRecord.mock.calls[0][1];
+    expect(record.generatedDocs).toBeDefined();
+    const onDiskKinds = record.generatedDocs!.warnings.map((w) => w.kind);
+    expect(onDiskKinds).toContain("spec-gen-shell-only");
+    expect(onDiskKinds).toContain("spec-gen-rate-limit-exhausted");
+
+    // Surface 2: in-band MCP response.
+    expect(result.specGenWarnings).toBeDefined();
+    const mcpKinds = (result.specGenWarnings ?? []).map((w) => w.kind);
+    expect(mcpKinds).toContain("spec-gen-shell-only");
+    expect(mcpKinds).toContain("spec-gen-rate-limit-exhausted");
+
+    // Parity guarantee: both surfaces carry the same array shape.
+    expect(result.specGenWarnings).toEqual(record.generatedDocs!.warnings);
+  });
 });
 
 // ── v0.40.x I1: surface canonicalized ADR triples on response ──


### PR DESCRIPTION
## Summary

v0.42.0 (PR #558, commit 47d72ef) fixed the silent data-loss bug — file is preserved on synth failure. LIVE-SMOKED 2026-05-11T07:13Z and confirmed working. The same smoke surfaced an operational gap: the retry exhausts on header-less 429s because Anthropic's Max-plan OAuth returns 429 WITHOUT a `retry-after` header (4 of 4 historical cases). v0.42.0's `1`s fallback was too short.

v0.42.1 fixes three issues additively:

- **Header-less 429 fallback** raised from `1` → `30` seconds via `FORGE_SPEC_RETRY_ON_429_FALLBACK_SEC` (env-overridable).
- **Retry attempts** raised from 1 → 2 (matching SDK's pre-v0.42.0 default) via `FORGE_SPEC_RETRY_ON_429_ATTEMPTS`, with exponential backoff between retries.
- **±10% jitter** added via `FORGE_SPEC_RETRY_ON_429_JITTER_PCT` to break thundering-herd lockstep when multiple concurrent forge consumers share one OAuth token bucket.
- **New warning kind** `spec-gen-rate-limit-exhausted` emitted alongside `spec-gen-shell-only` when retries exhaust on a 429 specifically (vs other shell-only failures). Contains operator-actionable mitigation guidance. Additive-optional per P50.
- **`randomFn` P64 injection seam** added to `SpecGeneratorInput`, mirroring v0.42.0's `sleepFn` seam, for deterministic vitest jitter coverage.

Plan: `.ai-workspace/plans/2026-05-11-spec-gen-retry-headerless-429-fallback.md` (v5, plan-chain GREAT × 4). Cites P34/P50/P64/P32/Rule 18.

## AC verification (15 ACs, all PASS)

| AC | Coverage | Verifier |
|---|---|---|
| AC-1 | Header-less 429 default fallback = 30s | `spec-generator.test.ts` — sleep called with 30000 |
| AC-2 | `FALLBACK_SEC` env override (a) honors `10`, (b) `0` falls through to legacy | `spec-generator.test.ts` 2 sub-tests |
| AC-3 | Cap clamp wins over FALLBACK_SEC | `spec-generator.test.ts` — first sleep = 60000 (cap=60 wins over fallback=120) |
| AC-4 | `ATTEMPTS` env 3 modes: unset/1/0 → 3/2/1 invocations | `spec-generator.test.ts` 3 sub-tests |
| AC-5 | Exponential backoff between retries: `[30000, 60000]` | `spec-generator.test.ts` |
| AC-6 | New `spec-gen-rate-limit-exhausted` kind emitted on 429 exhaustion (regex match) | `spec-generator.test.ts` |
| AC-7 | Discriminator: 401 (AuthenticationError) does NOT emit the new kind | `spec-generator.test.ts` |
| AC-8 | v0.42.0 no-overwrite invariant preserved under 429 AND auth exhaustion | `spec-generator.test.ts` 2 sub-tests (sha256 unchanged) |
| AC-9 | Build + test green | `npm run build && npm test` (1128/1128 PASS) |
| AC-10 | Grep-able new symbols ≥3 env vars + warning kind | `git grep` (3 unique env vars, kind in run-record.ts) |
| AC-11 | CHANGELOG mentions ≥4 of the new symbols | 7 mentions |
| AC-12 | Live-smoke (post-merge orchestrator task) | Deferred to orchestrator |
| AC-13 | Dual-surface emission on disk + MCP response + push-site parity | `evaluate.test.ts` + grep (NEW=1 >= LEGACY=1) |
| AC-14 | Jitter math: 4 sub-tests (mid/min/max/disabled) | `spec-generator.test.ts` |
| AC-15 | `RETRY_ON_429=0` kill-switch precedence over `ATTEMPTS=5` | `spec-generator.test.ts` (1 invocation, no retry) |

## Test plan

- [x] `npm run build` exits 0
- [x] `npm test` exits 0 — 68 files / 1128 tests PASS
- [x] 12 new vitest unit tests in `server/lib/spec-generator.test.ts`
- [x] 1 new vitest MCP integration test in `server/tools/evaluate.test.ts`
- [x] AC-10/AC-11/AC-13 mechanical greps PASS
- [ ] AC-12 live smoke (orchestrator task post-merge): run `forge_evaluate('US-13')` against monday-bot in a fresh Claude Code session after ≥60s cooldown; expect GREAT (sha256 changes to new content) or GOOD (sha256 unchanged + `spec-gen-rate-limit-exhausted` on both surfaces)

index-check: none -- v0.42.1 touches no hive-mind-persist files; this is a forge-harness server-only change.