### PR TITLE
fix(spec-generator): surface callerAction inside MCP content (v0.43.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.43.1](https://github.com/ziyilam3999/forge-harness/compare/v0.43.0...v0.43.1) (2026-05-11)
+
+MCP-client-visible surfacing fix for the v0.43.0 caller-action directive. Plan: `.ai-workspace/plans/2026-05-11-spec-gen-directive-mcp-content-surfacing.md`. Cairn-stones (to place at /ship): `F-DIRECTIVE-EMITTED-OUTSIDE-CONTENT`, `F-DIRECTIVE-INTO-VOID` (retroactive n=2 recording).
+
+### Fixed
+
+- **MCP-client-visible directive surfacing** on `forge_evaluate`'s PASS path. v0.43.0 emitted `callerAction: "generate-spec-inline"` and `specGenBrief` as siblings of `content` on the outer MCP response envelope, but standard MCP clients (Claude Code's renderer included) only expose `content[0].text` to the calling agent — emitting the directive into a void. The AC-11 live smoke run record (`monday-bot/.forge/runs/forge_evaluate-2026-05-11T09-34-10-439Z-bc5b.json`) showed `specGenMode: "caller-action"` server-side but `content[0].text` carrying only `{storyId, verdict, criteria}`; the caller agent never saw the directive and silently no-op'd, leaving `docs/generated/TECHNICAL-SPEC.md` unchanged (pre-sha = post-sha). v0.43.1 merges `callerAction`, `specGenBrief`, and `specGenWarnings` INTO the JSON-stringified `content[0].text` payload alongside the eval report so the documented `JSON.parse(result.content[0].text).callerAction` access path actually works. Mirrors the working pattern in `forge_generate` (live since v0.36.0). Envelope-sibling fields (`result.callerAction`, `result.specGenBrief`, `result.specGenWarnings`) are RETAINED unchanged for envelope-aware clients — same data on both surfaces, belt-and-suspenders.
+
+### Changed
+
+- README §"Handling the `generate-spec-inline` directive" now documents the `JSON.parse(result.content[0].text)` access pattern as the primary path; the legacy envelope-sibling reference remains for envelope-aware clients.
+
+### Tests
+
+- 4 new vitest tests in `server/tools/evaluate.test.ts` (AC-1 / AC-3 / AC-4 / AC-5) assert the post-`JSON.parse(content[0].text)` access path mechanically: directive reachable on PASS, `specGenWarnings` present (empty array on no warnings), legacy-path (`FORGE_SPEC_CALLER_ACTION=0`) content omits the directive fields, hand-author short-circuit content omits the directive but carries the `spec-gen-short-circuited-hand-author` warning. Suite size grew from 1144 → 1148 tests.
+
 ## [0.43.0](https://github.com/ziyilam3999/forge-harness/compare/v0.42.1...v0.43.0) (2026-05-11)
 
 Architectural fix: the MCP child no longer calls the Anthropic API on the spec-gen path. Plan: `.ai-workspace/plans/2026-05-11-spec-gen-via-caller-action-directive.md` (v5, plan-chain GREAT × 4). Cairn-stone: `F-OAUTH-MCP-CHILD-NOT-ALLOWED-DIRECT-ANTHROPIC-CALL`.

--- a/README.md
+++ b/README.md
@@ -92,10 +92,23 @@ After setting the env var, restart Claude Code so the forge MCP child picks up t
 
 Starting in v0.43.0, `forge_evaluate`'s PASS path **does not call Anthropic itself**. Instead it returns a directive asking the calling Claude Code session to do the spec-gen LLM round-trip inline. This sidesteps Max-plan OAuth's header-less anti-abuse 429s entirely — the MCP child no longer hits the Anthropic API for spec-gen.
 
-The MCP response envelope looks like this on a story-mode PASS:
+**v0.43.1 surfacing fix.** Starting in v0.43.1, the directive fields (`callerAction`, `specGenBrief`, `specGenWarnings`) are embedded INSIDE `content[0].text` as JSON-stringified data so standard MCP clients (which render the `content` field) can reach them via `JSON.parse(result.content[0].text)`. The v0.43.0 envelope-sibling shape (`result.callerAction`, `result.specGenBrief`) is retained for envelope-aware clients — same data on both surfaces, belt-and-suspenders. **Use the `JSON.parse` access path** in new caller integrations:
+
+```javascript
+const parsed = JSON.parse(result.content[0].text);
+if (parsed.callerAction === "generate-spec-inline") {
+  const brief = parsed.specGenBrief;
+  // ... act on the directive
+}
+```
+
+The MCP response shape on a story-mode PASS (post-`JSON.parse(content[0].text)`):
 
 ```json
 {
+  "storyId": "US-13",
+  "verdict": "PASS",
+  "criteria": [{ "id": "AC-01", "status": "PASS", "evidence": "ok" }],
   "callerAction": "generate-spec-inline",
   "specGenBrief": {
     "storyId": "US-13",
@@ -115,15 +128,14 @@ The MCP response envelope looks like this on a story-mode PASS:
       "test-surface": "..."
     }
   },
-  "specGenWarnings": [],
-  ...
+  "specGenWarnings": []
 }
 ```
 
 Six-step caller-side flow:
 
-1. **Detect the directive.** Inspect the response envelope for `result.callerAction === "generate-spec-inline"`. When absent (hand-author short-circuit, non-PASS verdict, or `FORGE_SPEC_CALLER_ACTION=0` opt-out), do nothing — there's no caller work.
-2. **Extract the prompts.** Read `result.specGenBrief.systemPrompt` and `result.specGenBrief.userPrompt`. Both are pre-rendered server-side; do NOT re-assemble.
+1. **Detect the directive.** Parse `result.content[0].text` as JSON and inspect `parsed.callerAction === "generate-spec-inline"`. When absent (hand-author short-circuit, non-PASS verdict, or `FORGE_SPEC_CALLER_ACTION=0` opt-out), do nothing — there's no caller work. (Envelope-aware clients may also read `result.callerAction` directly; both surfaces carry the same value.)
+2. **Extract the prompts.** Read `parsed.specGenBrief.systemPrompt` and `parsed.specGenBrief.userPrompt`. Both are pre-rendered server-side; do NOT re-assemble.
 3. **Call your LLM.** Send the system + user message to your Anthropic connection (the calling Claude Code session's own, which is the path that works — the MCP child is the one with the OAuth-bucket issue). Request JSON-mode output. The model returns a single JSON object matching this schema:
    ```json
    {
@@ -136,8 +148,8 @@ Six-step caller-side flow:
      }
    }
    ```
-4. **Parse the response.** Validate that `sections` contains exactly the four keys from `result.specGenBrief.expectedSections`. Each section is a Markdown bullet list (or the literal string `"(none)"`). Capture the `tokens` your LLM client reports — `{inputTokens, outputTokens}`.
-5. **Call `forge_apply_spec_gen`.** Invoke the MCP tool with `{runId, storyId, projectPath, sections, contracts, tokens, affectedPaths, gitSha}`. The `runId` MUST be the one from the brief (`result.specGenBrief.runId`) so the merge event lands on the same run-record file as the brief-emit event. `affectedPaths` and `gitSha` are echoed from the brief for vocabulary-grounding + front-matter stamping.
+4. **Parse the response.** Validate that `sections` contains exactly the four keys from `parsed.specGenBrief.expectedSections`. Each section is a Markdown bullet list (or the literal string `"(none)"`). Capture the `tokens` your LLM client reports — `{inputTokens, outputTokens}`.
+5. **Call `forge_apply_spec_gen`.** Invoke the MCP tool with `{runId, storyId, projectPath, sections, contracts, tokens, affectedPaths, gitSha}`. The `runId` MUST be the one from the brief (`parsed.specGenBrief.runId`) so the merge event lands on the same run-record file as the brief-emit event. `affectedPaths` and `gitSha` are echoed from the brief for vocabulary-grounding + front-matter stamping.
 6. **Verify success.** The tool returns `{specPath, warnings, contracts, bodyChanged, runRecordPath}`. Success = `runRecordPath` is non-null AND `warnings` contains no `spec-gen-empty-sections` entries.
 
 **Opt-out: legacy v0.42.x in-MCP synth.** Set `FORGE_SPEC_CALLER_ACTION=0` in the environment that launches the MCP server (e.g., your Claude Code config). The PASS path then calls Anthropic directly via the legacy `generateSpecForStory` code path. Use this only when you have a stable API-key identity (not Max-plan OAuth) and want the simpler one-shot flow. Both v0.42.0's preserve-invariant and v0.42.1's retry-on-429 remain active on the legacy path; both inherit by reuse on the new path's `forge_apply_spec_gen` merge half.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forge-harness",
-  "version": "0.42.1",
+  "version": "0.43.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forge-harness",
-      "version": "0.42.1",
+      "version": "0.43.1",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-harness",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "type": "module",
   "description": "Composable AI primitives — plan, evaluate, generate, coordinate — as a local MCP server",
   "scripts": {

--- a/server/tools/evaluate.test.ts
+++ b/server/tools/evaluate.test.ts
@@ -1499,6 +1499,112 @@ describe("v0.43.0 — callerAction directive flow on PASS path", () => {
   });
 });
 
+// ── v0.43.1: directive surfacing inside MCP content[0].text ─────────────────
+//
+// v0.43.0 emitted `callerAction` and `specGenBrief` as siblings of `content`
+// on the outer MCP response envelope. Standard MCP clients (Claude Code
+// included) only expose `content[0].text` to the calling agent, so the
+// directive emitted to a place the agent couldn't see — the AC-11 live smoke
+// (run record `monday-bot/.forge/runs/forge_evaluate-2026-05-11T09-34-10-439Z-bc5b.json`)
+// surfaced this. v0.43.1 merges the directive fields INTO the JSON-stringified
+// `content[0].text` payload while retaining envelope siblings as
+// belt-and-suspenders. These tests pin the post-`JSON.parse(content[0].text)`
+// access path.
+describe("v0.43.1 — directive surfacing inside content[0].text", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default-path (directive flow) for these tests except where AC-4 flips
+    // back to legacy via FORGE_SPEC_CALLER_ACTION=0.
+    vi.stubEnv("FORGE_SPEC_CALLER_ACTION", "");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("AC-1: PASS-path content[0].text JSON includes callerAction + specGenBrief reachable via JSON.parse", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport({ verdict: "PASS" }));
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].type).toBe("text");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.callerAction).toBe("generate-spec-inline");
+    expect(parsed.specGenBrief).toBeDefined();
+    expect(typeof parsed.specGenBrief).toBe("object");
+    expect(typeof parsed.specGenBrief.runId).toBe("string");
+    expect(parsed.specGenBrief.runId.length).toBeGreaterThan(0);
+    expect(typeof parsed.specGenBrief.systemPrompt).toBe("string");
+    expect(parsed.specGenBrief.systemPrompt.length).toBeGreaterThan(0);
+    // Eval-report fields MUST NOT be shadowed by directive fields (spread
+    // order: report first).
+    expect(parsed.storyId).toBe("US-01");
+    expect(parsed.verdict).toBe("PASS");
+    expect(Array.isArray(parsed.criteria)).toBe(true);
+  });
+
+  it("AC-3: specGenWarnings is present in content[0].text JSON (empty array on no warnings)", async () => {
+    mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport({ verdict: "PASS" }));
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    expect("specGenWarnings" in parsed).toBe(true);
+    expect(Array.isArray(parsed.specGenWarnings)).toBe(true);
+    // Same data as the outer-envelope sibling (belt-and-suspenders).
+    expect(parsed.specGenWarnings).toEqual(result.specGenWarnings);
+  });
+
+  it("AC-4: legacy-path (FORGE_SPEC_CALLER_ACTION=0) content[0].text JSON has NO callerAction or specGenBrief fields", async () => {
+    vi.stubEnv("FORGE_SPEC_CALLER_ACTION", "0");
+    mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport({ verdict: "PASS" }));
+    const result = await handleEvaluate({
+      storyId: "US-01",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    expect("callerAction" in parsed).toBe(false);
+    expect("specGenBrief" in parsed).toBe(false);
+    // Envelope siblings also absent on legacy path.
+    expect(result.callerAction).toBeUndefined();
+    expect(result.specGenBrief).toBeUndefined();
+    // Eval-report fields still present.
+    expect(parsed.storyId).toBe("US-01");
+    expect(parsed.verdict).toBe("PASS");
+  });
+
+  it("AC-5: hand-author short-circuit content[0].text JSON has NO directive but DOES carry the short-circuit warning", async () => {
+    // Simulate hand-author marker on one sub-section so AC-3b fires.
+    mockedExtractCurrent.mockReturnValueOnce({
+      "api-contracts": "<!-- hand-authored 2026-05-11 by operator -->\n- something",
+      "data-models": "",
+      invariants: "",
+      "test-surface": "",
+    });
+    mockedHasHandAuthored.mockReturnValueOnce(true);
+
+    mockedEvaluateStory.mockResolvedValueOnce(makeEvalReport({ verdict: "PASS" }));
+    const result = await handleEvaluate({
+      storyId: "US-13",
+      planJson: makeValidPlanJson(),
+      projectPath: "/some/path",
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    expect("callerAction" in parsed).toBe(false);
+    expect("specGenBrief" in parsed).toBe(false);
+    expect(Array.isArray(parsed.specGenWarnings)).toBe(true);
+    const kinds = parsed.specGenWarnings.map(
+      (w: { kind: string }) => w.kind,
+    );
+    expect(kinds).toContain("spec-gen-short-circuited-hand-author");
+  });
+});
+
 describe("computeReverseFindingId — determinism", () => {
   it("same inputs produce the same id across calls", () => {
     const a = computeReverseFindingId("server/foo.ts:10", "method-divergence", "x");

--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -712,8 +712,32 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
   // field presence as a "did the canonicalizer run?" signal. Coherence-mode
   // and divergence-mode handlers do NOT set this field — see McpResponse
   // type doc.
+  //
+  // v0.43.1 — merge `callerAction`, `specGenBrief`, and `specGenWarnings`
+  // INTO the JSON-stringified `content[0].text` payload alongside the eval
+  // report so standard MCP clients (which render `content`, not envelope
+  // siblings) can reach them via `JSON.parse(content[0].text)`. The v0.43.0
+  // envelope-sibling shape is RETAINED as belt-and-suspenders for any
+  // envelope-aware MCP client (same data, both surfaces). Mirrors the
+  // working pattern in forge_generate (`server/tools/generate.ts`, live
+  // since v0.36.0). Spread order pins eval-report keys (storyId, verdict,
+  // criteria, …) FIRST so directive fields never shadow them. See
+  // `.ai-workspace/plans/2026-05-11-spec-gen-directive-mcp-content-surfacing.md`
+  // and AC-11 live smoke run record
+  // `monday-bot/.forge/runs/forge_evaluate-2026-05-11T09-34-10-439Z-bc5b.json`.
+  const contentPayload: Record<string, unknown> = {
+    ...report,
+    specGenWarnings,
+  };
+  if (storyEvalCallerAction !== undefined) {
+    contentPayload.callerAction = storyEvalCallerAction;
+  }
+  if (storyEvalSpecGenBrief !== undefined) {
+    contentPayload.specGenBrief = storyEvalSpecGenBrief;
+  }
+
   const response: McpResponse = {
-    content: [{ type: "text", text: JSON.stringify(report, null, 2) }],
+    content: [{ type: "text", text: JSON.stringify(contentPayload, null, 2) }],
     specGenWarnings,
   };
   if (storyEvalAdrCanonicalized !== undefined) {
@@ -721,7 +745,8 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
   }
   // v0.43.0 — surface the caller-action directive + brief on the response
   // envelope when the new path emitted them. Absent on the legacy path,
-  // non-PASS verdicts, and hand-author short-circuits.
+  // non-PASS verdicts, and hand-author short-circuits. Retained at v0.43.1
+  // as belt-and-suspenders alongside the content-payload surface above.
   if (storyEvalCallerAction !== undefined) {
     response.callerAction = storyEvalCallerAction;
   }


### PR DESCRIPTION
## ELI5

In v0.43.0 the MCP server learned to tell the calling agent "go run the spec-gen LLM call yourself" via a `callerAction` directive. But the server put that note on the *envelope* of the response (outer fields next to `content`), and standard MCP clients only show the agent what's inside `content[0].text`. So the note got hidden, the agent never saw it, and `TECHNICAL-SPEC.md` was never regenerated. AC-11 live smoke this morning proved it: server-side recorded `specGenMode: \"caller-action\"`, caller-side never acted. This patch merges the note INTO `content[0].text` as JSON-stringified data so `JSON.parse(result.content[0].text).callerAction` actually works. The old envelope copy stays as a backup for any envelope-aware client — same data, two places.

## AC verification matrix

| AC | Status | Evidence |
|----|--------|----------|
| AC-1 (PASS-path directive reachable via JSON.parse) | PASS | New test `v0.43.1 — directive surfacing inside content[0].text > AC-1` (`server/tools/evaluate.test.ts`); asserts `parsed.callerAction === "generate-spec-inline"`, `specGenBrief.runId` non-empty, `systemPrompt.length > 0`, eval-report keys unshadowed |
| AC-2 (envelope siblings preserved) | PASS | Existing v0.43.0 `AC-1: PASS path emits callerAction…` test continues to pass — outer `result.callerAction` + `result.specGenBrief` still populated |
| AC-3 (specGenWarnings in content) | PASS | New test AC-3; asserts `Array.isArray(parsed.specGenWarnings)` AND equals `result.specGenWarnings` envelope sibling |
| AC-4 (legacy path content omits directive) | PASS | New test AC-4 with `FORGE_SPEC_CALLER_ACTION=0`; asserts `"callerAction" in parsed === false` AND `"specGenBrief" in parsed === false` |
| AC-5 (hand-author short-circuit content shape) | PASS | New test AC-5; asserts content omits directive but `parsed.specGenWarnings` includes `kind === "spec-gen-short-circuited-hand-author"` |
| AC-6 (README JSON.parse code example) | PASS | `grep -c "JSON.parse" README.md` = **3** (≥1); §"Handling the directive" now leads with the JSON.parse access pattern |
| AC-7 (CHANGELOG v0.43.1 entry) | PASS | `grep -cE "content\[0\]\.text\|MCP-client-visible\|directive into a void\|surfacing" CHANGELOG.md` = **4** (≥3); cites AC-11 run record provenance |
| AC-8 (build + test green; no count regression) | PASS | `npm run build` exit 0; `npm test` exit 0; suite **1144 → 1148** (+4 net positive); lint clean |
| AC-9 | RETIRED | Behavioral AC-1/3/4/5 cover the access path; no separate verifier needed |
| AC-10 (live post-merge smoke) | DEFERRED | Operator-gated post-`/ship`; requires fresh Claude Code session for the MCP child to reload dist (F54 runtime variant) |

## Test counts

- Baseline (origin/master = `42016dd` v0.43.0): `Test Files 70 passed (70) | Tests 1144 passed (1144)`
- Post-fix (this branch tip): `Test Files 70 passed (70) | Tests 1148 passed (1148)`
- Delta: **+4** new tests (AC-1 / AC-3 / AC-4 / AC-5), zero regressions.

## Reversibility

- Content-merge is purely additive in the JSON payload. Clients that only read `parsed.verdict` or `parsed.criteria` are unaffected — spread order pins eval-report keys first so they cannot be shadowed.
- Envelope-sibling fields (`response.callerAction`, `response.specGenBrief`, `response.specGenWarnings`) unchanged from v0.43.0; envelope-aware clients keep working.
- `FORGE_SPEC_CALLER_ACTION=0` still opts back to v0.42.x legacy in-MCP synth (unchanged).
- If AC-10 BLOCK triggers post-merge: `git revert <v0.43.1 squash>` + ship v0.43.2 corrective patch.

## Plan path

`.ai-workspace/plans/2026-05-11-spec-gen-directive-mcp-content-surfacing.md`

## Test plan

- [x] `npm run build` — exit 0
- [x] `npm test` — exit 0, 1148 passed (baseline 1144 + 4 new)
- [x] `grep -c "JSON.parse" README.md` — 3 (≥1)
- [x] `grep -cE "content\[0\]\.text|MCP-client-visible|directive into a void|surfacing" CHANGELOG.md` — 4 (≥3)
- [x] `npm run lint` — clean
- [ ] AC-10 post-merge live smoke (operator-gated, fresh Claude Code session)

---
plan-refresh: no-op