### PR TITLE
fix(spec-generator): v0.43.2 I1 deferred follow-ups

### DIFF
--- a/server/lib/run-record.test.ts
+++ b/server/lib/run-record.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   writeRunRecord,
+  findAndMergeRunRecord,
   type RunRecord,
   GeneratedDocsSchema,
   SpecGeneratorWarningSchema,
@@ -264,5 +265,77 @@ describe("GeneratedDocsSchema (AC-10) — warnings is a typed array, default []"
     const parsed = GeneratedDocsSchema.parse(lenient);
     expect(parsed.warnings).toHaveLength(1);
     expect(parsed.warnings[0].kind).toBe("no-vocabulary");
+  });
+});
+
+// ── v0.43.2 (I1 fold) — findAndMergeRunRecord totalCostUsd sum-not-overwrite ─
+
+describe("findAndMergeRunRecord — totalCostUsd sum (v0.43.2 I1 fold)", () => {
+  async function writeFakeRunRecord(
+    projectPath: string,
+    runId: string,
+    body: Record<string, unknown>,
+  ): Promise<string> {
+    const runsDir = join(projectPath, ".forge", "runs");
+    await mkdir(runsDir, { recursive: true });
+    const filename = `forge_evaluate-2026-05-11T20-00-00-000Z-${runId}.json`;
+    const filePath = join(runsDir, filename);
+    await writeFile(filePath, JSON.stringify(body, null, 2), "utf-8");
+    return filePath;
+  }
+
+  it("sums totalCostUsd when both existing and patch are numeric (primary case)", async () => {
+    const runId = "abcd";
+    const shellAcCost = 0.0042;
+    const specGenCost = 0.013;
+    await writeFakeRunRecord(tempDir, runId, {
+      tool: "forge_evaluate",
+      totalCostUsd: shellAcCost,
+    });
+
+    const merged = await findAndMergeRunRecord(tempDir, runId, {
+      totalCostUsd: specGenCost,
+    });
+
+    expect(merged).not.toBeNull();
+    const raw = await readFile(merged as string, "utf-8");
+    const parsed = JSON.parse(raw) as { totalCostUsd: number };
+    expect(parsed.totalCostUsd).toBeCloseTo(shellAcCost + specGenCost, 10);
+  });
+
+  it("treats existing-undefined as 0 when summing (patch becomes the first leg)", async () => {
+    const runId = "bbbb";
+    const specGenCost = 0.007;
+    await writeFakeRunRecord(tempDir, runId, {
+      tool: "forge_evaluate",
+      // no totalCostUsd field present at all
+    });
+
+    const merged = await findAndMergeRunRecord(tempDir, runId, {
+      totalCostUsd: specGenCost,
+    });
+
+    expect(merged).not.toBeNull();
+    const raw = await readFile(merged as string, "utf-8");
+    const parsed = JSON.parse(raw) as { totalCostUsd: number };
+    expect(parsed.totalCostUsd).toBeCloseTo(specGenCost, 10);
+  });
+
+  it("is a no-op when patch.totalCostUsd is null (does NOT reset existing value)", async () => {
+    const runId = "cccc";
+    const existing = 0.0099;
+    await writeFakeRunRecord(tempDir, runId, {
+      tool: "forge_evaluate",
+      totalCostUsd: existing,
+    });
+
+    const merged = await findAndMergeRunRecord(tempDir, runId, {
+      totalCostUsd: null,
+    });
+
+    expect(merged).not.toBeNull();
+    const raw = await readFile(merged as string, "utf-8");
+    const parsed = JSON.parse(raw) as { totalCostUsd: number };
+    expect(parsed.totalCostUsd).toBeCloseTo(existing, 10);
   });
 });

--- a/server/lib/run-record.ts
+++ b/server/lib/run-record.ts
@@ -550,8 +550,23 @@ export async function findAndMergeRunRecord(
     if (patch.generatedDocs !== undefined) {
       parsed.generatedDocs = patch.generatedDocs;
     }
-    if (patch.totalCostUsd !== undefined) {
-      parsed.totalCostUsd = patch.totalCostUsd;
+    // v0.43.2 (I1 fold) — sum-not-overwrite for totalCostUsd. The brief-emit
+    // event in forge_evaluate records a shell-AC cost (the eval LLM call); a
+    // subsequent forge_apply_spec_gen patch should ADD the spec-gen leg, not
+    // clobber the shell-AC portion. Explicit null and undefined patches are
+    // no-ops — reset is intentionally NOT a supported operation (forge today
+    // never emits null; making reset a no-op closes a future-bug hatch where
+    // a regression in the producer would silently zero the rollup).
+    //
+    // Concurrency: the read-modify-write here is NOT atomic — no file lock.
+    // Today's MCP caller is single-threaded per runId (forge_evaluate is the
+    // sole producer of brief-emit events; the directive round-trip has one
+    // consumer), so concurrent applies on the same runId cannot happen. If a
+    // future parallel-spec-gen feature breaks that assumption, this seam
+    // needs a file lock or transactional rewrite.
+    if (typeof patch.totalCostUsd === "number") {
+      const existing = typeof parsed.totalCostUsd === "number" ? parsed.totalCostUsd : 0;
+      parsed.totalCostUsd = existing + patch.totalCostUsd;
     }
     await writeFile(filePath, JSON.stringify(parsed, null, 2), "utf-8");
     return filePath;

--- a/server/tools/apply-spec-gen.test.ts
+++ b/server/tools/apply-spec-gen.test.ts
@@ -35,6 +35,22 @@ function readSpec(tmp: string): string {
 }
 
 /**
+ * v0.43.2 (I1 fold) — seed a fake brief-emit run record under .forge/runs/
+ * so handleApplySpecGen's pre-validation probe finds it. Without this, the
+ * pre-validation returns isError before any merge work happens.
+ */
+function seedRunRecord(tmp: string, runId: string): void {
+  const runsDir = join(tmp, ".forge", "runs");
+  mkdirSync(runsDir, { recursive: true });
+  const filename = `forge_evaluate-2026-05-11T20-00-00-000Z-${runId}.json`;
+  writeFileSync(
+    join(runsDir, filename),
+    JSON.stringify({ tool: "forge_evaluate", runId }, null, 2),
+    "utf-8",
+  );
+}
+
+/**
  * Seed a TECHNICAL-SPEC.md with one story section. Used by AC-5 and AC-6
  * to verify the preserve-invariant + hand-author race-window guard.
  */
@@ -152,6 +168,7 @@ describe("forge_apply_spec_gen — AC-5 v0.42.0 preserve-invariant", () => {
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), "forge-apply-spec-gen-"));
     seedTechSpec(tmp, {});
+    seedRunRecord(tmp, "abcd");
   });
   afterEach(() => {
     rmSync(tmp, { recursive: true, force: true });
@@ -216,6 +233,10 @@ describe("forge_apply_spec_gen — AC-6 hand-author race-window guard", () => {
     // sub-sections are NOT hand-authored — the caller's content for those
     // should overwrite while api-contracts stays preserved.
     seedTechSpec(tmp, { handAuthored: true });
+    // v0.43.2 (I1 fold) — seed brief-emit run record so pre-validation passes.
+    // The AC-14 sub-test re-creates tmp from scratch and generates its own
+    // runId via handleEvaluate, so it doesn't depend on this seed.
+    seedRunRecord(tmp, "abcd");
   });
   afterEach(() => {
     rmSync(tmp, { recursive: true, force: true });
@@ -344,5 +365,79 @@ describe("forge_apply_spec_gen — AC-6 hand-author race-window guard", () => {
     expect(afterBody).toContain("caller-generated test bullet, SHOULD land");
     // The body changed (despite api-contracts being preserved verbatim) because
     // the other three sub-sections changed.
+  });
+});
+
+// ── v0.43.2 (I1 fold) — runId pre-validation (nonexistent runId case) ───
+
+describe("forge_apply_spec_gen — v0.43.2 runId pre-validation (I1 fold)", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "forge-apply-spec-gen-v0432-"));
+    seedTechSpec(tmp, {});
+    // INTENTIONALLY DO NOT seed a brief-emit run record — the pre-validation
+    // probe should fail before any spec mutation happens.
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("syntactically-valid but nonexistent runId returns isError + leaves spec bytes unchanged", async () => {
+    const before = readSpec(tmp);
+    const beforeSha = sha256(before);
+
+    const result = await handleApplySpecGen({
+      runId: "dead", // 4-char hex, Zod-valid, but no brief-emit record exists
+      storyId: "US-01",
+      projectPath: tmp,
+      sections: {
+        "api-contracts": "- `newApi`: caller content that should NOT land",
+        "data-models": "- `NewShape`: caller content that should NOT land",
+        invariants: "- caller invariant that should NOT land",
+        "test-surface": "- caller test that should NOT land",
+      },
+      contracts: [],
+      tokens: { inputTokens: 100, outputTokens: 50 },
+    });
+
+    // Pre-validation fired: isError set, error text mentions the missing record.
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "no brief-emit run record found for runId=dead",
+    );
+
+    // Spec file bytes unchanged — the spec mutation never happened.
+    const after = readSpec(tmp);
+    expect(sha256(after)).toBe(beforeSha);
+  });
+
+  it(".forge/runs/ directory entirely missing → same isError path", async () => {
+    // Re-create tmp without the .forge/runs/ dir at all.
+    rmSync(tmp, { recursive: true, force: true });
+    tmp = mkdtempSync(join(tmpdir(), "forge-apply-spec-gen-v0432-noruns-"));
+    seedTechSpec(tmp, {});
+    // Deliberately do NOT create .forge/runs/.
+
+    const before = readSpec(tmp);
+    const beforeSha = sha256(before);
+
+    const result = await handleApplySpecGen({
+      runId: "abcd",
+      storyId: "US-01",
+      projectPath: tmp,
+      sections: {
+        "api-contracts": "(none)",
+        "data-models": "(none)",
+        invariants: "(none)",
+        "test-surface": "(none)",
+      },
+      contracts: [],
+      tokens: { inputTokens: 0, outputTokens: 0 },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("no brief-emit run record found for runId=abcd");
+    const after = readSpec(tmp);
+    expect(sha256(after)).toBe(beforeSha);
   });
 });

--- a/server/tools/apply-spec-gen.ts
+++ b/server/tools/apply-spec-gen.ts
@@ -22,6 +22,8 @@
  */
 
 import { z } from "zod";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
 import type { EvalReport } from "../types/eval-report.js";
 import {
   applySpecGenResult,
@@ -92,7 +94,7 @@ export const applySpecGenInputSchema = {
     .unknown()
     .optional()
     .describe(
-      "Optional: the eval report from the original brief. Currently observational; not used by the merge logic itself but threaded through for parity with the legacy in-MCP shape.",
+      "Optional: the eval report from the original brief. Accepted for schema compatibility with the legacy in-MCP shape; currently no-op in the apply path (the field is not persisted to the run record). May be threaded into the brief-emit echo in a future revision.",
     ),
   gitSha: z
     .string()
@@ -132,6 +134,33 @@ type McpResponse = {
 export async function handleApplySpecGen(
   input: ApplySpecGenInput,
 ): Promise<McpResponse> {
+  // v0.43.2 (I1 fold) — pre-validate runId before any disk mutation. The Zod
+  // schema only checks shape (4-char lowercase hex); it cannot verify the
+  // runId corresponds to a real brief-emit record. Without this probe, a
+  // syntactically-valid but nonexistent runId would still trigger the spec
+  // file write, with only a log-and-continue warning when findAndMergeRunRecord
+  // (line ~210 below) fails to locate the record. Closing the disk-mutates-
+  // without-observability gap is the v0.43.2 correctness win.
+  const runsDir = join(input.projectPath, ".forge", "runs");
+  let runRecordExists = false;
+  try {
+    const entries = await readdir(runsDir);
+    runRecordExists = entries.some((e) => e.endsWith(`-${input.runId}.json`));
+  } catch {
+    runRecordExists = false;
+  }
+  if (!runRecordExists) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `forge_apply_spec_gen error: no brief-emit run record found for runId=${input.runId} under ${input.projectPath}/.forge/runs/. The runId must be echoed verbatim from a prior forge_evaluate call that emitted a generate-spec-inline directive.`,
+        },
+      ],
+      isError: true,
+    };
+  }
+
   // Reuse the lib-layer merge logic. `applySpecGenResult` is the canonical
   // single locus for: (a) AC-6 race-window hand-author preserve, (b) v0.42.0
   // empty-sections no-overwrite invariant, (c) vocabulary-grounded post-validator.


### PR DESCRIPTION
## Summary

Closes the three I1-reviewer follow-ups deferred from the v0.43.0 ship:

1. **`totalCostUsd` sum-not-overwrite** in `findAndMergeRunRecord` — the brief-emit event records the shell-AC cost; a subsequent `forge_apply_spec_gen` patch now ADDS the spec-gen leg instead of clobbering it. Explicit-null and undefined patches are no-ops (reset is intentionally NOT supported).
2. **`runId` pre-validation** in `handleApplySpecGen` — added a probe of `.forge/runs/` BEFORE any disk mutation. A syntactically-valid but nonexistent runId now returns isError without touching `TECHNICAL-SPEC.md`. The existing post-merge log-and-continue path is preserved for the race window between probe and merge.
3. **`evalReport` Zod docstring** — replaced stale "threaded through for parity with the legacy in-MCP shape" with an accurate description (accepted for schema compatibility; currently no-op in the apply path).

## Test plan

- [x] **AC-1..AC-6** — grep verifiers on source/test files all pass (AC-1: overwrite pattern gone; AC-2: sum pattern present; AC-3: 3 sum tests; AC-4a/b: pre-validation + post-merge messages both present; AC-5: 5 hits for nonexistent-runId test indicators; AC-6: stale phrase removed).
- [x] **AC-7** — 1153/1153 tests passing (1148 baseline + 5 new: 3 sum sub-cases + 2 pre-validation cases).
- [x] **AC-8** — `npm run build` clean (no TS errors).
- [x] **AC-9** — commit message references `totalCostUsd`/`runId`/`v0.43.2`/`I1`.
- [ ] **AC-10** (post-ship, operator-gated) — re-run the v0.43.1 AC-10 dogfood and verify the final run record's `totalCostUsd` is the SUM of shell-AC + spec-gen legs.

## Review trail

- Plan-chain P1 stateless: PASS-WITH-FOLLOW-UP, GREAT. Amendments folded into plan v2 (null no-op semantic clarified; AC greps tightened; AC-6 baseline pinned).
- Per-task post-code reviewer: PASS, GREAT, 11 cross-checks PASS, zero fix-ups. Sum logic traced through 4 sub-cases; pre-validation block placement verified; `seedRunRecord` helper consistent with `findAndMergeRunRecord` glob shape.

Plan: `.ai-workspace/plans/2026-05-11-v0432-i1-deferred-followups.md` (v2 post-fold).

---
plan-refresh: baseline