### PR TITLE
feat(spec-generator): v0.44.0 vocabulary scanner follows relative-import chains

### DIFF
--- a/server/lib/__fixtures__/spec-vocabulary/imports-1hop/a.ts
+++ b/server/lib/__fixtures__/spec-vocabulary/imports-1hop/a.ts
@@ -1,0 +1,7 @@
+import { Foo } from "./b.js";
+
+export class A {
+  public useFoo(): Foo {
+    return new Foo();
+  }
+}

--- a/server/lib/__fixtures__/spec-vocabulary/imports-1hop/b.ts
+++ b/server/lib/__fixtures__/spec-vocabulary/imports-1hop/b.ts
@@ -1,0 +1,10 @@
+export class Foo {
+  public hello(): string {
+    return "world";
+  }
+}
+
+export interface BShape {
+  id: number;
+  name: string;
+}

--- a/server/lib/__fixtures__/spec-vocabulary/imports-2hop/a.ts
+++ b/server/lib/__fixtures__/spec-vocabulary/imports-2hop/a.ts
@@ -1,0 +1,7 @@
+import { Bee } from "./b.js";
+
+export class Alpha {
+  public useBee(): Bee {
+    return new Bee();
+  }
+}

--- a/server/lib/__fixtures__/spec-vocabulary/imports-2hop/b.ts
+++ b/server/lib/__fixtures__/spec-vocabulary/imports-2hop/b.ts
@@ -1,0 +1,7 @@
+import { CeeShape } from "./c.js";
+
+export class Bee {
+  public makeC(): CeeShape {
+    return { id: 1, name: "x" };
+  }
+}

--- a/server/lib/__fixtures__/spec-vocabulary/imports-2hop/c.ts
+++ b/server/lib/__fixtures__/spec-vocabulary/imports-2hop/c.ts
@@ -1,0 +1,10 @@
+export interface CeeShape {
+  id: number;
+  name: string;
+}
+
+export class CeeHelper {
+  public build(): CeeShape {
+    return { id: 0, name: "" };
+  }
+}

--- a/server/lib/__fixtures__/spec-vocabulary/imports-cycle/a.ts
+++ b/server/lib/__fixtures__/spec-vocabulary/imports-cycle/a.ts
@@ -1,0 +1,5 @@
+import type { Bravo } from "./b.js";
+
+export class Alpha {
+  public mate?: Bravo;
+}

--- a/server/lib/__fixtures__/spec-vocabulary/imports-cycle/b.ts
+++ b/server/lib/__fixtures__/spec-vocabulary/imports-cycle/b.ts
@@ -1,0 +1,5 @@
+import type { Alpha } from "./a.js";
+
+export class Bravo {
+  public mate?: Alpha;
+}

--- a/server/lib/__fixtures__/spec-vocabulary/imports-depth-disabled/a.ts
+++ b/server/lib/__fixtures__/spec-vocabulary/imports-depth-disabled/a.ts
@@ -1,0 +1,7 @@
+import { OnlySeenWhenFollowed } from "./b.js";
+
+export class Root {
+  public ref(): OnlySeenWhenFollowed {
+    return new OnlySeenWhenFollowed();
+  }
+}

--- a/server/lib/__fixtures__/spec-vocabulary/imports-depth-disabled/b.ts
+++ b/server/lib/__fixtures__/spec-vocabulary/imports-depth-disabled/b.ts
@@ -1,0 +1,5 @@
+export class OnlySeenWhenFollowed {
+  public greet(): string {
+    return "hello";
+  }
+}

--- a/server/lib/__fixtures__/spec-vocabulary/imports-unresolvable/a.ts
+++ b/server/lib/__fixtures__/spec-vocabulary/imports-unresolvable/a.ts
@@ -1,0 +1,9 @@
+// Imports a sibling that does NOT exist on disk. The vocabulary harvester
+// should surface a warning and continue, NOT throw.
+import { Phantom } from "./does-not-exist.js";
+
+export class Solid {
+  public usePhantom(): Phantom {
+    return new Phantom();
+  }
+}

--- a/server/lib/spec-source-vocabulary.test.ts
+++ b/server/lib/spec-source-vocabulary.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { resolve } from "node:path";
 import {
   buildSourceVocabulary,
@@ -154,5 +154,79 @@ describe("vocabularyContains — predicate semantics", () => {
     expect(vocabularyContains(vocab, "Baz.id")).toBe(true);
     expect(vocabularyContains(vocab, "Bogus")).toBe(false);
     expect(vocabularyContains(vocab, "Foo.bogus")).toBe(false);
+  });
+});
+
+// ── v0.44.0 — relative-import-following BFS (AC-7..AC-12) ────────────────
+
+describe("spec-source-vocabulary — v0.44.0 follows imports (AC-7)", () => {
+  const ORIG_DEPTH = process.env.FORGE_VOCAB_IMPORT_DEPTH;
+  afterEach(() => {
+    if (ORIG_DEPTH === undefined) delete process.env.FORGE_VOCAB_IMPORT_DEPTH;
+    else process.env.FORGE_VOCAB_IMPORT_DEPTH = ORIG_DEPTH;
+  });
+
+  it("AC-7: import from sibling file pulls the sibling's exports into vocabulary (1 hop)", () => {
+    delete process.env.FORGE_VOCAB_IMPORT_DEPTH; // default = 2
+    const vocab = buildSourceVocabulary(PROJECT_ROOT, [`${FIXTURE_REL}/imports-1hop/a.ts`]);
+    // a.ts's own exports.
+    expect(vocab.identifiers.has("A")).toBe(true);
+    // b.ts's exports (reached via `import { Foo } from "./b.js"` in a.ts).
+    expect(vocab.identifiers.has("Foo")).toBe(true);
+    expect(vocab.identifiers.has("BShape")).toBe(true);
+    expect(vocab.methods.has("Foo.hello")).toBe(true);
+    expect(vocab.fields.has("BShape.id")).toBe(true);
+  });
+
+  it("AC-8: cycle import a↔b does NOT infinite-loop and produces no cycle warning", () => {
+    delete process.env.FORGE_VOCAB_IMPORT_DEPTH;
+    const vocab = buildSourceVocabulary(PROJECT_ROOT, [`${FIXTURE_REL}/imports-cycle/a.ts`]);
+    expect(vocab.identifiers.has("Alpha")).toBe(true);
+    expect(vocab.identifiers.has("Bravo")).toBe(true);
+    // Visited-set prevents re-enqueue; no warning text should mention "cycle".
+    for (const w of vocab.warnings) {
+      expect(w.toLowerCase()).not.toContain("cycle");
+    }
+  });
+
+  it("AC-9: FORGE_VOCAB_IMPORT_DEPTH=1 follows 1 hop but NOT a 2-hop transitive import", () => {
+    process.env.FORGE_VOCAB_IMPORT_DEPTH = "1";
+    const vocab = buildSourceVocabulary(PROJECT_ROOT, [`${FIXTURE_REL}/imports-2hop/a.ts`]);
+    expect(vocab.identifiers.has("Alpha")).toBe(true); // seed
+    expect(vocab.identifiers.has("Bee")).toBe(true);    // 1 hop
+    // 2-hop file should NOT be harvested under depth=1.
+    expect(vocab.identifiers.has("CeeShape")).toBe(false);
+    expect(vocab.identifiers.has("CeeHelper")).toBe(false);
+  });
+
+  it("AC-9b: default depth (2) DOES follow the 2-hop transitive import", () => {
+    delete process.env.FORGE_VOCAB_IMPORT_DEPTH;
+    const vocab = buildSourceVocabulary(PROJECT_ROOT, [`${FIXTURE_REL}/imports-2hop/a.ts`]);
+    expect(vocab.identifiers.has("Alpha")).toBe(true);
+    expect(vocab.identifiers.has("Bee")).toBe(true);
+    expect(vocab.identifiers.has("CeeShape")).toBe(true);
+    expect(vocab.identifiers.has("CeeHelper")).toBe(true);
+  });
+
+  it("AC-10: FORGE_VOCAB_IMPORT_DEPTH=0 disables following (v0.43.x back-compat)", () => {
+    process.env.FORGE_VOCAB_IMPORT_DEPTH = "0";
+    const vocab = buildSourceVocabulary(PROJECT_ROOT, [
+      `${FIXTURE_REL}/imports-depth-disabled/a.ts`,
+    ]);
+    expect(vocab.identifiers.has("Root")).toBe(true); // seed harvested
+    // Imported sibling NOT harvested when depth=0.
+    expect(vocab.identifiers.has("OnlySeenWhenFollowed")).toBe(false);
+  });
+
+  it("AC-12: unresolvable relative import surfaces a warning with specifier + source", () => {
+    delete process.env.FORGE_VOCAB_IMPORT_DEPTH;
+    const vocab = buildSourceVocabulary(PROJECT_ROOT, [
+      `${FIXTURE_REL}/imports-unresolvable/a.ts`,
+    ]);
+    expect(vocab.identifiers.has("Solid")).toBe(true);
+    const hasWarning = vocab.warnings.some(
+      (w) => w.includes("does-not-exist") && w.includes("imports-unresolvable") && w.includes("a.ts"),
+    );
+    expect(hasWarning).toBe(true);
   });
 });

--- a/server/lib/spec-source-vocabulary.ts
+++ b/server/lib/spec-source-vocabulary.ts
@@ -17,7 +17,7 @@
 
 import * as ts from "typescript";
 import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
-import { join, resolve, extname, basename } from "node:path";
+import { join, resolve, extname, basename, dirname, relative, sep } from "node:path";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -37,6 +37,31 @@ export interface SourceVocabulary {
 }
 
 const SOURCE_EXTS = new Set([".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"]);
+
+/**
+ * v0.44.0 — extension probe order for relative-import resolution.
+ *
+ * Prefers TS source over compiled JS. `index.*` variants are appended when a
+ * direct file resolution fails (handles `import "./foo"` where `foo` is a
+ * directory containing `index.ts`).
+ */
+const IMPORT_RESOLVE_EXTS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"];
+
+/**
+ * v0.44.0 — read FORGE_VOCAB_IMPORT_DEPTH at call time so a process can flip
+ * the var between calls (tests rely on this). Default `2` covers the common
+ * case of importing from siblings + their siblings. Range `0..5` clamped:
+ * `0` = no following (v0.43.x back-compat); `5` is the maximum to bound
+ * unbounded harvest in deep-graph projects.
+ */
+function readImportDepth(): number {
+  const raw = process.env.FORGE_VOCAB_IMPORT_DEPTH;
+  if (raw === undefined || raw === "") return 2;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed < 0) return 2;
+  if (parsed > 5) return 5;
+  return parsed;
+}
 
 // ── File walker ──────────────────────────────────────────────────────────
 
@@ -304,6 +329,176 @@ function harvestTestNames(sf: ts.SourceFile, vocab: SourceVocabulary): void {
   ts.forEachChild(sf, visit);
 }
 
+// ── v0.44.0 — relative-import resolver + BFS follower ────────────────────
+
+/**
+ * v0.44.0 — resolve a relative import specifier to an absolute file path.
+ *
+ * Returns the first existing candidate from `IMPORT_RESOLVE_EXTS`, then the
+ * `${path}/index.*` variants. Returns `null` if no candidate exists or the
+ * specifier is not relative (bare imports, TS path aliases, absolute paths).
+ *
+ * Bare imports (no leading `./` or `../`) are NOT resolved. TS `paths` /
+ * `baseUrl` aliasing is intentionally out-of-scope for v0.44.0.
+ */
+function resolveRelativeImport(
+  fromFile: string,
+  specifier: string,
+): string | null {
+  if (!specifier.startsWith("./") && !specifier.startsWith("../")) return null;
+  const base = resolve(dirname(fromFile), specifier);
+  const baseNoTrail = base.endsWith(sep) ? base.slice(0, -1) : base;
+
+  const tryPath = (p: string): string | null => {
+    if (!existsSync(p)) return null;
+    try {
+      return statSync(p).isFile() ? p : null;
+    } catch {
+      return null;
+    }
+  };
+
+  // TS NodeNext convention: `import "./b.js"` resolves to `b.ts` (TS source)
+  // OR `b.js` (compiled JS). Strip a trailing source extension and probe the
+  // TS variants first, then fall through to original-extension and bare-name
+  // probes so JS-first projects also resolve.
+  const existingExt = extname(baseNoTrail);
+  if (existingExt && SOURCE_EXTS.has(existingExt)) {
+    const stem = baseNoTrail.slice(0, -existingExt.length);
+    // Swap the imported extension's TS sibling first, then full probe order.
+    const jsToTsSwap: Record<string, string> = {
+      ".js": ".ts",
+      ".jsx": ".tsx",
+      ".mjs": ".mts",
+      ".cjs": ".cts",
+    };
+    const swap = jsToTsSwap[existingExt];
+    if (swap) {
+      const r = tryPath(stem + swap);
+      if (r) return r;
+    }
+    // Full extension probe on the stem (TS first, JS last).
+    for (const ext of IMPORT_RESOLVE_EXTS) {
+      const r = tryPath(stem + ext);
+      if (r) return r;
+    }
+    // Direct hit on the literal specifier (e.g. someone really did import a .js).
+    const direct = tryPath(baseNoTrail);
+    if (direct) return direct;
+  } else {
+    // No extension on the specifier — append each candidate.
+    for (const ext of IMPORT_RESOLVE_EXTS) {
+      const r = tryPath(baseNoTrail + ext);
+      if (r) return r;
+    }
+  }
+
+  // Directory + `index.*` probes (specifier resolves to a directory).
+  for (const ext of IMPORT_RESOLVE_EXTS) {
+    const r = tryPath(join(baseNoTrail, `index${ext}`));
+    if (r) return r;
+  }
+  return null;
+}
+
+/**
+ * v0.44.0 — collect import specifiers from a parsed source file.
+ *
+ * Walks the top-level `ts.ImportDeclaration` nodes and returns the string
+ * literal text of each `moduleSpecifier`. Includes `import type` declarations
+ * (the target file's exports still grant grounding — the type-only flag is
+ * a compile-time hint, not a semantic difference for vocabulary harvest).
+ * Dynamic `import("...")` expressions are NOT collected (they're CallExpression
+ * nodes, not ImportDeclaration).
+ */
+function collectImportSpecifiers(sf: ts.SourceFile): string[] {
+  const out: string[] = [];
+  ts.forEachChild(sf, (node) => {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      out.push(node.moduleSpecifier.text);
+    }
+  });
+  return out;
+}
+
+/**
+ * v0.44.0 — BFS over the import graph rooted at `seedFiles`.
+ *
+ * Returns the full set of files to harvest (absolute paths), including the
+ * seeds plus everything reachable within `maxDepth` hops via relative imports.
+ * Cycle-safe (visited set); skips test files (they're collected separately).
+ * Bare imports + unresolvable relative imports surface as warnings.
+ *
+ * Operates ONLY on source files. Test files are intentionally excluded from
+ * the BFS so test-name identifiers from followed modules cannot leak into
+ * the production-grounding vocabulary.
+ */
+function followImports(
+  projectPath: string,
+  seedFiles: string[],
+  maxDepth: number,
+  warnings: string[],
+): string[] {
+  if (maxDepth <= 0) return [...seedFiles];
+
+  const visited = new Set<string>(seedFiles);
+  type QueueItem = { file: string; depth: number };
+  const queue: QueueItem[] = seedFiles.map((f) => ({ file: f, depth: 0 }));
+  const out: string[] = [...seedFiles];
+
+  while (queue.length > 0) {
+    const { file, depth } = queue.shift()!;
+    if (depth >= maxDepth) continue;
+    let content: string;
+    try {
+      content = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    const ext = extname(file);
+    const isJs = ext === ".js" || ext === ".jsx" || ext === ".mjs" || ext === ".cjs";
+    const sf = ts.createSourceFile(
+      file,
+      content,
+      ts.ScriptTarget.ES2022,
+      /*setParentNodes*/ true,
+      isJs ? ts.ScriptKind.JS : (ext === ".tsx" || ext === ".jsx" ? ts.ScriptKind.TSX : ts.ScriptKind.TS),
+    );
+    const specifiers = collectImportSpecifiers(sf);
+    for (const spec of specifiers) {
+      if (!spec.startsWith("./") && !spec.startsWith("../")) {
+        // Bare imports (npm packages) and TS path aliases are out-of-scope.
+        // Don't warn on every bare import — too noisy; only flag aliased ones
+        // (starting with `@` but not the well-known `@types/` patterns).
+        continue;
+      }
+      const resolved = resolveRelativeImport(file, spec);
+      if (resolved === null) {
+        warnings.push(`unresolvable import "${spec}" from ${relative(projectPath, file)}`);
+        continue;
+      }
+      // Project-internal gate: must be inside projectPath AND not under
+      // node_modules / .git / dist / build. Path-prefix check is sufficient
+      // since `resolve()` already canonicalized everything.
+      const rel = relative(projectPath, resolved);
+      if (rel.startsWith("..") || rel.includes(`${sep}node_modules${sep}`) || rel.startsWith(`node_modules${sep}`)) {
+        continue;
+      }
+      // Test-file gate: do NOT enqueue tests. Their identifiers are harvested
+      // via the dedicated `collectTestFiles` path in `buildSourceVocabulary`,
+      // which scopes test-name harvest to the affectedPaths roots only.
+      if (basename(resolved).match(/\.(test|spec)\.[mc]?[jt]sx?$/)) {
+        continue;
+      }
+      if (visited.has(resolved)) continue;
+      visited.add(resolved);
+      out.push(resolved);
+      queue.push({ file: resolved, depth: depth + 1 });
+    }
+  }
+  return out;
+}
+
 // ── Public entry ─────────────────────────────────────────────────────────
 
 /**
@@ -333,7 +528,13 @@ export function buildSourceVocabulary(
     return vocab;
   }
 
-  const sourceFiles = resolveAffectedFiles(projectPath, affectedPaths, vocab.warnings);
+  const seedSourceFiles = resolveAffectedFiles(projectPath, affectedPaths, vocab.warnings);
+  // v0.44.0 — follow relative-import chains rooted at the seed source files.
+  // `FORGE_VOCAB_IMPORT_DEPTH=0` reverts to v0.43.x behavior (no following).
+  // Default depth=2 covers the common case of importing from siblings + their
+  // siblings (e.g. `src/index.ts → src/slack/adapter.ts → src/slack/queryHandler.ts`).
+  const maxImportDepth = readImportDepth();
+  const sourceFiles = followImports(projectPath, seedSourceFiles, maxImportDepth, vocab.warnings);
   const testFiles = collectTestFiles(projectPath, affectedPaths);
   const allFiles = [...sourceFiles, ...testFiles];
 


### PR DESCRIPTION
## Summary

The vocabulary post-validator (`server/lib/spec-source-vocabulary.ts`) now follows relative-import chains rooted at the story's `affectedPaths` files. Previously, only the affectedPaths files themselves were harvested, so any cross-module symbol imported into them got stripped from the LLM's regenerated TECHNICAL-SPEC content. v0.43.1 AC-10 dogfood observed 25 such stripped identifiers (`SlackAdapter`, `KnowledgeService`, `AppEnv.slackBotToken`, etc.).

Closes Task #59.

## Behavior

- New env var `FORGE_VOCAB_IMPORT_DEPTH` controls follow depth.
  - Default: `2` (covers the common siblings-of-siblings case).
  - Range: `0..5` (clamped). `0` reverts to v0.43.x behavior — back-compat escape hatch.
- TS NodeNext-aware resolution: `import "./b.js"` correctly resolves to `b.ts` when the TS source exists; falls through to `b.js`, `b.jsx`, ..., `${path}/index.ts`, etc.
- Cycle-safe via visited set.
- Project-internal only: skips `node_modules`, bare/aliased imports.
- Test files NEVER followed via imports (prevents test-name leakage).
- Unresolvable relative imports → warning, never throw.

## Test plan

- [x] **AC-1..AC-6** — grep verifiers + build + commit-message keywords all pass.
- [x] **AC-7** (1-hop): import from sibling pulls the sibling's exports into vocab.
- [x] **AC-8** (cycle): a↔b cycle does not infinite-loop.
- [x] **AC-9** (depth=1): 1 hop followed, 2-hop transitive NOT followed.
- [x] **AC-9b** (default depth=2): 2-hop transitive DOES get followed.
- [x] **AC-10** (depth=0 back-compat): disables following entirely.
- [x] **AC-12** (unresolvable warning): warning text contains both specifier and source file path.
- [x] **Full suite**: 1153 → 1159 (+6); no regressions.
- [ ] **AC-11** (post-ship dogfood, operator-gated): re-run v0.43.1 AC-10 dogfood, verify the previously-stripped 25 cross-module identifiers now appear in the regenerated TECHNICAL-SPEC.

## Out of scope (deliberate)

- TS `paths` / `baseUrl` alias resolution. Both forge-harness and monday-bot use `moduleResolution: "NodeNext"` with no aliases. Trigger condition for v0.44.1: a real-world story hits an aliased import that fails AC-7 behavioral test.
- Re-export following (`export * from "./foo"`).
- Cross-package (npm) resolution.

## Review trail

Plan-chain P1 stateless reviewer: PASS-WITH-FOLLOW-UP, GREAT, PROCEED-AS-IS. AC-12 (unresolvable-import warning surface) + AC count clarification folded into plan v2.

Plan: `.ai-workspace/plans/2026-05-11-v0440-vocab-follow-imports.md`.

---
plan-refresh: baseline