### PR TITLE
feat(spec-gen): tokensEstimated field on applySpecGenInputSchema

### DIFF
--- a/server/lib/run-record.ts
+++ b/server/lib/run-record.ts
@@ -118,11 +118,11 @@ export interface RunRecord {
      */
     specGenMode?: "in-mcp" | "caller-action" | "short-circuited-hand-author";
     /**
-     * v0.44.1 — when true, `genTokens` was computed via a byte/4 estimate
+     * v0.45.0 — when true, `genTokens` was computed via a byte/4 estimate
      * rather than measured from an LLM-usage response. Set by the caller-action
      * path when the caller (e.g. /forge-execute v1.1.0 in a Claude Code session)
      * cannot observe its own LLM token usage. Additive-optional per P50; pre-
-     * v0.44.1 records lack the field. Consumers should treat absence as "false"
+     * v0.45.0 records lack the field. Consumers should treat absence as "false"
      * (measured tokens). Cost rollups derived via `computeSpecGenCostUsd` are
      * unaffected mathematically — the flag is a confidence-signal for audit.
      */
@@ -372,7 +372,7 @@ export const GeneratedDocsSchema = z.object({
   specGenMode: z
     .enum(["in-mcp", "caller-action", "short-circuited-hand-author"])
     .optional(),
-  // v0.44.1 — additive optional confidence flag. When true, genTokens is a
+  // v0.45.0 — additive optional confidence flag. When true, genTokens is a
   // byte/4 estimate from a caller that cannot observe its own LLM usage
   // (e.g. /forge-execute v1.1.0 spec-inline path). Cost math is unchanged.
   tokensEstimated: z.boolean().optional(),

--- a/server/lib/run-record.ts
+++ b/server/lib/run-record.ts
@@ -117,6 +117,16 @@ export interface RunRecord {
      *      time. No directive emitted, no LLM call, no overwrite.
      */
     specGenMode?: "in-mcp" | "caller-action" | "short-circuited-hand-author";
+    /**
+     * v0.44.1 — when true, `genTokens` was computed via a byte/4 estimate
+     * rather than measured from an LLM-usage response. Set by the caller-action
+     * path when the caller (e.g. /forge-execute v1.1.0 in a Claude Code session)
+     * cannot observe its own LLM token usage. Additive-optional per P50; pre-
+     * v0.44.1 records lack the field. Consumers should treat absence as "false"
+     * (measured tokens). Cost rollups derived via `computeSpecGenCostUsd` are
+     * unaffected mathematically — the flag is a confidence-signal for audit.
+     */
+    tokensEstimated?: boolean;
   };
   metrics: {
     inputTokens: number;
@@ -362,6 +372,10 @@ export const GeneratedDocsSchema = z.object({
   specGenMode: z
     .enum(["in-mcp", "caller-action", "short-circuited-hand-author"])
     .optional(),
+  // v0.44.1 — additive optional confidence flag. When true, genTokens is a
+  // byte/4 estimate from a caller that cannot observe its own LLM usage
+  // (e.g. /forge-execute v1.1.0 spec-inline path). Cost math is unchanged.
+  tokensEstimated: z.boolean().optional(),
 });
 
 /**

--- a/server/tools/apply-spec-gen.test.ts
+++ b/server/tools/apply-spec-gen.test.ts
@@ -159,6 +159,29 @@ describe("forge_apply_spec_gen — Zod input validation (AC-5)", () => {
     const result = schema.safeParse(wellFormed);
     expect(result.success).toBe(true);
   });
+
+  it("accepts an optional tokensEstimated: true field (v0.44.1)", () => {
+    const schema = z.object(applySpecGenInputSchema);
+    const withEstimate = {
+      runId: "a1b2",
+      storyId: "US-01",
+      projectPath: "/tmp/x",
+      sections: {
+        "api-contracts": "(none)",
+        "data-models": "(none)",
+        invariants: "(none)",
+        "test-surface": "(none)",
+      },
+      contracts: [],
+      tokens: { inputTokens: 100, outputTokens: 50 },
+      tokensEstimated: true,
+    };
+    const result = schema.safeParse(withEstimate);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.tokensEstimated).toBe(true);
+    }
+  });
 });
 
 // ── AC-5: preserve-invariant (empty/all-none sections → bytes unchanged) ──
@@ -328,6 +351,74 @@ describe("forge_apply_spec_gen — AC-6 hand-author race-window guard", () => {
     expect(record.generatedDocs!.specPath).toContain("TECHNICAL-SPEC.md");
     expect(record.generatedDocs!.specGenMode).toBe("caller-action");
     expect(record.generatedDocs!.contracts).toEqual(["forge_evaluate"]);
+  });
+
+  it("v0.44.1: tokensEstimated: true threads onto generatedDocs.tokensEstimated", async () => {
+    // Caller-action path where the caller (e.g. /forge-execute v1.1.0)
+    // estimates tokens via byte/4 and marks them as approximate. The flag
+    // must land on the run record's generatedDocs envelope so cost-audit
+    // consumers can mark the totalCostUsd as estimated.
+    rmSync(tmp, { recursive: true, force: true });
+    tmp = mkdtempSync(join(tmpdir(), "forge-apply-spec-gen-tokens-est-"));
+    seedTechSpec(tmp, { handAuthored: false });
+    seedRunRecord(tmp, "abcd");
+
+    const applyResp = await handleApplySpecGen({
+      runId: "abcd",
+      storyId: "US-01",
+      projectPath: tmp,
+      sections: {
+        "api-contracts": "- `est`: caller bullet",
+        "data-models": "- `Est`: caller bullet",
+        invariants: "- caller invariant",
+        "test-surface": "- caller test",
+      },
+      contracts: [],
+      tokens: { inputTokens: 1000, outputTokens: 500 },
+      tokensEstimated: true,
+    });
+    expect(applyResp.isError).toBeUndefined();
+
+    const runsDir = join(tmp, ".forge", "runs");
+    const entries = readdirSync(runsDir) as string[];
+    const recordFile = entries.find((e) => e.endsWith("-abcd.json"));
+    expect(recordFile).toBeDefined();
+    const record = JSON.parse(
+      readFileSync(join(runsDir, recordFile!), "utf-8"),
+    ) as { generatedDocs?: { tokensEstimated?: boolean } };
+    expect(record.generatedDocs?.tokensEstimated).toBe(true);
+  });
+
+  it("v0.44.1: tokensEstimated unset → field absent from generatedDocs (backwards compat)", async () => {
+    rmSync(tmp, { recursive: true, force: true });
+    tmp = mkdtempSync(join(tmpdir(), "forge-apply-spec-gen-no-est-"));
+    seedTechSpec(tmp, { handAuthored: false });
+    seedRunRecord(tmp, "abcd");
+
+    const applyResp = await handleApplySpecGen({
+      runId: "abcd",
+      storyId: "US-01",
+      projectPath: tmp,
+      sections: {
+        "api-contracts": "- `m`: caller bullet",
+        "data-models": "- `M`: caller bullet",
+        invariants: "- caller invariant",
+        "test-surface": "- caller test",
+      },
+      contracts: [],
+      tokens: { inputTokens: 100, outputTokens: 50 },
+      // tokensEstimated intentionally omitted (default = measured tokens)
+    });
+    expect(applyResp.isError).toBeUndefined();
+
+    const runsDir = join(tmp, ".forge", "runs");
+    const entries = readdirSync(runsDir) as string[];
+    const recordFile = entries.find((e) => e.endsWith("-abcd.json"));
+    expect(recordFile).toBeDefined();
+    const record = JSON.parse(
+      readFileSync(join(runsDir, recordFile!), "utf-8"),
+    ) as { generatedDocs?: { tokensEstimated?: boolean } };
+    expect(record.generatedDocs?.tokensEstimated).toBeUndefined();
   });
 
   it("preserves hand-authored sub-section AND overwrites the other three", async () => {

--- a/server/tools/apply-spec-gen.test.ts
+++ b/server/tools/apply-spec-gen.test.ts
@@ -160,7 +160,7 @@ describe("forge_apply_spec_gen — Zod input validation (AC-5)", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts an optional tokensEstimated: true field (v0.44.1)", () => {
+  it("accepts an optional tokensEstimated: true field (v0.45.0)", () => {
     const schema = z.object(applySpecGenInputSchema);
     const withEstimate = {
       runId: "a1b2",
@@ -353,7 +353,7 @@ describe("forge_apply_spec_gen — AC-6 hand-author race-window guard", () => {
     expect(record.generatedDocs!.contracts).toEqual(["forge_evaluate"]);
   });
 
-  it("v0.44.1: tokensEstimated: true threads onto generatedDocs.tokensEstimated", async () => {
+  it("v0.45.0: tokensEstimated: true threads onto generatedDocs.tokensEstimated", async () => {
     // Caller-action path where the caller (e.g. /forge-execute v1.1.0)
     // estimates tokens via byte/4 and marks them as approximate. The flag
     // must land on the run record's generatedDocs envelope so cost-audit
@@ -389,7 +389,7 @@ describe("forge_apply_spec_gen — AC-6 hand-author race-window guard", () => {
     expect(record.generatedDocs?.tokensEstimated).toBe(true);
   });
 
-  it("v0.44.1: tokensEstimated unset → field absent from generatedDocs (backwards compat)", async () => {
+  it("v0.45.0: tokensEstimated unset → field absent from generatedDocs (backwards compat)", async () => {
     rmSync(tmp, { recursive: true, force: true });
     tmp = mkdtempSync(join(tmpdir(), "forge-apply-spec-gen-no-est-"));
     seedTechSpec(tmp, { handAuthored: false });

--- a/server/tools/apply-spec-gen.ts
+++ b/server/tools/apply-spec-gen.ts
@@ -84,6 +84,12 @@ export const applySpecGenInputSchema = {
     .describe(
       "Token usage from the caller's LLM round-trip. Used by the run record's totalCostUsd rollup.",
     ),
+  tokensEstimated: z
+    .boolean()
+    .optional()
+    .describe(
+      "Optional: when true, the caller computed `tokens` via a byte/4 estimate (e.g. /forge-execute v1.1.0 in-session spec-inline path where Claude cannot observe its own LLM usage). Threaded onto `generatedDocs.tokensEstimated` so cost-audit consumers can mark the totalCostUsd as approximate.",
+    ),
   affectedPaths: z
     .array(z.string())
     .optional()
@@ -119,6 +125,7 @@ type ApplySpecGenInput = {
   };
   contracts: string[];
   tokens: { inputTokens: number; outputTokens: number };
+  tokensEstimated?: boolean;
   affectedPaths?: string[];
   evalReport?: unknown;
   gitSha?: string;
@@ -215,6 +222,7 @@ export async function handleApplySpecGen(
     contracts: result.contracts,
     warnings: result.warnings,
     specGenMode: "caller-action",
+    ...(input.tokensEstimated === true ? { tokensEstimated: true } : {}),
   };
   // totalCostUsd: forge_apply_spec_gen owns the spec-gen leg's cost; the
   // run-level (shell-AC) cost was already recorded by evaluate.ts in the


### PR DESCRIPTION
## Summary
- Add `tokensEstimated?: boolean` to `applySpecGenInputSchema` so caller-action paths that compute tokens via byte/4 (e.g. /forge-execute v1.1.0 in-session spec-inline) can mark them as approximate.
- Thread the flag onto `RunRecord.generatedDocs.tokensEstimated`. Cost math unchanged; the flag is a confidence-signal for audit consumers.
- Additive optional per P50 — legacy callers continue working unchanged; absent field = "measured tokens" (back-compat).

## Test plan
- [x] New test: schema accepts `tokensEstimated: true` (Zod validation passes).
- [x] New test: when `tokensEstimated: true` is passed through `handleApplySpecGen`, `generatedDocs.tokensEstimated === true` on the persisted run record.
- [x] New test: when `tokensEstimated` is omitted, field is absent from `generatedDocs` (back-compat).
- [x] Existing 1159 tests still pass — test count 1159 → 1162 (+3).

## Related
- PR #755 (ai-brain) — /forge-execute v1.1.0 caller that produces the byte/4 estimates this field receives.
- KB pattern P50 (Additive Optional Fields).

---
plan-refresh: no-op