### PR TITLE
fix: add defensive UTF-8 BOM strip in parseSpec and splitFrontMatter

### DIFF
--- a/scripts/validate-tech-spec.mjs
+++ b/scripts/validate-tech-spec.mjs
@@ -42,7 +42,8 @@ const AGENT_FIRST_HEADER_RE =
  */
 function splitFrontMatter(text) {
   // Normalise CRLF → LF for the split, then operate on LF-only text.
-  const normalised = text.replace(/\r\n/g, "\n");
+  // Strip UTF-8 BOM if present (e.g. from Windows editors).
+  const normalised = text.replace(/^﻿/, "").replace(/\r\n/g, "\n");
   // Strip the optional agent-first header. Files written before Bundle 1a
   // skip this strip and continue to validate.
   const stripped = normalised.replace(AGENT_FIRST_HEADER_RE, "");

--- a/server/lib/spec-generator.ts
+++ b/server/lib/spec-generator.ts
@@ -347,7 +347,8 @@ interface ParsedSpec {
 }
 
 function parseSpec(text: string): ParsedSpec {
-  const normalised = text.replace(/\r\n/g, "\n");
+  // Strip UTF-8 BOM if present (e.g. from Windows editors).
+  const normalised = text.replace(/^﻿/, "").replace(/\r\n/g, "\n");
   // Skip the agent-first header (Bundle 1a) if present. The header lives BEFORE
   // the YAML front-matter fence; older spec files written prior to v0.40.0
   // start directly with `---\n` and pass through unchanged.


### PR DESCRIPTION
Closes #512

Auto-fix by /housekeep Stage 4.

Adds a defensive UTF-8 BOM strip (`.replace(/^﻿/, '')`) at the head of `parseSpec()` in `server/lib/spec-generator.ts` and `splitFrontMatter()` in `scripts/validate-tech-spec.mjs`. This tolerates hand-edits from Windows editors that add a BOM, which would otherwise block the front-matter parse.