### PR TITLE
fix: remove misleading 'array copy' comment in specGenWarnings

### DIFF
--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -698,8 +698,7 @@ async function handleStoryEval(input: EvaluateInput): Promise<McpResponse> {
 
   // v0.38.0 I3 — surface spec-generator warnings at the top level of the
   // forge_evaluate MCP response. Byte-identical to the on-disk run record's
-  // `generatedDocs.warnings` (same array reference at this point — array
-  // copy here just to avoid downstream mutation).
+  // `generatedDocs.warnings` (same array reference).
   // The `specGenWarnings` field is also set on records that omit
   // `generatedDocs` entirely (non-PASS verdicts, spec-gen failure) — empty
   // array in that case so consumers can rely on field presence.


### PR DESCRIPTION
Closes #466

Auto-fix by /housekeep Stage 4.

Removes the misleading comment "array copy here just to avoid downstream mutation" from the `specGenWarnings` assignment. The code `const specGenWarnings = storyEvalSpecGenWarnings ?? []` is the same array reference, not a copy, so the comment was incorrect.