### PR TITLE
fix: extract deriveCriticOutcome helper to avoid nested ternary

### DIFF
--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -1126,6 +1126,15 @@ export async function handleSmokeTest(
 
 // ── Critic Mode Handler ───────────────────────────────────
 
+/** Derives the run-record outcome for a critic eval from the per-plan results. */
+function deriveCriticOutcome(
+  results: Array<{ error?: string }>,
+): "failure" | "partial" | "success" {
+  if (results.every((r) => r.error)) return "failure";
+  if (results.some((r) => r.error)) return "partial";
+  return "success";
+}
+
 /**
  * Q0.5/C1 — critic eval mode. Loads N plan files, fans out N critic prompt
  * calls via `trackedCallClaude`, aggregates findings into a `CriticEvalReport`.
@@ -1218,11 +1227,7 @@ async function handleCriticEval(input: EvaluateInput): Promise<McpResponse> {
       0,
     );
     const base = buildRunRecord(ctx, startTime, findingsTotal);
-    const outcome = results.every((r) => r.error)
-      ? "failure"
-      : results.some((r) => r.error)
-        ? "partial"
-        : "success";
+    const outcome = deriveCriticOutcome(results);
     await writeRunRecord(input.projectPath, {
       ...base,
       outcome,


### PR DESCRIPTION
Closes #427

Auto-fix by /housekeep Stage 4.

Extract the nested ternary at evaluate.ts lines 1221-1225 into a small named helper function `deriveCriticOutcome(results)` placed immediately before the critic handler. The logic is equivalent — all-errored → "failure", some-errored → "partial", none-errored → "success". The call site is reduced to a single readable line.