### PR TITLE
fix: handleCriticEval: empty-plans edge case yields misleading 'failure' outcome

### DIFF
--- a/server/tools/evaluate.ts
+++ b/server/tools/evaluate.ts
@@ -1174,6 +1174,28 @@ async function handleCriticEval(input: EvaluateInput): Promise<McpResponse> {
     }
   }
 
+  // Guard: no plan files resolved → return a clear "no plans" outcome rather
+  // than falling through to the empty-loop path which yields a misleading
+  // failure verdict (JS `[].every(...)` is vacuously true).
+  if (resolvedPaths.length === 0) {
+    const emptyReport: CriticEvalReport = {
+      evaluationMode: "critic",
+      results: [],
+    };
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { ...emptyReport, summary: "no plans to evaluate" },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  }
+
   const results: CriticEvalReport["results"] = [];
 
   for (const planPath of resolvedPaths) {


### PR DESCRIPTION
Closes #425

Auto-fix by /housekeep Stage 4.

Added an early-return guard in `handleCriticEval` for when `resolvedPaths` is empty (no plan files found). Previously the empty array fell through to the loop, producing an empty `results: []` array. JS's `[].every(...)` is vacuously `true`, so the outcome was written as `"failure"` to the run record even though there was nothing to evaluate. The fix returns a clear `{ evaluationMode: "critic", results: [], summary: "no plans to evaluate" }` response instead.