### PR TITLE
fix: wrapper: redacted token verdict lines lack stable hash for triage

### DIFF
--- a/scripts/promo-pr-readme-acceptance.sh
+++ b/scripts/promo-pr-readme-acceptance.sh
@@ -146,11 +146,12 @@ else
     printf "%s\n" "$diff_out" > "$_ac9_tmp"
     while IFS= read -r token; do
       [ -z "$token" ] && continue
+      hash=$(printf "%s" "$token" | sha1sum | cut -c1-6)
       if grep -i -F -e "$token" "$_ac9_tmp" >/dev/null 2>&1; then
-        printf "    [token: redacted] MATCH FOUND in PR diff\n"
+        printf "    [token: redacted #%s] MATCH FOUND in PR diff\n" "$hash"
         ac9_failures=$((ac9_failures + 1))
       else
-        printf "    [token: redacted] no match\n"
+        printf "    [token: redacted #%s] no match\n" "$hash"
       fi
     done <<<"$tokens"
     rm -f "$_ac9_tmp"


### PR DESCRIPTION
Closes #430

Auto-fix by /housekeep Stage 4.

In the AC-9 token loop, added a `sha1sum`-derived 6-char hash prefix to each verdict line. Each `[token: redacted]` line is now `[token: redacted #<hash>]` where `hash=$(printf "%s" "$token" | sha1sum | cut -c1-6)`. This makes multi-token failures triagable across runs without exposing the regulated literal: the same token always produces the same 6-char prefix, so log diffs stay meaningful.