### PR TITLE
feat: bundle the /prd skill into the public repo (#907)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ cd forge-harness
 
 Then restart Claude Code. The forge tools will appear in your tool list.
 
+`./setup.sh` also installs the **`/prd` skill** into your global Claude Code skills directory (`~/.claude/skills/prd/`), so `/prd` is available in every project. `/prd` is the companion that authors `forge_plan`'s input — it runs a guided product diagnostic and writes a PRD, the vision doc `forge_plan` turns into an execution plan.
+
+## From PRD to plan
+
+`/prd` and `forge_plan` are a two-step flow: `/prd` writes the PRD, `forge_plan` turns it into a structured execution plan.
+
+1. **Author the PRD.** In Claude Code, run `/prd`. It runs a product diagnostic (challenges your premise, validates demand, scopes the narrowest wedge), then writes the PRD to `PRD.md` (default).
+2. **Hand the PRD to `forge_plan`.** Pass the PRD's contents as the vision doc. Lead with the master tier to decompose it into phases:
+
+   ```javascript
+   forge_plan({ documentTier: "master", visionDoc: <contents of PRD.md> })
+   ```
+
+   Or, for a single focused plan, pass it as `intent`:
+
+   ```javascript
+   forge_plan({ intent: <contents of PRD.md> })
+   ```
+
 ## Tools
 
 | Tool | What It Does | LLM? | Phase |

--- a/docs/primitive-backlog.md
+++ b/docs/primitive-backlog.md
@@ -320,6 +320,11 @@ Key principle: **files canonical, SQL derived.** DB corruption is a non-event (`
 
 **Decision:** Ship one public GitHub repo containing forge-harness MCP server + skills (`/prd`, `/prototype`, `/recall`) + indexer CLI + docs + examples. One-command install via `setup.sh`.
 
+**Status (reconciled 2026-06-14, task #907):**
+- **`/prd` — SHIPPED / bundled.** Lives at `skills/prd/`, installed into `~/.claude/skills/prd/` by `setup.sh` via `scripts/install-skills.cjs`. It is the front door that authors `forge_plan`'s input (see README "From PRD to plan").
+- **`/prototype` — DEFERRED (roadmap-only, not built).** No skill exists yet; bundle when it does.
+- **`/recall` — DEFERRED (roadmap-only, not built).** No skill exists yet; bundle when it does.
+
 **Full design:** `.ai-workspace/plans/2026-04-09-forge-memory-ui-package-design.md` Part C
 
 ---

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "server/",
     "scripts/",
     "schema/",
+    "skills/",
     "README.md",
     "CHANGELOG.md"
   ]

--- a/scripts/install-skills-acceptance.sh
+++ b/scripts/install-skills-acceptance.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Acceptance wrapper for the #907 /prd-skill bundling + installer.
+# Plan: .ai-workspace/plans/2026-06-14-907-bundle-prd-skill.md
+#
+# Runs the REAL install (scripts/install-skills.cjs) into a THROWAWAY HOME so the
+# reviewer's real ~/.claude/skills is never touched, then asserts the outcome.
+# This is the Rule-18 prove-primary smoke: a real install + real assertions, not
+# a fixture parse.
+#
+# Exit 0 iff every AC passes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+# ---------- Host-pollution snapshot ----------
+# Capture the reviewer's real ~/.claude/skills/prd state BEFORE anything runs so
+# we can prove the scratch-HOME isolation didn't leak into the real home.
+HOST_PRD_DIR="$HOME/.claude/skills/prd"
+if [ -e "$HOST_PRD_DIR" ]; then HOST_PRD_BEFORE="present"; else HOST_PRD_BEFORE="absent"; fi
+
+SCRATCH="$(mktemp -d -t forge-install-skills-XXXXXX)"
+cleanup() { rm -rf "$SCRATCH"; }
+trap cleanup EXIT
+
+FAIL=0
+PASS_COUNT=0
+ok() { echo "  ✓ $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "  ✗ $1"; FAIL=1; }
+ac() { echo; echo "=== $1 ==="; }
+
+DEST="$SCRATCH/.claude/skills/prd"
+
+# ---------- AC-2 — installer lands the skill ----------
+ac "AC-2 — install exits 0 + SKILL.md lands"
+set +e
+HOME="$SCRATCH" node "$REPO_ROOT/scripts/install-skills.cjs" "$REPO_ROOT" \
+  >"$SCRATCH/run1.out" 2>"$SCRATCH/run1.err"
+RUN1_EXIT=$?
+set -e
+if [ "$RUN1_EXIT" -eq 0 ]; then ok "first install exited 0"; else fail "first install exit=$RUN1_EXIT"; sed 's/^/    /' "$SCRATCH/run1.err"; fi
+[ -f "$DEST/SKILL.md" ] && ok "SKILL.md landed at $DEST" || fail "SKILL.md missing at $DEST"
+
+# ---------- AC-3 — references installed (all 5) ----------
+ac "AC-3 — references dir + 5 reference files"
+[ -d "$DEST/references" ] && ok "references/ exists" || fail "references/ missing"
+REF_COUNT=$(ls "$DEST/references/"*.md 2>/dev/null | wc -l | tr -d ' ')
+[ "$REF_COUNT" -ge 5 ] && ok "found $REF_COUNT reference .md files (>=5)" || fail "expected >=5 reference files, found $REF_COUNT"
+for f in product-diagnostic scope-modes document-template premise-challenge quality-checklist; do
+  [ -f "$DEST/references/$f.md" ] && ok "references/$f.md present" || fail "references/$f.md missing"
+done
+
+# ---------- AC-4 — frontmatter well-formed ----------
+ac "AC-4 — SKILL.md frontmatter well-formed"
+if [ -f "$DEST/SKILL.md" ]; then
+  FIRST_LINE=$(head -1 "$DEST/SKILL.md")
+  [ "$FIRST_LINE" = "---" ] && ok "first line is '---'" || fail "first line is '$FIRST_LINE' (expected '---')"
+  grep -Eq '^name: prd$' "$DEST/SKILL.md" && ok "has 'name: prd'" || fail "missing 'name: prd' line"
+  # description: opens a block; assert a non-empty description follows it.
+  DESC_OK=$(node -e '
+    const fs=require("fs");
+    const t=fs.readFileSync(process.argv[1],"utf-8");
+    const fm=t.split(/^---\s*$/m)[1]||"";
+    const m=fm.match(/description:\s*(\|[\s\S]*?)?\n([\s\S]*?)(?:\n\w+:|$)/);
+    // Simpler: check there is a description: key and at least one non-blank line after it within the frontmatter.
+    const lines=fm.split(/\r?\n/);
+    const i=lines.findIndex(l=>/^description:/.test(l));
+    if(i<0){console.log("no-key");process.exit(0);}
+    const inline=lines[i].replace(/^description:\s*\|?\s*/,"").trim();
+    let nonEmpty = inline.length>0;
+    for(let j=i+1;j<lines.length && /^\s/.test(lines[j]);j++){ if(lines[j].trim().length>0) nonEmpty=true; }
+    console.log(nonEmpty?"ok":"empty");
+  ' "$DEST/SKILL.md")
+  [ "$DESC_OK" = "ok" ] && ok "description: is non-empty" || fail "description check: $DESC_OK"
+fi
+
+# ---------- AC-5 — idempotent + non-destructive (backup on 2nd run) ----------
+ac "AC-5 — second run is idempotent + backs up"
+set +e
+HOME="$SCRATCH" node "$REPO_ROOT/scripts/install-skills.cjs" "$REPO_ROOT" \
+  >"$SCRATCH/run2.out" 2>"$SCRATCH/run2.err"
+RUN2_EXIT=$?
+set -e
+[ "$RUN2_EXIT" -eq 0 ] && ok "second install exited 0" || { fail "second install exit=$RUN2_EXIT"; sed 's/^/    /' "$SCRATCH/run2.err"; }
+BACKUP_COUNT=$(ls -d "$SCRATCH/.claude/skills/_prd-backup-"* 2>/dev/null | wc -l | tr -d ' ')
+[ "$BACKUP_COUNT" -ge 1 ] && ok "backup dir _prd-backup-* created ($BACKUP_COUNT)" || fail "no _prd-backup-* dir after 2nd run"
+[ -f "$DEST/SKILL.md" ] && head -1 "$DEST/SKILL.md" | grep -q '^---$' && ok "re-landed SKILL.md still valid" || fail "SKILL.md invalid/missing after 2nd run"
+# Non-destructive: the backup must itself carry a valid SKILL.md (nothing was rm'd).
+BK=$(ls -d "$SCRATCH/.claude/skills/_prd-backup-"* 2>/dev/null | head -1)
+[ -n "$BK" ] && [ -f "$BK/SKILL.md" ] && ok "backup preserved a valid SKILL.md (non-destructive)" || fail "backup did not preserve SKILL.md"
+
+# ---------- AC-6 — rebrand complete (zero hive-mind in installed skill) ----------
+ac "AC-6 — zero hive-mind remnants in installed skill"
+if grep -rEi 'hive[- ]?mind' "$DEST" >/dev/null 2>&1; then
+  fail "found hive-mind remnant(s) in installed skill"
+  grep -rEi 'hive[- ]?mind' "$DEST" | sed 's/^/    /'
+else
+  ok "no hive-mind string in installed skill"
+fi
+
+# ---------- AC-7 — no external-file dependency ----------
+ac "AC-7 — no ../.hive-mind-persist dependency"
+if grep -rn '\.\./\.hive-mind-persist' "$DEST" >/dev/null 2>&1; then
+  fail "found ../.hive-mind-persist reference in installed skill"
+else
+  ok "no ../.hive-mind-persist reference"
+fi
+
+# ---------- AC-8 — no committed home-paths ----------
+# Build the needle dynamically so this script's own source never contains the
+# literal home-path substring (otherwise the scan would false-positive on its own
+# grep pattern). Asserts no absolute macOS home-path leaked into committed files.
+ac "AC-8 — no absolute home-path leak in committed files"
+HOME_NEEDLE="/$(printf 'Users')/"
+SCAN_TARGETS=("$REPO_ROOT/skills" "$REPO_ROOT/scripts/install-skills.cjs" "$REPO_ROOT/scripts/install-skills-acceptance.sh" "$REPO_ROOT/setup.sh")
+if grep -rn "$HOME_NEEDLE" "${SCAN_TARGETS[@]}" >/dev/null 2>&1; then
+  fail "found absolute home-path leak in committed files"
+  grep -rn "$HOME_NEEDLE" "${SCAN_TARGETS[@]}" | sed 's/^/    /'
+else
+  ok "no absolute home-path leak in committed files"
+fi
+
+# ---------- AC-host — real ~/.claude/skills/prd untouched ----------
+ac "AC-host — real home untouched (isolation held)"
+if [ -e "$HOST_PRD_DIR" ]; then HOST_PRD_AFTER="present"; else HOST_PRD_AFTER="absent"; fi
+[ "$HOST_PRD_BEFORE" = "$HOST_PRD_AFTER" ] && ok "real ~/.claude/skills/prd state unchanged ($HOST_PRD_BEFORE)" || fail "real home mutated: before=$HOST_PRD_BEFORE after=$HOST_PRD_AFTER"
+
+# ---------- Summary ----------
+echo
+echo "=== Summary ==="
+echo "  Passed: $PASS_COUNT checks"
+if [ "$FAIL" -ne 0 ]; then
+  echo "  FAIL — one or more AC failed."
+  exit 1
+fi
+echo "  PASS — all AC green."

--- a/scripts/install-skills.cjs
+++ b/scripts/install-skills.cjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Install the forge-harness bundled skills into the user's global Claude Code
+// skills directory so they are available in every project.
+//
+// Today this installs the `/prd` skill. The destination is the GLOBAL skills
+// dir (`~/.claude/skills/`), derived from os.homedir() — never a hardcoded
+// home path — so `/prd` works in every Claude Code session after one install.
+//
+// Idempotency policy: BACKUP-THEN-OVERWRITE. If a `prd` skill already exists at
+// the destination, the existing directory is moved aside to a timestamped backup
+// (`~/.claude/skills/_prd-backup-YYYYMMDD-HHMMSS/`, mv-not-rm — recoverable) and
+// the bundled version is copied in fresh. This keeps the bundled skill
+// authoritative after every setup.sh run while never destroying a prior install.
+//
+// Usage: node scripts/install-skills.cjs [<repo-root-path>]
+//   repo-root-path defaults to the parent dir of this script.
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const repoRoot = path.resolve(process.argv[2] || path.join(__dirname, ".."));
+
+// Skills bundled in this repo that get installed globally. Add new entries here
+// as more skills are bundled.
+const SKILLS = ["prd"];
+
+const skillsSrcRoot = path.join(repoRoot, "skills");
+const skillsDestRoot = path.join(os.homedir(), ".claude", "skills");
+
+function timestamp() {
+  // YYYYMMDD-HHMMSS in local time, zero-padded.
+  const d = new Date();
+  const p = (n, w = 2) => String(n).padStart(w, "0");
+  return (
+    `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}` +
+    `-${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`
+  );
+}
+
+function installSkill(name) {
+  const src = path.join(skillsSrcRoot, name);
+  if (!fs.existsSync(path.join(src, "SKILL.md"))) {
+    console.error(
+      `install-skills: ERROR — bundled skill '${name}' not found at ${src} (missing SKILL.md). Did the clone complete?`
+    );
+    process.exit(1);
+  }
+
+  fs.mkdirSync(skillsDestRoot, { recursive: true });
+  const dest = path.join(skillsDestRoot, name);
+
+  // Backup-then-overwrite: if a prior install exists, move it aside (mv-not-rm).
+  if (fs.existsSync(dest)) {
+    const backup = path.join(skillsDestRoot, `_${name}-backup-${timestamp()}`);
+    fs.renameSync(dest, backup);
+    console.error(
+      `install-skills: existing '${name}' skill backed up to ${backup}`
+    );
+  }
+
+  // Copy (not symlink): a public user's clone may move or disappear, and a
+  // dangling symlink would silently break the skill.
+  fs.cpSync(src, dest, { recursive: true });
+  console.error(`install-skills: installed '/${name}' skill → ${dest} ✓`);
+}
+
+for (const name of SKILLS) {
+  installSkill(name);
+}
+
+console.error(
+  "install-skills: done. Restart Claude Code so the skill(s) are picked up."
+);
+process.exit(0);

--- a/setup.sh
+++ b/setup.sh
@@ -22,4 +22,8 @@ echo "forge setup: compiling TypeScript..."
 echo "forge setup: registering MCP server..."
 node "$SCRIPT_DIR/scripts/setup-config.cjs" "$SCRIPT_DIR"
 
-echo "forge setup: done. Restart Claude Code to pick up the forge tools."
+# Install bundled skills (the /prd skill) into the global Claude Code skills dir
+echo "forge setup: installing skills..."
+node "$SCRIPT_DIR/scripts/install-skills.cjs" "$SCRIPT_DIR"
+
+echo "forge setup: done. Restart Claude Code to pick up the forge tools and the /prd skill."

--- a/skills/prd/SKILL.md
+++ b/skills/prd/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: prd
+description: |
+  Interactive PRD creation with product diagnostic. Guides users through a structured
+  interview that challenges premises, validates demand, and produces a pipeline-ready PRD
+  following the forge-harness PRD document structure.
+  Use when asked to "create a PRD", "write a PRD", "I have an idea", "help me define
+  requirements", "what should I build", or "/prd".
+  Proactively suggest when the user describes a new product idea or feature before any
+  code is written — product-level rethinking should happen before a line of code.
+---
+
+# PRD Creation Skill
+
+Create structured PRDs for the forge-harness pipeline through a guided product diagnostic and requirements interview. Challenges whether you're building the right thing before structuring requirements.
+
+The PRD this skill produces is the **vision doc** that `forge_plan` transforms into an execution plan — `/prd` is the front door, `forge_plan` is the next step.
+
+**You ASSIST, you do not REPLACE the human's judgment.** The human decides WHAT to build and WHY. You push them to think harder about both.
+
+## Session Resume
+
+Check if `.ai-workspace/prd-draft.md` exists. If found, ask: "Found an in-progress PRD draft. Resume or start fresh?" Best-effort — skip if user intent is clear.
+
+## Phase Flow
+
+```
+1. DISCOVER  ->  2. DRAFT  ->  3. VALIDATE  ->  4. REFINE  ->  5. EXPORT
+```
+
+## Phase 1: DISCOVER
+
+Five steps, run sequentially.
+
+**1A. Context Gathering**
+1. Read the project codebase to understand what exists
+2. Read optional project-context files if present — e.g. a repo `README.md`, a `.forge/` config directory, or any project memory / constitution / principles doc the repo happens to carry. These reads are **best-effort**: if a file is absent, skip it silently and continue (a fresh public project may have none). Never error on a missing file.
+3. If greenfield, note that and skip codebase reading
+
+**1B. Product Diagnostic**
+Challenge whether the right thing is being built using four forcing questions (Q1-Q4), plus a conditional Q5 for UI/visual features. Between Q3 and Q4, an infrastructure prerequisite scan checks whether the feature needs plumbing (event emitters, auth, WebSocket, etc.) that doesn't exist in the codebase -- advisory only, surfaces gaps to inform Q4's wedge choice. See `references/product-diagnostic.md` for the full question set, infra scan table, smart routing, response posture, and escape hatch.
+
+**Q4 must explicitly challenge infrastructure gaps surfaced by the prereq scan.** When the scan flags missing plumbing (auth, event emitters, persistence, etc.), Q4's "narrowest wedge" answer must address the gap directly rather than route around it. Empirically: when Q4 doesn't reference the scan's gap output, expansion options collapse to UI-layer-only and the diagnostic loses its forcing function. If the scan returns gaps, restate them in Q4's prompt verbatim before asking for the wedge.
+
+**Expansion options must span at least two layers.** A SELECTIVE EXPAND or EXPAND that produces only UI-layer additions is a quality smell — the diagnostic flagged gaps for a reason. Each expansion REQ should name its layer (UI / data / control / infra). If all expansion REQs land on UI, the diagnostic's infra scan was ignored. Re-prompt for at least one non-UI expansion before proceeding to 1C Premise Challenge.
+
+**1C. Premise Challenge**
+Synthesize diagnostic answers into premises. Get explicit agree/disagree. See `references/premise-challenge.md`.
+
+**1D. Scope Mode Selection**
+Ask user to pick: EXPAND, SELECTIVE EXPAND (default), HOLD, or REDUCE. See `references/scope-modes.md` for mode definitions and requirements-interview behavior per mode.
+
+**1E. Requirements Interview**
+Collect requirements informed by diagnostic and scope mode:
+1. Key capabilities -> REQ-01, REQ-02, etc.
+2. Out of Scope (informed by Narrowest Wedge)
+3. Success criteria (binary pass/fail only)
+4. Concrete input/output examples per key requirement
+
+If user gives terse answers, prompt with examples from similar PRDs or codebase context.
+
+## Phase 2: DRAFT
+
+Assemble answers into the 10-section PRD structure defined in `references/document-template.md` (self-contained — it carries the canonical section list, the diagnostic-answer-to-section mapping, and the drafting rules; no external document is required).
+
+Save draft to `.ai-workspace/prd-draft.md`. Present to human.
+
+## Phase 3: VALIDATE
+
+Run advisory quality checks on the draft. See `references/quality-checklist.md` for the full check table and compliance notes.
+
+All severities are advisory. The human is the real quality gate. Present results as a summary table.
+
+## Phase 4: REFINE
+
+Iterate on human feedback. Re-run quality checklist after changes. Continue until satisfied.
+
+## Phase 5: EXPORT
+
+1. Write final PRD to user-specified path (default: `PRD.md`)
+2. Delete `.ai-workspace/prd-draft.md`
+3. Hand off to `forge_plan` (see "Handoff to forge_plan" below) — the exported PRD is the vision doc `forge_plan` turns into an execution plan.
+
+If write fails, report error and ask for alternative path.
+
+### Handoff to forge_plan
+
+The exported PRD is the input `forge_plan` was built to consume. Print this handoff to the user.
+
+**Lead with the master tier — decompose the PRD into phases (the richer forge flow):**
+
+```
+forge_plan({ documentTier: "master", visionDoc: <the exported PRD's contents> })
+```
+
+**Or, for a single standalone plan (simpler — one focused plan, no phase decomposition):**
+
+```
+forge_plan({ intent: <the exported PRD's contents> })
+```
+
+Pick `documentTier: "master"` when the PRD spans multiple phases of work; pick `intent` when it's one focused slice. Either way, pass the **contents** of the exported PRD as the string value.
+
+## Rules
+
+- The human decides WHAT and WHY -- you challenge both but defer to their judgment
+- Every REQ needs an ID (REQ-NN) and binary acceptance criteria
+- Out of Scope must be explicit with rationale
+- No HOW sections -- architecture belongs in the execution plan / SPEC
+- Be direct, not sycophantic -- take positions, challenge weak answers
+- The product diagnostic is not optional
+
+## Run Data Recording
+
+<!-- skill version: 1.0.1 (2026-04-15) — outcome enum expanded + issues field added -->
+
+After Phase 5 (EXPORT) completes — or if the user abandons early — persist run data. This section always runs.
+
+**Resolve the skill base directory** from the skill's own install directory (where this `SKILL.md` lives), not the current working directory.
+
+### What to record
+
+Append to `runs/data.json` (create with `{"skill":"prd","lastRun":null,"totalRuns":0,"runs":[]}` if missing):
+
+```json
+{
+  "timestamp": "{ISO-8601}",
+  "outcome": "exported-clean|exported-with-warnings|exported-verify-failed|abandoned|resumed",
+  "project": "{current project directory name}",
+  "prdTopic": "{one-line topic from Q1/user description}",
+  "routing": "new-product|enhancement|internal-tooling",
+  "questionsAsked": ["Q1","Q2","Q3","Q4","Q5"],
+  "infraScanRan": true,
+  "infraGapsFound": "{N or 0}",
+  "scopeMode": "EXPAND|SELECTIVE_EXPAND|HOLD|REDUCE",
+  "requirementCount": "{N REQs in final PRD}",
+  "qualityChecks": {"fail": 0, "warn": 0, "info": 0},
+  "refinementRounds": "{N iterations in Phase 4}",
+  "outputPath": "{path to exported PRD or null}",
+  "issues": [
+    {"stage": "verify", "type": "false-negative", "description": "parser rejected a valid story assertion on story 3/4"}
+  ],
+  "summary": "{one-line: e.g., 'Pipeline Observability Dashboard, 7 REQs, SELECTIVE EXPAND, exported to PRD.md'}"
+}
+```
+
+**Outcome value semantics (v1.0.1 2026-04-15):**
+- `exported-clean` — PRD generated AND all Phase 4 verification passed without warnings or failures
+- `exported-with-warnings` — PRD generated; verification produced warnings (e.g., scope warnings, non-blocking quality checks)
+- `exported-verify-failed` — PRD generated AND exported, but verification failed outright (e.g., story-level assertions failed, parser false-negatives not resolvable). The PRD is still shipped because the generation succeeded — verification failure is a separate signal tracked in `issues: []`.
+- `abandoned` — user exited before Phase 5 (EXPORT)
+- `resumed` — continuation of a prior session; the new run picked up mid-flow
+
+Prior to v1.0.1 the outcome enum was just `exported|abandoned|resumed`, which conflated clean runs with verify-failed runs and prevented quality-trend tracking. Readers of pre-v1.0.1 data should treat `exported` as equivalent to `exported-with-warnings` (the safe fallback) unless the summary explicitly says "all passed."
+
+**Issues field (v1.0.1 2026-04-15):** each entry conforms to the cross-skill convention `{stage, type, description}` — e.g. `{"stage": "verify", "type": "false-negative", "description": "..."}`. This is the field skill-improvement tooling mines to find recurring quality issues. Historical runs (pre-v1.0.1) did not populate this field; treat missing `issues` as `null`, not an error.
+
+Keep last 50 runs (older runs are permanently discarded). Set `lastRun` and increment `totalRuns`.
+
+Append one line to `runs/run.log` (keep last 100 lines):
+```
+{timestamp} | {outcome} | {prdTopic} | {requirementCount} REQs | {scopeMode} | {summary}
+```
+
+Do not fail the skill if recording fails — log a warning and continue.
+
+## Attribution
+
+Product diagnostic adapted from [Garry Tan's gstack](https://github.com/garrytan/gstack).

--- a/skills/prd/references/document-template.md
+++ b/skills/prd/references/document-template.md
@@ -1,0 +1,31 @@
+# Document Template (Phase 2: DRAFT)
+
+This reference is the **canonical PRD structure for forge-harness**. It defines the 10 sections, maps diagnostic answers to each section, and states the drafting rules — no external document is required.
+
+## 10 Sections
+
+1. **Problem Statement** -- from Q1 (Demand Reality) and Q2 (Status Quo) answers
+2. **Objective** -- from agreed premises
+3. **Requirements** -- REQ-NN format with user stories and acceptance criteria
+4. **Non-Functional Requirements** -- constraints without specifying HOW
+5. **User Workflow** -- step-by-step from user perspective, no implementation detail
+6. **Success Criteria** -- binary pass/fail only
+7. **Out of Scope** -- with rationale per exclusion (informed by Q4: Narrowest Wedge)
+8. **Future Scope / Roadmap** -- deferred expansions from scope mode go here
+9. **Open Questions** -- mark unresolved items with `[NEEDS CLARIFICATION]`
+10. **Evidence Base** -- demand evidence from Q1, status quo from Q2, user research from Q3
+
+## Drafting Rules
+
+- Auto-number requirements as REQ-01, REQ-02, etc.
+- Every REQ must have a user story and binary acceptance criteria
+- Suggest user stories for functional requirements (best-effort -- human should review)
+- No HOW sections -- architecture, file organization, CLI commands belong in the execution plan / SPEC
+- NFRs constrain without specifying: "Response time < 200ms" is an NFR; "Use Redis" is a SPEC decision
+- Include concrete input/output examples in the relevant requirement sections
+- Include agreed premises in the Evidence Base section
+- If scope mode was EXPAND or SELECTIVE EXPAND, include accepted expansions as requirements and deferred ones in Future Scope
+
+## Session Persistence
+
+Save the draft to `.ai-workspace/prd-draft.md` after completing it. This is best-effort session persistence -- if interrupted, the user can re-invoke `/prd` and point at the draft.

--- a/skills/prd/references/premise-challenge.md
+++ b/skills/prd/references/premise-challenge.md
@@ -1,0 +1,27 @@
+# Premise Challenge (Step 1C)
+
+Synthesize what you learned from the diagnostic. State the premises the PRD will be built on and get explicit agreement.
+
+## Template
+
+```
+PREMISES:
+1. [The problem is X] -- agree/disagree?
+2. [The target user is Y] -- agree/disagree?
+3. [The narrowest valuable version is Z] -- agree/disagree?
+4. [Doing nothing costs the user W] -- agree/disagree?
+```
+
+## Additional Challenges
+
+After stating premises, also challenge:
+- Is this the right problem? Could a different framing yield a simpler or more impactful solution?
+- What happens if we do nothing? Real pain point or hypothetical?
+- What existing code already partially solves this? (from Step 1A context)
+
+## Rules
+
+- If the user disagrees with a premise, revise and re-present. Loop until all premises are agreed.
+- Do NOT proceed to scope mode selection or requirements until premises are agreed.
+- Keep premises concrete and testable -- avoid vague statements.
+- Reference specific evidence from the diagnostic answers (Q1-Q4) in each premise.

--- a/skills/prd/references/product-diagnostic.md
+++ b/skills/prd/references/product-diagnostic.md
@@ -1,0 +1,183 @@
+# Product Diagnostic (Step 1B)
+
+Ask these forcing questions ONE AT A TIME. Wait for the response before asking the next. Push on each until the answer is specific, evidence-based, and uncomfortable.
+
+## Choice Presentation
+
+For each question (Q1-Q4), present context-aware answer suggestions using the `AskUserQuestion` tool with the `options` parameter. Generate choices dynamically from what you learned in Step 1A (codebase, memory, constitution, existing PRDs).
+
+### Rules
+- Generate 3-4 context-specific choices per question. The user can always select "Other" to type their own answer (this is built into AskUserQuestion).
+- Choices are thinking aids, not crutches. After the user selects one, still apply the push-for-specificity posture -- challenge vague selections the same way you'd challenge vague free-text.
+- If the user selects "Other" and types their own answer, apply the standard push posture as before.
+- Never generate choices that anchor the user to one framing. Offer genuinely different angles.
+
+### Choice Generation Sources (priority order)
+1. **Codebase patterns** -- existing features, known users, current workflows, README descriptions
+2. **Memory/constitution** -- product principles, past decisions, known pain points
+3. **Session context** -- what the user said when invoking the skill, earlier answers in Q1-Q4
+4. **Domain archetypes** -- common patterns for the detected project type (CLI tool, web app, library, etc.). Use as fallback when codebase context is thin (e.g., greenfield projects).
+
+### Post-Selection Push
+When the user selects a suggested choice (not "Other"):
+1. Acknowledge the selection briefly (one sentence, no praise).
+2. Push for more specificity: "You picked [X]. Make it more concrete -- [specific follow-up based on the question's red flags]."
+3. If the selection was already specific enough, proceed to the next question.
+
+## Smart Routing
+
+Not all questions apply to every situation:
+- New product/feature: Q1, Q2, Q3, Q4
+- Enhancement to existing feature: Q2, Q4
+- Internal tooling: Q2, Q4
+- **UI/visual feature** (dashboard, web app, mobile app, interface, frontend): Q1, Q2, Q3, Q4, **Q5**
+
+Q5 triggers when the feature involves a visual interface. Detect by scanning the PRD topic and Q1-Q4 answers for keywords: "dashboard", "web", "UI", "interface", "screen", "page", "frontend", "mobile", "app", "display", "visual", "view".
+
+## Q1: Demand Reality
+
+Ask: "What's the strongest evidence someone actually wants this -- not 'is interested,' but would be genuinely upset if it disappeared tomorrow?"
+
+**Suggested Choices:** Generate 3-4 options representing different evidence types, grounded in Step 1A context:
+- Option sourced from **usage data** (if codebase has analytics, logs, or user metrics)
+- Option sourced from **user feedback** (if memory/constitution mentions user complaints or requests)
+- Option sourced from **behavioral proxy** (e.g., "Users currently run command X 50+ times/day" if seen in codebase)
+- Option representing a **common archetype** for the project type (e.g., for a CLI: "Users have built shell aliases/scripts around the current tool")
+
+Push until you hear specific behavior: someone paying, expanding usage, building workflows around it, scrambling if it vanished.
+
+Red flags: "People say it's interesting." "We got waitlist signups." "VCs are excited." None of these are demand.
+
+After the answer, check:
+- Are the key terms defined? If they said "AI tool for developers" -- challenge: "What specific task does a specific developer waste 2+ hours on per week?"
+- Is there evidence of actual pain, or is this a thought experiment?
+
+## Q2: Status Quo
+
+Ask: "What are your users doing right now to solve this -- even badly? What does that workaround cost them?"
+
+**Suggested Choices:** Generate 3-4 options based on current workarounds visible in the codebase or described in memory:
+- Option describing a **manual process** visible in the codebase (scripts, READMEs, docs mentioning manual steps)
+- Option describing a **tool combination** users currently stitch together
+- Option describing **doing nothing** (with the cost stated)
+- Option from **memory/constitution** if past discussions mention current workflow
+
+Push until you hear a specific workflow: hours spent, dollars wasted, tools duct-taped together, manual processes.
+
+Red flags: "Nothing -- there's no solution, that's why the opportunity is huge." If no one does anything, the problem may not be painful enough.
+
+## Q3: Desperate Specificity
+
+Ask: "Name the actual human who needs this most. What's their role? What keeps them up at night about this problem?"
+
+**Suggested Choices:** Generate 3-4 options representing different user archetypes, informed by codebase context:
+- Option naming a **specific role** that interacts with the codebase (contributor types, README audience)
+- Option naming a **power user** archetype (someone who would use this daily)
+- Option naming an **adjacent stakeholder** (someone affected but not the direct user)
+
+Push until you hear a name, a role, a specific consequence if the problem isn't solved.
+
+Red flags: Category-level answers -- "Healthcare enterprises." "Marketing teams." You can't email a category.
+
+## Infrastructure Prerequisite Scan (Pre-Q4)
+
+After Q3 and before asking Q4, silently check whether the proposed feature requires infrastructure that doesn't exist in the codebase. This is advisory only -- it informs Q4, it does not gate or block the user.
+
+### When to run
+
+Always, using Step 1A codebase context. If Step 1A was skipped (greenfield project), skip this scan.
+
+### How it works
+
+1. Extract feature keywords from the user's initial description + Q1-Q3 answers
+2. Match keywords against the table below to identify expected infrastructure
+3. Use Grep/Glob to check whether the expected infrastructure exists in the codebase
+4. If any infrastructure is **missing**, present findings before Q4
+5. If all infrastructure is present or no keywords matched, skip silently
+
+### Keyword-to-infrastructure mapping
+
+| Feature keywords | Expected infrastructure | What to grep for |
+|-----------------|------------------------|-----------------|
+| dashboard, monitor, status view, observability | Structured event emission, observable state | `emit(`, `EventEmitter`, `on(`, `Observable`, `subscribe` |
+| API, endpoint, REST, GraphQL, webhook | HTTP server or route framework | `express`, `fastify`, `createServer`, `Router`, `app.get(`, `app.post(` |
+| real-time, live, streaming, push updates | WebSocket, SSE, or pub-sub | `WebSocket`, `ws(`, `EventSource`, `Server-Sent`, `pubsub`, `subscribe` |
+| auth, login, permissions, roles, access control | Auth middleware or session management | `passport`, `jwt`, `bcrypt`, `session`, `authenticate`, `authorize` |
+| notification, alert, email, SMS | Message queue or push infrastructure | `queue`, `notify`, `sendEmail`, `nodemailer`, `twilio`, `push` |
+| search, filter, query | Search index or full-text search | `elasticsearch`, `algolia`, `meilisearch`, `LIKE '%`, `tsvector`, `createIndex` |
+| storage, upload, file, image, asset | File storage or CDN integration | `multer`, `S3`, `blob`, `upload`, `createWriteStream`, `sharp` |
+| schedule, cron, recurring, periodic | Job scheduler or cron infrastructure | `cron`, `agenda`, `bull`, `setInterval`, `schedule`, `node-cron` |
+| database, CRUD, model, migration, persist, store | Relational DB / ORM | `prisma`, `typeorm`, `sequelize`, `knex`, `drizzle`, `sqlalchemy`, `ActiveRecord`, `CREATE TABLE` |
+| document, NoSQL, collection, mongo | Document DB / ODM | `mongoose`, `MongoClient`, `firestore`, `dynamodb`, `collection(`, `createCollection` |
+
+> **Ecosystem note:** The grep terms above are illustrative and skew toward Node.js/TypeScript. For Python, Dart, Java, or other ecosystems, adapt to equivalent libraries (e.g., `flask`/`django` instead of `express`, `sqlalchemy` instead of `prisma`). The principle -- checking whether required infrastructure exists -- applies universally.
+
+This table is not exhaustive. Use judgment for feature types not listed -- the principle is: "does this feature assume plumbing that doesn't exist?"
+
+### Presentation
+
+If missing infrastructure is found, present it as a push before Q4:
+
+> "Before we scope the wedge: I checked the codebase and this [feature type] needs [missing infrastructure] that doesn't exist yet. [Specific grep result or absence]. This means the narrowest wedge might be that infrastructure layer rather than the feature on top of it. Keep this in mind for the next question."
+
+Then proceed to Q4 normally. The user decides whether the wedge should be infrastructure or the feature.
+
+### Rules
+
+- **Advisory only.** Never block Q4 or override the user's wedge choice based on this scan.
+- If the user acknowledges the gap and chooses to build the feature anyway, respect it. Note the infrastructure gap in the premises (Step 1C) so it surfaces in the PRD's Risks section.
+- If multiple infrastructure items are missing, list all of them. Let the user prioritize.
+- Do not repeat infrastructure that already exists. Only surface gaps.
+
+## Q4: Narrowest Wedge
+
+Ask: "What's the smallest version of this that someone would actually use -- this week, not after you build the full vision?"
+
+**Suggested Choices:** Generate 3-4 options representing different scope cuts, informed by earlier Q1-Q3 answers and codebase:
+- Option that is the **single-command MVP** (one workflow, no config)
+- Option that is the **core loop only** (the repeated action, nothing around it)
+- Option that **removes the hardest technical piece** and ships the rest
+- Reference the user's Q1-Q3 answers to ground the wedge in their stated demand and user
+
+Push until you hear one feature, one workflow, something shippable in days not months.
+
+Red flags: "We need the full platform before anyone can use it." That's attachment to architecture over value.
+
+Bonus push: "What if the user didn't have to do anything at all to get value? No login, no integration, no setup. What would that look like?"
+
+## Q5: Visual Design (UI features only)
+
+Ask: "What should this look like at a glance? How should someone absorb the key information in under 3 seconds?"
+
+**Suggested Choices:** Generate 3-4 options representing different visual approaches, informed by Q1-Q4 answers and the project context:
+- Option for a **data-dense** approach (tables, lists, compact layout -- for power users who want everything visible)
+- Option for a **visual/infographic** approach (charts, progress bars, color-coded status -- for scanability)
+- Option for a **minimal/text** approach (clean typography, big numbers, whitespace -- for glance-and-go)
+- Option grounded in **existing project aesthetics** (if the codebase has an existing UI style, reference it)
+
+Push until you hear a concrete visual direction: layout structure, information hierarchy, what stands out first.
+
+Red flags: "Make it look nice." "Modern and clean." These are non-answers. Push: "If someone glances at this for 2 seconds, what's the ONE thing they should see first?"
+
+After the answer, also ask about constraints:
+- Light or dark theme? Or system-preference?
+- Any branding requirements (logo, colors)?
+- Any anti-patterns to avoid? (e.g., "no emoji", "no fancy animations")
+
+**Post-Q5:** The visual design answers feed into REQ-08-style requirements in the PRD. They also inform a future design prototype stage (if the pipeline supports it).
+
+## Response Posture
+
+- Be direct to the point of discomfort. Comfort means you haven't pushed hard enough.
+- Push once, then push again. The first answer is the polished version. The real answer comes after the second push.
+- Never say "That's an interesting approach" -- take a position instead.
+- If you recognize a common failure pattern ("solution in search of a problem," "hypothetical users," "waiting to launch until it's perfect"), name it directly.
+- When the user gives a specific, evidence-based answer, name what was good and pivot to a harder question. Don't linger on praise.
+
+## Escape Hatch
+
+If the user says "just do it" or "skip the questions":
+- Say: "The hard questions are the value. Let me ask one more, then we'll move."
+- If they push back a second time, respect it and proceed to Step 1C immediately.
+
+Smart-skip: If earlier answers already cover a later question, skip it.

--- a/skills/prd/references/quality-checklist.md
+++ b/skills/prd/references/quality-checklist.md
@@ -1,0 +1,46 @@
+# Quality Checklist (Phase 3: VALIDATE)
+
+Run these checks on the draft and present results to the human. All checks are advisory -- the human reviewer is the real quality gate.
+
+## Checks
+
+| Check | Rule | Severity |
+|-------|------|----------|
+| All 10 sections present | Template completeness | FAIL |
+| No placeholder text (`[TODO]`, `TBD`) | Content completeness | FAIL |
+| Success criteria are binary | Flag words: "reasonable", "appropriate", "good", "proper", "adequate", "sufficient", "acceptable" | WARN |
+| Requirements have IDs | REQ-NN format | FAIL |
+| Each REQ has acceptance criteria | Formal requirement structure | WARN |
+| Out of Scope is non-empty | Explicit boundaries | WARN |
+| No HOW sections | See examples below | WARN |
+| Open Questions flagged | `[NEEDS CLARIFICATION]` markers | INFO |
+| Concrete examples present | At least one input/output example per key requirement | WARN |
+
+## HOW Section Examples
+
+**Flag (implementation detail):**
+- "Use PostgreSQL with a normalized schema."
+- "Store logs in `/var/log/app/` using JSON format."
+
+**Don't flag (requirement):**
+- "Data must persist across restarts."
+- "System must provide queryable audit logs."
+
+## Override Behavior
+
+All severity levels are advisory:
+- FAIL-severity issues produce a prominent warning but do not block export
+- The user can acknowledge and proceed
+- WARN and INFO issues are displayed for awareness
+
+## Compliance Reality Check
+
+These checks are advisory prose rules executed by the same agent that drafted the PRD:
+- F2 (Behavioral Prose Without Consequences): prose rules achieve 17% compliance without mechanical enforcement
+- F9 (Self-Scoring Bias): self-assessment inflates by 10-15pp
+
+The primary quality improvement comes from the guided DISCOVER interview. This checklist serves as a reminder for the human reviewer -- not a substitute for human review.
+
+## Presentation
+
+Present results as a summary table with pass/fail status for each check. Group by severity (FAIL first, then WARN, then INFO).

--- a/skills/prd/references/scope-modes.md
+++ b/skills/prd/references/scope-modes.md
@@ -1,0 +1,37 @@
+# Scope Modes (Step 1D)
+
+Ask the user which scope posture to take. If no preference, default to SELECTIVE EXPAND.
+
+## Modes
+
+| Mode | Posture | When to use |
+|------|---------|-------------|
+| **EXPAND** | Dream big. What's the 10-star product hiding in this request? Push scope UP. | Exploratory phase, greenfield, "think bigger" |
+| **SELECTIVE EXPAND** | Hold scope as baseline, surface expansion opportunities one by one for user to cherry-pick. | Default for most PRDs |
+| **HOLD** | Lock scope. Make it bulletproof -- catch every edge case, map every failure mode. | Scope already agreed, need rigor |
+| **REDUCE** | Surgeon mode. Find minimum viable version. Cut everything else ruthlessly. | Time pressure, MVP, smallest thing that ships value |
+
+## Mode-Specific Requirements Interview Behavior (Step 1E)
+
+**EXPAND mode:**
+- After each requirement, ask "what would make this 10x better for 2x the effort?"
+- Surface delight opportunities
+- Present each expansion as an individual decision for the user to accept or defer
+- Accepted expansions become requirements; deferred ones go to Future Scope
+
+**SELECTIVE EXPAND mode:**
+- Collect requirements normally
+- At the end, surface 3-5 expansion opportunities for the user to cherry-pick
+- Neutral posture -- present opportunity, state effort, let user decide
+- **Layer diversity check:** Classify each expansion by architectural layer (UI, data, infrastructure, integration). If all candidates target the same layer, replace at least one with an expansion from a different layer. This prevents anchoring the user on surface-level additions while missing deeper infrastructure or data opportunities.
+
+**HOLD mode:**
+- After each requirement, probe for edge cases and failure modes
+- Challenge completeness: "What happens when X fails?" "What about empty input?"
+- Do not add scope -- only strengthen existing scope
+
+**REDUCE mode:**
+- After each requirement, ask "is this truly essential for the minimum viable version?"
+- Challenge anything that isn't core
+- "What if we shipped without this? Would anyone notice?"
+- Goal: find the smallest thing that delivers value this week


### PR DESCRIPTION
## Summary

Bundles the `/prd` skill into the public forge-harness repo so users can build a PRD interactively and feed it straight into `forge_plan`. The `/prd` skill is a guided product-diagnostic + pick-from-options requirements interview (EXPAND / SELECTIVE-EXPAND / HOLD / REDUCE) that writes a structured PRD ready for `forge_plan(documentTier: "master", visionDoc)`.

- New `skills/prd/` (SKILL.md + self-contained references) — rebranded to forge-harness, no external branding.
- `scripts/install-skills.cjs` — portable installer (os.homedir, copies not symlinks, backup-then-overwrite into a timestamped `_prd-backup-YYYYMMDD-HHMMSS`).
- `scripts/install-skills-acceptance.sh` — Rule-18 prove-primary install smoke into a throwaway HOME (20 checks).
- `setup.sh` runs the installer after MCP registration; `package.json` ships `skills/`.
- README "From PRD to plan" subsection (master tier first, then intent); `docs/primitive-backlog.md` reconciled (/prd shipped; /prototype + /recall deferred).

## Test plan

- `scripts/install-skills-acceptance.sh` — 20/20 install checks pass into an isolated HOME.
- build + lint + test green; no home-path / brand leaks on any committed surface.

---
plan-refresh: no-op