### PR TITLE
fix(dashboard): rebrand logo "Hive Mind Forge" → "forge-harness"

### DIFF
--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -684,7 +684,7 @@ function renderHeader(
     return `
 <div class="top-bar">
   <div class="top-bar-left">
-    <div class="logo">Hive Mind <span>Forge</span><span class="logo-divider">/</span><span class="logo-sub">Coordinate</span></div>
+    <div class="logo"><span>forge</span>-harness<span class="logo-divider">/</span><span class="logo-sub">Coordinate</span></div>
     <div class="phase-tag">no brief</div>
     ${declarationHtml}
   </div>
@@ -739,7 +739,7 @@ function renderHeader(
   return `
 <div class="top-bar">
   <div class="top-bar-left">
-    <div class="logo">Hive Mind <span>Forge</span><span class="logo-divider">/</span><span class="logo-sub">Coordinate</span></div>
+    <div class="logo"><span>forge</span>-harness<span class="logo-divider">/</span><span class="logo-sub">Coordinate</span></div>
     <div class="phase-tag">${escapeHtml(brief.status)}</div>
     ${declarationHtml}
   </div>


### PR DESCRIPTION
## Summary

Completes the #907 `Hive Mind → forge-harness` rebrand for the **dashboard surface**. The `.forge/dashboard.html` header logo rendered by `server/lib/dashboard-renderer.ts` still read "Hive Mind Forge"; this swaps it to "forge-harness" (green "forge", matching the existing `.logo span` accent), so the live dashboard matches the public product name.

- `server/lib/dashboard-renderer.ts`: `Hive Mind <span>Forge</span>` → `<span>forge</span>-harness` (both render paths).

## Test plan

- `npm run build` (tsc clean).
- `npx vitest run server/lib/dashboard-renderer` — 95 tests pass.
- Rendered the live dashboard via the built renderer across 3 states (working/idle/all-done); header reads `forge-harness/Coordinate` in every frame, no "Hive Mind" residue.

---
plan-refresh: no-op