### PR TITLE
fix(setup): explicit exit on install-skills.cjs failure

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,6 @@ node "$SCRIPT_DIR/scripts/setup-config.cjs" "$SCRIPT_DIR"
 
 # Install bundled skills (the /prd skill) into the global Claude Code skills dir
 echo "forge setup: installing skills..."
-node "$SCRIPT_DIR/scripts/install-skills.cjs" "$SCRIPT_DIR"
+node "$SCRIPT_DIR/scripts/install-skills.cjs" "$SCRIPT_DIR" || exit 1
 
 echo "forge setup: done. Restart Claude Code to pick up the forge tools and the /prd skill."


### PR DESCRIPTION
## Summary

- Add `|| exit 1` after the `install-skills.cjs` node command in `setup.sh` so a failed skill installation is immediately surfaced with a clear non-zero exit code
- Relying solely on `set -e` can be insufficient in some shell contexts; this makes the failure explicit and unambiguous

## Related

Closes #581

## Change

```diff
-node "$SCRIPT_DIR/scripts/install-skills.cjs" "$SCRIPT_DIR"
+node "$SCRIPT_DIR/scripts/install-skills.cjs" "$SCRIPT_DIR" || exit 1
```

*Auto-fix PR opened by /housekeep — review before merging (HK-SAFE-9: no auto-merge)*