### PR TITLE
feat: responsive mobile/narrow dashboard layout (vertical grouped-by-status at <=640px)

### DIFF
--- a/server/lib/dashboard-renderer-mobile.test.ts
+++ b/server/lib/dashboard-renderer-mobile.test.ts
@@ -1,0 +1,87 @@
+// Mobile / narrow responsive layout (v0.46.x). The 6-column board is a wide,
+// short artifact that crops sideways or floats as an island on a tall phone, so
+// at <=640px the board collapses to a vertical "grouped-by-status list": the six
+// statuses stack full-width in workflow order, empty statuses collapse to a
+// one-line header (the `is-empty` class), and card fonts step up to the mobile
+// legibility floor. These assertions lock BOTH ends: the markup hook (is-empty)
+// and the CSS behaviour (single-column reflow + collapse + enlarged fonts).
+import { describe, it, expect } from "vitest";
+import { renderDashboardHtml, type DashboardRenderInput } from "./dashboard-renderer.js";
+import type { PhaseTransitionBrief, StoryStatusEntry } from "../types/coordinate-result.js";
+
+function story(storyId: string, status: StoryStatusEntry["status"]): StoryStatusEntry {
+  return { storyId, status, retryCount: 0, retriesRemaining: 3, priorEvalReport: null, evidence: null };
+}
+
+function brief(stories: StoryStatusEntry[]): PhaseTransitionBrief {
+  return {
+    status: "in-progress",
+    stories,
+    readyStories: [],
+    depFailedStories: [],
+    failedStories: [],
+    completedCount: stories.filter((s) => s.status === "done").length,
+    totalCount: stories.length,
+    budget: { usedUsd: 0, budgetUsd: null, remainingUsd: null, incompleteData: false, warningLevel: "none" },
+    timeBudget: { elapsedMs: 0, maxTimeMs: null, warningLevel: "none" },
+    replanningNotes: [],
+    recommendation: "",
+    configSource: {},
+  };
+}
+
+function render(stories: StoryStatusEntry[]): string {
+  const input: DashboardRenderInput = {
+    brief: brief(stories),
+    activity: null,
+    auditEntries: [],
+    renderedAt: "2026-06-14T00:00:00.000Z",
+  };
+  return renderDashboardHtml(input);
+}
+
+/** Pull the opening tag of a column wrapper (anchored to the class, so the CSS
+ *  `[id="col-x"]` selectors inside <style> are ignored). */
+function columnTag(html: string, columnId: string): string {
+  const m = new RegExp(`<div class="kanban-column[^"]*" id="${columnId}">`).exec(html);
+  if (!m) throw new Error(`column ${columnId} not found`);
+  return m[0];
+}
+
+describe("dashboard mobile / narrow responsive layout", () => {
+  it("marks zero-card columns with is-empty and full columns without it", () => {
+    // 3 done -> DONE is full; the other five statuses are empty.
+    const html = render([story("DEMO-1", "done"), story("DEMO-2", "done"), story("DEMO-3", "done")]);
+    expect(columnTag(html, "col-done")).not.toContain("is-empty");
+    for (const empty of ["col-backlog", "col-ready", "col-in-progress", "col-retry", "col-blocked"]) {
+      expect(columnTag(html, empty)).toContain("is-empty");
+    }
+  });
+
+  it("does not mark a populated column as empty", () => {
+    const html = render([story("DEMO-1", "pending")]); // pending routes to backlog
+    expect(columnTag(html, "col-backlog")).not.toContain("is-empty");
+    expect(columnTag(html, "col-done")).toContain("is-empty");
+  });
+
+  it("ships a <=640px media query that reflows the board to a single column", () => {
+    const html = render([story("DEMO-1", "done")]);
+    // The mobile block is the last rule in DASHBOARD_CSS, so capture from its
+    // opener to the closing </style> (greedy-to-style-end, not first nested }).
+    const media = /@media \(max-width: 640px\) \{[\s\S]*?<\/style>/.exec(html);
+    expect(media, "mobile media query present").not.toBeNull();
+    const css = media![0];
+    // board -> one vertical column (the grouped-by-status list)
+    expect(css).toMatch(/\.kanban-board\s*\{\s*grid-template-columns:\s*1fr/);
+    // empty sections collapse (body hidden) so the board stays scannable
+    expect(css).toMatch(/\.kanban-column\.is-empty\s+\.column-body\s*\{\s*display:\s*none/);
+    // legibility floor: card body bumped to >=16px on mobile
+    expect(css).toMatch(/\.story-card\s*\{\s*font-size:\s*16px/);
+  });
+
+  it("leaves the desktop board as a 6-column grid (no responsive regression)", () => {
+    const html = render([story("DEMO-1", "done")]);
+    // The base (desktop) rule is unchanged: 6 equal columns.
+    expect(html).toMatch(/\.kanban-board\s*\{\s*display:\s*grid;\s*grid-template-columns:\s*repeat\(6,\s*1fr\)/);
+  });
+});

--- a/server/lib/dashboard-renderer.ts
+++ b/server/lib/dashboard-renderer.ts
@@ -915,7 +915,12 @@ function renderBoard(
           : accent === "red"
             ? "accent-red"
             : "accent-grey";
-    return `<div class="kanban-column ${accentClass}" id="${id}">
+    // v0.46.x — mark zero-card columns so the narrow/mobile media query can
+    // collapse them to a one-line section header (kills dead vertical space
+    // when 5 of 6 statuses are empty). Desktop layout is unaffected. The id
+    // and the existing `kanban-column[^"]*` test anchor are preserved.
+    const emptyClass = count === 0 ? " is-empty" : "";
+    return `<div class="kanban-column ${accentClass}${emptyClass}" id="${id}">
   <div class="column-header"><span class="col-title">${escapeHtml(title)}</span><span class="col-count">${count}</span></div>
   <div class="column-body">${extra}${cards}${emptyState}</div>
 </div>`;
@@ -1181,6 +1186,62 @@ body { font-family: var(--font-ui); line-height: 1.5; background: var(--off-whit
 .feed-stage { color: var(--text); }
 .feed-decision { color: var(--text-secondary); font-style: italic; }
 .feed-role { font-family: var(--font-mono); color: var(--text-dim); font-size: 11px; text-align: right; }
+
+/* ── Narrow / mobile (phones, vertical screens) ─────────────────────────────
+   The 6-column board is a wide, short artifact; on a tall narrow screen it
+   either crops sideways or floats as a short island, and six columns across a
+   ~360pt phone forces card text below the legibility floor. So at <=640px we
+   switch metaphor from BOARD to a vertical "grouped-by-status list": the six
+   statuses stack full-width in workflow order (Backlog->Ready->In Progress->
+   Retry->Done->Blocked, the markup order), each a section header + its cards.
+   This is the conventional responsive kanban pattern (Linear/Asana/Notion/
+   GitHub all offer a list-grouped-by-status sibling of the board) and it is
+   what LETS fonts step up to the mobile legibility floor (body >=16px). Empty
+   (zero-card) statuses collapse to a one-line header so the board stays
+   scannable instead of endlessly tall. Desktop layout is untouched. */
+@media (max-width: 640px) {
+  html { font-size: 16px; }
+  .dashboard { padding: 14px 16px; gap: 12px; }
+  .top-bar { flex-wrap: wrap; padding: 14px 16px; gap: 12px; }
+
+  /* stats: 4-up is illegible on a phone — go 2-up and enlarge */
+  .stats-row { grid-template-columns: repeat(2, 1fr); gap: 10px; }
+  .stat-value { font-size: 26px; }
+  .stat-value-sm { font-size: 16px; }
+  .stat-label { font-size: 13px; }
+  .stat-sub { font-size: 14px; }
+
+  /* board -> single-column stacked status sections */
+  .kanban-board { grid-template-columns: 1fr; gap: 10px; }
+  .kanban-column { min-height: 0; padding: 14px 16px; }
+  .column-header { font-size: 15px; padding-bottom: 10px; margin-bottom: 10px; }
+
+  /* legibility floor for card text (>=14px labels, >=16px body) */
+  .story-card { font-size: 16px; padding: 14px; }
+  .story-card .card-id { font-size: 17px; }
+  .story-card .card-tool { font-size: 15px; }
+  .story-card .card-stage { font-size: 15px; }
+  .story-card .card-label,
+  .story-card .card-evidence,
+  .story-card .card-live,
+  .story-card .card-path,
+  .story-card .card-non-fatal-warning { font-size: 14px; }
+  .story-card .card-warning-chip,
+  .story-card .master-merged-badge { font-size: 12px; }
+  .retry-badge { font-size: 14px; }
+
+  /* collapse EMPTY status sections to a compact one-liner (kill dead space) */
+  .kanban-column.is-empty { min-height: 0; padding: 12px 16px; opacity: 0.7; }
+  .kanban-column.is-empty .column-header { padding-bottom: 0; margin-bottom: 0; border-bottom: none; }
+  .kanban-column.is-empty .column-body { display: none; }
+
+  /* activity feed: drop the redundant trailing columns, enlarge the rest */
+  .activity-feed { font-size: 14px; max-height: none; }
+  .feed-entry { grid-template-columns: auto auto 1fr; gap: 10px; }
+  .feed-decision,
+  .feed-role { display: none; }
+  .feed-time { font-size: 13px; }
+}
 `;
 
 // ── Top-level render ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
The kanban dashboard is a wide, short artifact. On a tall narrow screen (a phone, full-screen) the 6-column board either crops sideways or floats as a short island, and six columns across a phone force card text below the legibility floor. This adds a `@media (max-width: 640px)` breakpoint that switches metaphor from **board** to a vertical **grouped-by-status list**:

- The six statuses stack full-width in workflow order (Backlog → Ready → In Progress → Retry → Done → Blocked).
- Empty (zero-card) statuses collapse to a one-line header via a new `is-empty` class, so the board stays scannable.
- Card/label fonts step up to the mobile legibility floor (body ≥16px).

This is the conventional responsive kanban pattern — Linear, Asana, Notion, and GitHub Projects all offer a list-grouped-by-status sibling of the board. **Desktop layout is unchanged** (the 6-column board only reflows ≤640px).

## Test plan
- `npx vitest run server/lib/dashboard-renderer` → 99 passed (95 existing + 4 new mobile assertions).
- New `server/lib/dashboard-renderer-mobile.test.ts` locks both ends: the `is-empty` markup hook (empty vs full columns) AND the CSS behaviour (single-column reflow + empty collapse + ≥16px card font), plus a guard that the desktop 6-column grid is unchanged.
- `npx tsc --noEmit` clean.
- Eyeballed the real rendered dashboard at desktop (1400px, unchanged) and mobile (412px, new layout) + an S25 full-screen crop-sim (no left/right crop).

---
plan-refresh: no-op