### PR TITLE
fix(ci): raise vitest timeout to 30s for Windows git-subprocess flake (#911)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,5 +9,18 @@ export default defineConfig({
     // explicitly by other tests as raw source rather than executed directly.
     exclude: ["**/__fixtures__/**", "node_modules/**", "dist/**"],
     passWithNoTests: true,
+    // #911 — several end-to-end tests shell out to real `git` (init/config/add/
+    // commit/push to a bare remote, then renderDashboard which scans git too):
+    // dashboard-renderer-reconciliation, evaluate-gitsha, git-master-stories,
+    // smoke-gate-check. On Linux these finish in <1s, but on the windows-latest
+    // runner git subprocess spawn latency is much higher AND variable, so the
+    // cumulative time occasionally crept past vitest's 5000ms default and the
+    // test was killed mid-flight (observed: AC-7 at 6236ms) — a non-deterministic
+    // Windows-only timeout flake, not a logic failure. Give every test generous
+    // headroom (and the same for the git-shelling beforeEach/afterEach hooks) so
+    // a slow-but-correct Windows git path can't time out. A genuinely hung test
+    // still fails — just after 30s instead of 5s.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary
Closes the non-deterministic **Windows-only CI flake** (#911) where git-environment tests fail intermittently.

**Root cause (not a logic bug):** four test files shell out to real `git` — `dashboard-renderer-reconciliation`, `evaluate-gitsha`, `git-master-stories`, `smoke-gate-check`. AC-7 alone spawns 8 sequential `git` processes (init / config×2 / add / commit / init --bare / remote add / push) then `renderDashboard` which scans git too. On `ubuntu-latest` these finish in <1s; on `windows-latest`, git subprocess-spawn latency is much higher **and variable**, so the cumulative time occasionally crossed vitest's **5000ms** default per-test timeout and the test was killed mid-flight. The assertions pass whenever the test completes — it's pure subprocess latency.

**Evidence:** AC-7 ran **6236ms** on windows-latest and was killed at 5000ms (`Error: Test timed out in 5000ms`, run 27040178724).

**Fix:** set a global `testTimeout` + `hookTimeout` of `30_000ms` in `vitest.config.ts`. Raising a timeout strictly *increases* headroom — it cannot make any test worse, and a genuinely hung test still fails (after 30s instead of 5s). No product/runtime code touched; test-infra config only.

## Test plan
- Local: `npm run build` ✅, `npm run lint` ✅, full `npm test` → **71 files / 1169 tests pass**.
- The 4 git-shelling test files in isolation: 26 tests pass.
- **The windows-latest CI matrix leg on this PR is the platform proof** — it exercises the exact slow path under the new budget.

---
plan-refresh: no-op