### PR TITLE
fix(test): add maxRetries/retryDelay to afterEach fs.rm (Windows EBUSY)

### DIFF
--- a/server/lib/git-master-stories.test.ts
+++ b/server/lib/git-master-stories.test.ts
@@ -96,9 +96,9 @@ beforeEach(async () => {
 
 afterEach(async () => {
   for (const r of extraRemotes) {
-    await rm(r, { recursive: true, force: true });
+    await rm(r, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   }
-  await rm(tmpRoot, { recursive: true, force: true });
+  await rm(tmpRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 });
 
 // ── AC-5 — single git call regardless of story count ──────────────────────


### PR DESCRIPTION
## Summary

- Adds `maxRetries: 3, retryDelay: 100` to both `fs.rm()` calls in the `afterEach` of `git-master-stories.test.ts`
- Fixes intermittent `EBUSY` failures on `build (windows-latest, 20)` where Windows briefly holds an exclusive file lock on a child process's working dir after the process is killed by `timeoutMs`

## Test plan

- [ ] CI passes on Windows runner (previously failing in PRs #575, #572, #487, #472)
- [ ] CI passes on Linux/macOS runners (no regression)

Closes #589